### PR TITLE
Pin CI and conda environment to Python 3.12

### DIFF
--- a/.github/workflows/build-and-publish-docs-on-dispatch.yml
+++ b/.github/workflows/build-and-publish-docs-on-dispatch.yml
@@ -4,15 +4,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  get-python-version:
-    uses: scikit-package/release-scripts/.github/workflows/_get-python-version-latest.yml@v0
-    with:
-      python_version: 0
-
   docs:
     uses: scikit-package/release-scripts/.github/workflows/_release-docs.yml@v0
     with:
       project: saxshell
       c_extension: false
       headless: true
-      python_version: ${{ fromJSON(needs.get-python-version.outputs.latest_python_version) }}
+      python_version: "3.12"

--- a/.github/workflows/build-wheel-release-upload.yml
+++ b/.github/workflows/build-wheel-release-upload.yml
@@ -13,6 +13,7 @@ jobs:
       project: saxshell
       c_extension: false
       maintainer_GITHUB_username: kewh5868
+      python_version: "3.12"
     secrets:
       PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
       PAT_TOKEN: ${{ secrets.PAT_TOKEN }}

--- a/.github/workflows/matrix-and-codecov.yml
+++ b/.github/workflows/matrix-and-codecov.yml
@@ -17,5 +17,6 @@ jobs:
       project: saxshell
       c_extension: false
       headless: true
+      python_version: "3.12"
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/tests-on-pr.yml
+++ b/.github/workflows/tests-on-pr.yml
@@ -11,5 +11,6 @@ jobs:
       project: saxshell
       c_extension: false
       headless: true
+      python_version: "3.12"
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ maintainers = [
 description = "Python package for analysis of small-angle scattering data from molecular dynamics derived liquid structures."
 keywords = ["scattering", "SAXS", "X-ray", "diffraction", "solvation"]
 readme = "README.rst"
-requires-python = ">=3.11, <3.15"
+requires-python = ">=3.11, <3.14"
 classifiers = [
   "Development Status :: 3 - Alpha",
   "Environment :: Console",
@@ -28,7 +28,6 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering :: Physics",
   "Topic :: Scientific/Engineering :: Chemistry",
 ]

--- a/requirements/conda.txt
+++ b/requirements/conda.txt
@@ -1,3 +1,4 @@
+python=3.12
 matplotlib=3.10.8
 numpy=2.4.2
 pyside6=6.6.0


### PR DESCRIPTION
Closes Issue #3 
- pin reusable GitHub workflow entry points to Python 3.12 instead of following the latest version
- set requirements/conda.txt to python=3.12 alongside PySide6 6.6.0
- stop advertising Python 3.14 support in package metadata while PySide6 6.6.0 remains incompatible