### PR TITLE
Born approx clusters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,8 @@ site/
 
 # pytest
 .pytest_cache/
+tests/edm_contiguous_mode_report/
+tests/smearing_analysis_*/
 
 # PyBuilder
 target/

--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,6 @@ src/saxshell/fullrmc/_deprecated/
 src/saxshell/debyer/_deprecated/
 src/saxshell/toolbox/_deprecated/
 src/saxshell/xyz2pdb/_deprecated/
-
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
@@ -77,6 +76,7 @@ coverage.xml
 # Sphinx documentation
 docs/build/
 docs/source/generated/
+docs/planned_updates/
 site/
 
 # pytest
@@ -99,6 +99,9 @@ target/
 
 # VSCode
 .vscode/
+
+# Local Claude/Codex workspace state
+.claude/
 
 # Ipython Notebook
 .ipynb_checkpoints

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# Repository Instructions
+
+## Secret Handling
+
+- Never store literal `GH_TOKEN` values or other credentials in `.claude/settings.local.json`, `.claude/claude-progress-log.jsonl`, or any tracked file.
+- If a secret appears in repo-local settings or logs, redact or remove it immediately and prefer external shell auth such as `gh auth login`.
+- Treat `.claude/` as local-only workspace state and keep it out of commits.
+
+## GitHub Process Flow
+
+- When the user says `run the github process flow`, treat that as a specific publish-prep workflow for this repository.
+- Inspect the current branch and working tree, analyze the recent changes, and split the work into logical separate commits.
+- Use clear commit messages with enough detail to explain each commit's purpose. Prefer a short subject plus a descriptive body when the diff is non-trivial.
+- If the worktree contains unrelated changes or there are multiple reasonable ways to split the commits, pause and confirm scope before staging.
+- Run the local commit flow and handle pre-commit fallout. If hooks reformat files or require fixes, review the resulting edits, stage the updated files, and retry the commit until it succeeds or a real blocker remains.
+- Finish the workflow with local commits only unless the user explicitly asks for a push or PR creation.
+- Do not push automatically. Instead, give the user the exact `git push` command to run manually.
+- Do not open the pull request automatically. Instead, provide a copyable PR body/comment for the user to paste into the GitHub PR description.
+- The PR body should summarize what changed, why it changed, how it was validated, and include issue-closing lines such as `Resolves #123` for every related issue number.
+- If the related GitHub issue numbers are not already clear from the conversation or branch context, ask for them before drafting the final PR body.

--- a/docs/getting-started/project-setup.md
+++ b/docs/getting-started/project-setup.md
@@ -1,8 +1,9 @@
 # Project Setup
 
-The **Project Setup** tab is where a SAXS project becomes concrete. It is the
-place to connect experimental data, cluster-derived scattering components, prior
-weights, and the active model template.
+The **Project Setup** tab is where a SAXS project becomes a reusable computed
+distribution. This is the point where you define the Project Setup snapshot,
+optionally compute Debye-Waller factors, and decide how SAXS components should
+be built for the active modeling branch.
 
 ## What lives here
 
@@ -10,29 +11,95 @@ The current UI code shows Project Setup as the first tab in the SAXS
 application. This is where you typically:
 
 - choose or confirm the project directory
-- select experimental SAXS data
-- point the project at a cluster folder
-- select a model template
-- build or refresh prior-weight and component metadata
-- preview histogram and distribution plots before moving to Prefit
+- select experimental and optional solvent SAXS data
+- point the project at frames, PDB structures, and clusters folders
+- choose a model template
+- set the q-range, grid behavior, recognized elements, and excluded elements
+- create or load computed distributions
+- optionally compute project-backed Debye-Waller factors
+- build SAXS components with the selected component-build mode
+- preview component traces and prior histograms before moving to Prefit
 
 ## Typical setup order
 
 1. Open the SAXS application with `saxshell saxs ui` or
    `PYTHONPATH=src conda run --no-capture-output -n saxshell-py312 python -m saxshell.saxs ui`.
 2. Create a new project or load an existing project directory.
-3. Select the experimental dataset.
-4. Select the cluster folder you want to model.
-5. Choose the template you want to use.
-6. Build the prior-weight and SAXS component inputs.
-7. Review the project summary and prior plots.
-8. Move to **SAXS Prefit** once the component build is ready.
+3. Select the experimental dataset and the cluster folder you want to model.
+4. Choose the template, q-range, grid mode, and excluded elements.
+5. Pick the **Component build mode** for the current modeling branch.
+6. Click **Create Computed Distribution**.
+7. Optionally click **Compute Debye-Waller Factors** if the active clusters are
+   PDB files and you want saved disorder terms for later workflows.
+8. Click **Build SAXS Components**.
+9. Review the component preview, cluster table, and prior histogram preview.
+10. Move to **SAXS Prefit** once the active distribution has the component
+    traces you want to fit.
+
+## Computed distributions
+
+The Project Setup tab now makes computed distributions explicit.
+
+**Create Computed Distribution** stores the current Project Setup snapshot and
+generates the matching prior-weight artifacts. The computed-distribution
+dropdown then lets you reload any saved distribution for the same project, and
+the **Active Computed Distribution** panel summarizes the saved state and
+artifact readiness for the selected one.
+
+From the current UI and project-manager behavior, a computed distribution is
+defined by the active Project Setup snapshot, including:
+
+- selected template
+- component build mode
+- cluster source folder
+- q-range and grid behavior
+- excluded elements
+- observed-only versus observed-plus-predicted structure weighting
+- model-only mode
+
+When experimental-grid mode is enabled, the experimental data source also feeds
+into the saved distribution identity.
+
+Because the component build mode is part of that identity, the same project can
+hold multiple otherwise-similar distributions at once, for example one built
+with `No Contrast (Debye)` and one built with
+`Born Approximation (Average)`.
+
+## Component build modes
+
+The **Component build mode** dropdown controls what happens when you click
+**Build SAXS Components**.
+
+| Mode                             | What happens                                                                                                                                                                                                                                                                                                   |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **No Contrast (Debye)**          | The main SAXS UI runs the direct Debye component builder and saves the component traces into the active computed distribution.                                                                                                                                                                                 |
+| **Contrast (Debye)**             | SAXSShell opens the linked **SAXS Contrast Mode** workflow so you can analyze representative structures, compute electron-density terms, and build contrast-aware Debye traces for that computed distribution.                                                                                                 |
+| **Born Approximation (Average)** | SAXSShell opens the linked **Electron Density Mapping** workflow in computed-distribution mode so you can compute per-stoichiometry electron-density profiles, apply optional solvent subtraction, evaluate Fourier transforms, and then push the resulting Born-approximation components back into the model. |
+
+## Debye-Waller factors
+
+**Compute Debye-Waller Factors** is an optional linked step in Project Setup.
+
+Important current behavior:
+
+- the button stays disabled until a project is open and the active clusters
+  folder resolves to readable `PDB` files only
+- the linked Debye-Waller tool inherits the active project directory and
+  clusters directory automatically
+- the readiness indicator turns green when saved Debye-Waller results match the
+  current PDB clusters folder
+- if saved factors exist for a different clusters folder, the indicator stays
+  off and the tooltip explains the mismatch
+
+You do not need Debye-Waller factors to create a computed distribution, but the
+tool is intended to be run before component building when you plan to reuse
+those saved disorder terms in later SAXSShell workflows.
 
 ## Model and Build section
 
-The Project Setup tab now also includes an **Install Model** action. This is
-for templates authored as Python model files that pass the repository's
-template-validation rules.
+Project Setup also includes **Install Custom Template**. This is for templates
+authored as Python model files that pass the repository's template-validation
+rules.
 
 The install flow collects:
 
@@ -57,15 +124,20 @@ Examples from the current codebase include:
 
 ## Practical advice
 
-- Finish the project-build steps before judging Prefit behavior. Many Prefit
-  features depend on the component list and template selected here.
+- Treat **Create Computed Distribution** as the point where you intentionally
+  branch the project into a specific build configuration.
+- Finish the Project Setup steps before judging Prefit behavior. Prefit and
+  DREAM both depend on the active computed distribution and its saved
+  component artifacts.
+- If you switch build modes, q-range, template, or excluded elements, create a
+  new computed distribution instead of assuming the previous saved state still
+  applies.
 - If you are experimenting with custom templates, validate and install them
   before building a new project around them.
-- If a template enables cluster geometry metadata, that capability shows up
-  later in the Prefit workflow rather than in Project Setup itself.
 
 ## Related pages
 
 - [Project Configuration](../user-guide/project-configuration.md)
+- [GUI Overview](../user-guide/gui-overview.md)
 - [Template System](../user-guide/template-system.md)
 - [SAXS Prefit](../user-guide/saxs-prefit.md)

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -64,9 +64,27 @@ Inside the UI, the normal path is:
 
 1. Create or open a SAXS project.
 2. Point the project at your experimental data and cluster folder.
-3. Build the SAXS components in **Project Setup**.
-4. Review the model in **SAXS Prefit**.
-5. Run **SAXS DREAM Fit** if you need Bayesian refinement.
+3. In **Project Setup**, choose the template, q-range, grid behavior, excluded
+   elements, and SAXS component build mode.
+4. Click **Create Computed Distribution** to save that Project Setup snapshot
+   and generate the matching prior-weight inputs.
+5. Optionally click **Compute Debye-Waller Factors** when the active clusters
+   folder contains PDB files and you want saved disorder terms for later
+   workflows.
+6. Click **Build SAXS Components**.
+7. If the build mode is `No Contrast (Debye)`, the main UI runs the direct
+   component builder.
+8. If the build mode is `Contrast (Debye)`, the linked SAXS Contrast Mode
+   window opens.
+9. If the build mode is `Born Approximation (Average)`, the linked Electron
+   Density Mapping window opens in computed-distribution mode.
+10. Review the model in **SAXS Prefit**.
+11. Run **SAXS DREAM Fit** if you need Bayesian refinement.
+
+A computed distribution is the saved Project Setup configuration for one SAXS
+modeling branch. In practice it tracks the active template, component-build
+mode, cluster source, q-range and grid choices, excluded elements, and whether
+the run uses observed structures only or observed plus predicted structures.
 
 ## 6. If you are starting from an existing project
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,10 +40,17 @@ The current repo supports an end-to-end path that usually looks like this:
 5. Optionally predict larger clusters and representative predicted structures
    with `clusterdynamicsml`.
 6. Measure bond and angle distributions with `bondanalysis`.
-7. Optionally compute trajectory-averaged PDFs and partial PDFs with `pdfsetup`.
-8. Build a SAXS project with `saxshell saxs`.
-9. Refine the project in **SAXS Prefit** and, if needed, run **pyDREAM**.
-10. Use the resulting distributions and selected structures in downstream tools
+7. Optionally compute project-backed Debye-Waller factors from sorted PDB
+   cluster folders with **Debye-Waller Analysis**.
+8. Optionally compute trajectory-averaged PDFs and partial PDFs with `pdfsetup`.
+9. Build a SAXS project with `saxshell saxs`, create or load a computed
+   distribution in **Project Setup**, and choose how SAXS components will be
+   prepared.
+10. Build components with one of the supported modes:
+    `No Contrast (Debye)`, `Contrast (Debye)`, or
+    `Born Approximation (Average)`.
+11. Refine the project in **SAXS Prefit** and, if needed, run **pyDREAM**.
+12. Use the resulting distributions and selected structures in downstream tools
     such as `saxshell fullrmc`.
 
 ## Documentation map
@@ -56,15 +63,18 @@ to create your first project quickly.
 ### User guide
 
 Use this section when you already know the rough workflow and need details
-about GUI tabs, file layout, template behavior, export paths, or the
-supporting applications that feed data into the main SAXS UI.
+about GUI tabs, computed distributions, component-build modes, file layout,
+template behavior, export paths, or the supporting applications that feed data
+into the main SAXS UI.
 
 The user guide is split into:
 
 - **Main UI workflow elements** for the `saxshell saxs` application and its
-  project, Prefit, DREAM, template, and export behavior
-- **Supporting applications** for trajectory preparation, cluster analysis,
-  predictive cluster expansion, and PDF calculations that support the main UI
+  project, computed distributions, Prefit, DREAM, template, and export
+  behavior
+- **Supporting applications** grouped the same way as the main `Tools` menu:
+  `MD Extraction`, `Structure Analysis`, `Cluster Dynamics`, `PDF`,
+  `Visualization`, `SAXS Calculation Preview`, and `X-ray Toolkit`
 
 ### Tutorials
 

--- a/docs/user-guide/blender-structure-renderer.md
+++ b/docs/user-guide/blender-structure-renderer.md
@@ -2,7 +2,8 @@
 
 The Blender tool is SAXSShell's publication-rendering application for atomistic
 structures. It is exposed as the standalone `blenderxyz` program and from the
-main SAXSShell window through `Tools > Open Blender XYZ Renderer`.
+main SAXSShell window through
+`Tools > Visualization > Open Blender XYZ Renderer`.
 
 ## Purpose
 

--- a/docs/user-guide/bond-analysis.md
+++ b/docs/user-guide/bond-analysis.md
@@ -1,0 +1,48 @@
+# Bond Analysis
+
+The **Bond Analysis** tool is SAXSShell's structure-analysis application for
+measuring bond-length and angle distributions from stoichiometry-sorted cluster
+folders.
+
+## Launching the application
+
+Open the tool from the main SAXS UI through
+`Tools > Structure Analysis > Open Bond Analysis`.
+
+When the window is launched from an active SAXS project, the current project
+and cluster-folder reference are carried into the tool. If you change the
+selected clusters folder there, that reference is saved back to the project.
+
+## What the tool does
+
+The current UI supports:
+
+- choosing one sorted clusters directory as the analysis source
+- saving results into a separate output directory
+- limiting the run to checked stoichiometry labels
+- defining bond-pair cutoffs directly in a table
+- defining angle triplets directly in a table
+- loading built-in presets and saving custom presets for later reuse
+- reopening an existing bond-analysis output folder and browsing its saved
+  distributions
+
+The right side of the window focuses on the computed distributions. You can
+refresh a results directory, select one or more saved bond-pair or angle
+entries, and open them in a dedicated plot window. Matching items from multiple
+cluster types can be overlaid together for comparison.
+
+## Typical workflow
+
+1. Start from the project's sorted clusters folder.
+2. Confirm or choose the bond-analysis output directory.
+3. Refresh the detected cluster types and clear any stoichiometries you do not
+   want to include.
+4. Load a preset or define the bond pairs and angle triplets manually.
+5. Run the calculation and inspect the saved distributions from the results
+   browser.
+
+## Related pages
+
+- [MD Extraction and Cluster Preparation](cluster-extraction.md)
+- [Debye-Waller Analysis](debye-waller-analysis.md)
+- [GUI Overview](gui-overview.md)

--- a/docs/user-guide/cluster-extraction.md
+++ b/docs/user-guide/cluster-extraction.md
@@ -1,4 +1,4 @@
-# Cluster Extraction
+# MD Extraction and Cluster Preparation
 
 Cluster extraction is the bridge between raw trajectory data and the SAXS model.
 In this repository, that bridge spans more than one tool.
@@ -10,8 +10,11 @@ In this repository, that bridge spans more than one tool.
 3. Use `clusters` to extract stoichiometry-sorted cluster files.
 4. Use `clusterdynamics` to build time-dependent cluster-distribution heatmaps
    and lifetime tables from the extracted frames.
-5. Use `bondanalysis` to measure bond or angle distributions on those clusters.
-6. Feed the resulting cluster folder into the SAXS project.
+5. Optionally use `bondanalysis` to measure bond or angle distributions on
+   those clusters.
+6. Optionally use **Debye-Waller Analysis** to estimate project-backed
+   pairwise disorder coefficients from sorted PDB cluster folders.
+7. Feed the resulting cluster folder into the SAXS project.
 
 ## `mdtrajectory`
 
@@ -84,11 +87,15 @@ Key outputs:
 - a sortable lifetime table by stoichiometry label
 - saved JSON/CSV datasets that can be reopened later for plotting
 
-## `bondanalysis`
+## Downstream structure analysis
 
-Bond analysis is downstream of cluster extraction. Use it to derive bond-pair
-and angle-triplet distributions from the stoichiometry folders produced by the
-cluster workflow.
+After the sorted cluster folders have been produced, the main UI exposes two
+structure-analysis tools that reuse them:
+
+- [Bond Analysis](bond-analysis.md) for bond-pair and angle-triplet
+  distributions
+- [Debye-Waller Analysis](debye-waller-analysis.md) for pairwise
+  thermal-displacement coefficients from sorted `PDB` cluster folders
 
 ## What SAXS expects from this stage
 
@@ -103,6 +110,8 @@ clusters before moving on.
 ## Related pages
 
 - [Project Setup](../getting-started/project-setup.md)
+- [Bond Analysis](bond-analysis.md)
+- [Debye-Waller Analysis](debye-waller-analysis.md)
 - [Project Configuration](project-configuration.md)
 - [Cluster Dynamics](cluster-dynamics.md)
 - [Cluster Dynamics ML](cluster-dynamics-ml.md)

--- a/docs/user-guide/debye-waller-analysis.md
+++ b/docs/user-guide/debye-waller-analysis.md
@@ -1,0 +1,106 @@
+# Debye-Waller Analysis
+
+The **Debye-Waller Analysis** tool is a separate supporting application for
+estimating pair-resolved thermal-displacement coefficients from sorted PDB
+cluster folders. It is designed to stay project-aware so the results can be
+saved, reopened, and reused by later SAXSShell workflows.
+
+## Launching the application
+
+Open the tool from the main SAXS UI through
+`Tools > Structure Analysis > Open Debye-Waller Analysis`.
+
+If the tool is launched from an active project, it uses that project to:
+
+- prefill the sorted clusters folder when a project cluster reference exists
+- choose a project-aware default output location
+- restore a previously saved Debye-Waller analysis when one already exists
+
+## Input requirements
+
+The workflow expects a sorted clusters folder whose subdirectories are the
+stoichiometry bins to evaluate.
+
+Important constraints:
+
+- input structures must be `PDB` files
+- `XYZ` cluster files are rejected
+- contiguous-frame grouping is inferred from frame-numbered filenames inside
+  each stoichiometry folder
+
+The PDB requirement matters because the tool uses residue, sequence, and
+segment metadata to separate intra-molecular and inter-molecular atom pairs.
+
+## What the tool computes
+
+For each stoichiometry label, the workflow:
+
+1. detects the contiguous frame sets available in that stoichiometry folder
+2. groups atoms into molecules from the PDB metadata
+3. identifies intra-molecular and inter-molecular atom-pair types
+4. computes Debye-Waller coefficients for each contiguous frame set
+5. averages those segment-level values into stoichiometry-level summaries with
+   preserved spread
+
+It also builds an aggregated view across all stoichiometries, so one combined
+coefficient row is available for each pair type and scope
+(`intra-molecular` or `inter-molecular`) with the spread preserved.
+
+## Live run feedback
+
+The run log is intended to make the workflow easy to sanity-check while it is
+running. It reports:
+
+- validation and output-path setup
+- how many contiguous frame sets were found for each stoichiometry label
+- how many frames belong to each contiguous frame set
+- per-segment progress as coefficient rows are generated
+- final artifact locations
+
+The tables update while the run is still active. The current tabs are:
+
+- `Stoichiometries`
+- `Aggregated Pairs`
+- `Pair Types`
+- `Scopes`
+- `Segments`
+- `Log`
+
+The `Stoichiometries` tab is a lightweight sanity check on the parsed PDB
+content. It shows metrics such as frame counts, contiguous-set counts, residue
+names, element inventory, average atoms per frame, average molecule groups per
+frame, and the most common molecule signatures.
+
+## Project save and restore behavior
+
+The tool includes **Save Current Analysis to Project** for manually storing the
+current result in the active project.
+
+It also auto-saves the first valid Debye-Waller analysis for a project when no
+project-saved analysis already exists. When the tool is reopened from that same
+active project, the saved analysis is loaded and the tables are repopulated
+without rerunning the calculation.
+
+## Saved outputs
+
+Run artifacts are written to the selected output directory, and project-backed
+copies are stored under the project's `exported_results/data/debye_waller/`
+area.
+
+The saved bundle includes:
+
+- a summary JSON payload
+- an aggregated pair-summary CSV across all stoichiometries
+- a per-stoichiometry pair-summary CSV
+- a per-stoichiometry scope-summary CSV
+- a segment-level CSV with the contiguous-set rows
+
+That keeps both the detailed per-stoichiometry data and the cross-stoichiometry
+aggregate coefficients available for future applications.
+
+## Related pages
+
+- [MD Extraction and Cluster Preparation](cluster-extraction.md)
+- [Bond Analysis](bond-analysis.md)
+- [Results and Export](results-and-export.md)
+- [GUI Overview](gui-overview.md)

--- a/docs/user-guide/electron-density-mapping.md
+++ b/docs/user-guide/electron-density-mapping.md
@@ -1,8 +1,23 @@
 # Electron Density Mapping
 
-The **Electron Density Mapping** tool is a supporting application that computes
-radial electron-density profiles from XYZ or PDB molecular structures. It can
-be launched directly from the `saxshell` main UI or from the terminal.
+The **Electron Density Mapping** tool is SAXSShell's supporting application for
+building radial electron-density profiles from XYZ or PDB inputs and, when
+needed, turning those profiles into q-space scattering estimates. The current
+UI supports three working styles:
+
+- Single-structure inspection from one XYZ or PDB file.
+- Folder averaging across many structures in one directory.
+- Cluster-folder workflows for Born-approximation component building, where each
+  stoichiometry gets its own density, solvent, Fourier, and saved-output state.
+
+In Project Setup, this is the linked component-build workspace for
+**Born Approximation (Average)**.
+
+In the main SAXS workflow the tool can run either in **Preview Mode** or in
+**Computed Distribution Mode**. Preview mode is for exploratory work. Computed
+distribution mode is the linked workflow launched from **Build SAXS Components**
+and is the only mode that can push Born-approximation components back into the
+active distribution.
 
 ## Launching the application
 
@@ -12,160 +27,172 @@ be launched directly from the `saxshell` main UI or from the terminal.
 PYTHONPATH=src conda run --no-capture-output -n saxshell-py312 python -m saxshell.saxs.electron_density_mapping
 ```
 
-### From the SAXSShell main UI
+### From the main SAXS UI
 
-Open the main SAXSShell application and select **Electron Density Mapping** from the supporting applications menu. When launched this way the tool inherits the active project directory and will default its output path to `exported_results/data/` within that project.
+- **Tools > SAXS Calculation Preview > Open Electron Density Mapping** opens
+  the tool in **Preview Mode**. The window title shows
+  `Electron Density Mapping (Preview)`, and the banner explains that pushed
+  model components are disabled in this mode.
+- **Build SAXS Components** with the
+  **Born Approximation (Average)** build mode opens the tool in
+  **Computed Distribution Mode**. The tool inherits the active project q-range,
+  the active computed distribution, the preferred input folder, and the
+  distribution output directory.
 
----
+## Operating modes
 
-The tool takes one or more structure files, centers each structure at a chosen
-origin, bins the atomic electron counts onto a spherical mesh, and returns an
-orientation-averaged radial profile ρ(r). An optional Gaussian-smearing step
-and a Fourier-transform stage can convert the real-space profile into a
-q-space scattering estimate.
-
----
+| Mode                 | What is loaded                                     | What the tool does                                                                                                                                                                                                 |
+| -------------------- | -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Single file**      | One `.xyz` or `.pdb` file                          | Computes one radial electron-density profile, optional solvent subtraction, and optional Born-approximation Fourier transform.                                                                                     |
+| **Structure folder** | One folder of `.xyz` / `.pdb` files                | Averages the profiles across the folder, tracks variance, and can optionally use contiguous-frame grouping when filenames follow `frame_<NNNN>`.                                                                   |
+| **Cluster folder**   | One folder whose subfolders are stoichiometry bins | Builds one state row per stoichiometry, lets you inspect each row independently, and supports batch or manual per-row workflows. Single-atom rows skip density generation and use direct Debye scattering instead. |
 
 ## What the tool computes
 
-For each structure, the workflow:
+For density-based rows, the workflow:
 
-1. Loads atom positions and element symbols from an XYZ or PDB file.
-2. Computes the mass-weighted center of mass using atomic masses from `xraydb`.
-3. Centers all atom positions relative to the chosen active origin.
-4. Partitions the structure domain into a spherical mesh of radial shells
-   and angular cells.
-5. Accumulates the atomic number of each atom (used as its electron count) into
-   the mesh cell it falls into.
-6. Averages the electron density over all angular directions within each radial
-   shell, yielding the orientation-averaged profile ρ(r).
-7. Optionally applies a Gaussian-smearing kernel to ρ(r).
-8. Optionally evaluates a spherical Born-approximation Fourier transform of the
-   smeared profile to produce a scattering amplitude and intensity I(q).
+1. Loads atom positions and element symbols from XYZ or PDB files.
+2. Computes the mass-weighted center of mass using atomic data from `xraydb`.
+3. Re-centers each structure using the active center mode.
+4. Partitions the structure into a spherical mesh of radial shells and angular
+   cells.
+5. Accumulates each atom's atomic number as its electron count on that mesh.
+6. Averages angular contributions into a radial profile `rho(r)`.
+7. Optionally applies Gaussian smearing.
+8. Optionally applies a flat solvent electron-density contrast and finds the
+   highest-r cutoff crossing.
+9. Optionally evaluates a spherical Born-approximation transform into `I(q)`.
 
-When a **folder** is provided instead of a single file, the workflow repeats
-steps 2–6 for every valid structure in the folder and averages the resulting
-profiles across the ensemble, also tracking inter-member variance.
+!!! note "Raw density versus shell bookkeeping"
+The plotted `rho(r)` and the derived Fourier/scattering outputs use a
+finite-radius shell-overlap density profile. Exported
+`electrons_in_shell` / `shell_electron_counts` values remain point-tagged
+shell bookkeeping totals. This distinction matters when an atom sits near
+the active origin: the finite-radius profile avoids an artificial
+near-origin spike that would otherwise exaggerate the perceived electron
+density and distort the scattering estimate.
 
----
+For single-atom stoichiometry rows in cluster-folder mode, the density step is
+skipped and the tool evaluates a direct Debye scattering profile instead.
 
-## Panels and input fields
+When folder averaging uses **Use Contiguous Frame Evaluation**, the tool groups
+filenames by `frame_<NNNN>` sequences when available and locks each contiguous
+set to a shared center offset relative to the heaviest-element anchor. If the
+expected naming pattern is not present, the run falls back to complete
+averaging and records that fallback in the status log.
 
-The window is split into a left-hand control panel and a right-hand plot area.
+## Left-panel controls
 
 ### Input
 
-| Field                 | Description                                                                                                                                                      |
-| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Path field**        | Type or paste the path to an XYZ or PDB file, or to a folder of such files. Press Enter or click **Load Input** to apply.                                        |
-| **Choose File**       | Opens a file-browser dialog pre-filtered for `.xyz` and `.pdb` files.                                                                                            |
-| **Choose Folder**     | Opens a folder-browser dialog. All valid structure files in the folder are discovered automatically.                                                             |
-| **Load Input**        | Inspects the selected path, determines the input mode, loads the reference structure, and populates the status fields below.                                     |
-| **Input mode**        | Read-only. Shows `file` when a single structure is loaded, or `folder` when a directory is active.                                                               |
-| **Reference file**    | Read-only. Shows the file that is used for the 3D structure preview and center-of-mass calculation. In folder mode this is the first file in natural sort order. |
-| **Structure summary** | Read-only. Shows atom count, element composition, center of mass, active center, and the domain radius rmax after a structure is loaded.                         |
+| Field                               | Description                                                                                               |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| **Path field**                      | Path to a single XYZ/PDB file, a folder of structures, or a folder of stoichiometry subfolders.           |
+| **Choose File** / **Choose Folder** | Open file-system pickers for the active input.                                                            |
+| **Load Input**                      | Inspects the selected path and populates the window state.                                                |
+| **Input mode**                      | Shows whether the current input is a file, a folder, or cluster folders with an active stoichiometry row. |
+| **Reference file**                  | The structure file shown in the viewer for the currently active row.                                      |
+| **Structure summary**               | Reports atom counts, element counts, center information, and domain size for the active structure.        |
 
-!!! note "Folder mode"
-When a folder is loaded, the **structure viewer** and **center** displays
-reflect only the reference (first) file. The **Run** step averages over
-every file in the folder and produces ensemble variance bands in the plots.
-
----
+!!! note "Cluster folders"
+When a cluster-folder input is loaded, the stoichiometry table becomes the
+main navigation surface for the tool. Clicking a row updates the plots,
+mesh controls, Fourier controls, and viewer to that row's state.
 
 ### Output
 
-| Field                | Description                                                                                                                                                                                                |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Output directory** | Folder where the CSV profile and JSON summary are written after a successful calculation run. Leave blank to skip file output and inspect results interactively only. Click **Browse** to choose a folder. |
-| **Output basename**  | Filename stem used for all output files. Defaults to `electron_density_profile`. The tool appends `_profile.csv` and `_summary.json` automatically.                                                        |
-
----
+| Field                | Description                                                                                                                                                                                                                                                                                                |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Output directory** | Where run outputs are written when file export is enabled. In preview mode the default is inferred from the loaded input, or from `<project>/electron_density_mapping` when a project-linked launch is available. In computed-distribution mode, the default is `<distribution>/electron_density_mapping`. |
+| **Output basename**  | Stem for exported density files. File and folder runs write `<basename>.csv` and `<basename>.json`. Cluster-folder runs append a stoichiometry suffix, for example `<basename>_PbI2.csv`.                                                                                                                  |
 
 ### Mesh Settings
 
-The spherical mesh controls how the structure domain is discretised before
-electron counts are binned.
+The mesh controls define the radial sampling domain before density accumulation.
 
-| Field                           | Description                                                                                                                                                                                                                                                                                              |
-| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **rstep (Å)**                   | Width of each radial shell in ångströms. Smaller values give a finer radial resolution at the cost of a larger mesh. Default: 0.1 Å.                                                                                                                                                                     |
-| **Theta divisions**             | Number of equal-angle bins along the polar (θ) axis from 0 to π. Higher values improve angular coverage. Default: 120.                                                                                                                                                                                   |
-| **Phi divisions**               | Number of equal-angle bins along the azimuthal (φ) axis from 0 to 2π. Default: 60.                                                                                                                                                                                                                       |
-| **rmax (Å)**                    | Maximum radial extent of the mesh in ångströms. Atoms beyond this radius are excluded from the profile and counted in the excluded-atom summary. Set this to at least the structural domain radius reported in the structure summary. Default: 8.0 Å (updated automatically when a structure is loaded). |
-| **Center mode**                 | Read-only label showing whether the active origin is the `Calculated center of mass` or the `Nearest atom` to the center of mass.                                                                                                                                                                        |
-| **Calculated center**           | Read-only. The mass-weighted center of mass of the reference structure in Cartesian coordinates (Å).                                                                                                                                                                                                     |
-| **Active center**               | Read-only. The origin actually used for centering. Matches the calculated center unless the center has been snapped to the nearest atom.                                                                                                                                                                 |
-| **Nearest atom**                | Read-only. The element symbol, atom index, and distance (Å) of the atom closest to the calculated center of mass.                                                                                                                                                                                        |
-| **Snap Center to Nearest Atom** | Moves the active origin from the calculated center of mass to the position of the nearest atom. Useful when the center of mass falls in an empty space between atoms and you prefer a physically grounded lattice site as the origin. The profile and viewer update immediately.                         |
-| **Reset to Calculated Center**  | Restores the active origin to the mass-weighted center of mass.                                                                                                                                                                                                                                          |
-| **Update Mesh Settings**        | Applies the current rstep, theta, phi, and rmax values to the active mesh and regenerates the profile if a calculation result is already loaded.                                                                                                                                                         |
-| **Active mesh**                 | Read-only summary of the mesh that was used for the most recent calculation: rstep, theta divisions, phi divisions, rmax.                                                                                                                                                                                |
-| **Pending fields**              | Read-only. If any mesh field has been changed since the last **Update Mesh Settings**, the changed fields are listed here as a reminder that the active mesh and the control values are out of sync.                                                                                                     |
+| Field                                                            | Description                                                                                               |
+| ---------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| **rstep (A)**                                                    | Width of the radial shells. Smaller values increase radial resolution.                                    |
+| **Theta divisions** / **Phi divisions**                          | Angular subdivision of the spherical mesh.                                                                |
+| **rmax (A)**                                                     | Maximum radial extent of the mesh. Atoms outside this radius are excluded and reported in the status log. |
+| **Center mode**                                                  | Read-only summary of the active centering choice.                                                         |
+| **Calculated center**                                            | Mass-weighted center of mass.                                                                             |
+| **Active center**                                                | The origin currently used by the calculation and viewer.                                                  |
+| **Nearest atom**                                                 | The atom nearest to the calculated center of mass.                                                        |
+| **Reference element**                                            | Element used for the reference-element geometric center when that center mode is selected.                |
+| **Total-atom geometric center**                                  | Geometric center of all atoms in the active reference structure.                                          |
+| **Reference-element geometric center**                           | Geometric center of only the chosen reference element.                                                    |
+| **Reference-center offset**                                      | Offset between the total-atom and reference-element geometric centers.                                    |
+| **Calculated Center** / **Nearest Atom** / **Reference Element** | The three center-snap buttons. Exactly one is active at a time.                                           |
+| **Update Mesh Settings**                                         | Applies the pending mesh values to the active row.                                                        |
+| **Active mesh**                                                  | Summary of the currently applied mesh.                                                                    |
+| **Pending fields**                                               | Highlights which mesh fields differ from the applied mesh.                                                |
 
----
+!!! warning "Mesh locking in manual cluster runs"
+In cluster-folder **Manual Mode**, once a manual density calculation has
+succeeded, mesh settings remain locked until **Reset Calculated Densities**
+is used.
 
 ### Actions
 
-| Control                              | Description                                                                                                                                                                                                                   |
-| ------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Run Electron Density Calculation** | Starts a background worker that processes all structure files under the active input path using the current mesh settings, center mode, and smearing settings. The progress bar and message update as each file is processed. |
-| **Progress bar / message**           | Shows the number of structures processed and a human-readable stage description during the calculation. Reads "Idle" when no calculation is running.                                                                          |
+The **Actions** group now covers both simple runs and cluster-folder workflows.
 
-!!! warning "Mesh rmax and atom exclusion"
-If **rmax** is smaller than the actual domain of the structure, atoms that
-fall outside the mesh will be excluded from the profile. The number of
-excluded atoms and their total electron count are reported in the status log
-after the run completes. This is expected if you deliberately want to
-restrict the profile to a sub-domain, but will produce an incomplete profile
-if rmax is simply left at a default value smaller than the structure.
-
----
+| Control                                       | Description                                                                                                                                                                                                                       |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Stoichiometry Table**                       | Appears for cluster-folder inputs. Columns report stoichiometry, file count, average atoms, density status, Fourier status, trace color, smearing, solvent density, solvent cutoff, Fourier settings summary, and reference file. |
+| **Use Contiguous Frame Evaluation**           | Enables contiguous-frame grouping for multi-structure folder and cluster-folder runs.                                                                                                                                             |
+| **Manual Mode (selected stoichiometry only)** | Runs only the selected row instead of the whole cluster table.                                                                                                                                                                    |
+| **Computed stoichiometries indicator**        | Shows overall completion state for cluster-folder work.                                                                                                                                                                           |
+| **Run Electron Density Calculation**          | Runs the active file/folder input, or the active row / entire table in cluster mode depending on Manual Mode.                                                                                                                     |
+| **Stop Active Calculation**                   | Cancels the active background calculation.                                                                                                                                                                                        |
+| **Reset Calculated Densities**                | Clears density, solvent, Fourier, saved-output, and session-restore state after secondary confirmation.                                                                                                                           |
+| **Overall progress**                          | Visible during cluster-folder batch runs and reports completed stoichiometry groups.                                                                                                                                              |
+| **Progress bar / message**                    | Shows detailed stage progress for the active run or workspace load.                                                                                                                                                               |
 
 ### Smearing
 
-The smearing section applies a Gaussian kernel to the raw radial profile.
-This is useful for softening the sharp step transitions between shells when
-comparing to experimental SAXS data or preparing a profile for Fourier
-transformation.
+The **Smearing** section applies a Gaussian kernel to the active density
+profile. The Debye-Waller factor is live and does not require rerunning the
+density calculation.
 
-<!-- prettier-ignore-start -->
+| Field                                             | Description                                                                                               |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| **Debye-Waller factor (A^2)**                     | Smearing strength. `0` disables smearing.                                                                 |
+| **Gaussian sigma**                                | Read-only sigma derived from the Debye-Waller factor.                                                     |
+| **Behavior**                                      | Read-only summary of the active smearing state.                                                           |
+| **Apply Smearing**                                | Applies the current smearing to the active row.                                                           |
+| **Apply to All**                                  | In cluster-folder mode, applies the current smearing setting to every selected or all stoichiometry rows. |
+| **Auto-save smearing snapshots to Saved Outputs** | When enabled, each smearing re-evaluation is captured as a reloadable Saved Outputs entry.                |
 
-| Field | Description |
-|---|---|
-| **Debye-Waller factor (Å²)** | Controls the width of the Gaussian kernel via $\sigma = \sqrt{B}$, where $B$ is this value. A value of 0 disables smearing entirely. Default: 0.006 Å². |
-| **Gaussian sigma** | Read-only. Shows the equivalent Gaussian standard deviation $\sigma$ in ångströms derived from the Debye-Waller factor. |
-| **Behavior** | Read-only. Confirms whether smearing is active or disabled and summarises the active σ value. |
+### Electron Density Contrast
 
-The smearing is applied live whenever the Debye-Waller factor is changed. It
-does not require re-running the full calculation.
+The **Electron Density Contrast** section estimates a flat solvent density and
+subtracts it from the smeared profile.
 
-The relation between the Debye-Waller factor $B$ and the Gaussian standard
-deviation $\sigma$ is:
-
-$$
-\sigma = \sqrt{B}
-$$
-
-<!-- prettier-ignore-end -->
-
----
+| Field                                    | Description                                                                                                          |
+| ---------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
+| **Compute option**                       | Choose between solvent formula plus density, reference solvent structure, or a direct electron-density value.        |
+| **Saved solvents**                       | Preset selector plus save/delete controls for custom solvent presets.                                                |
+| **Solvent formula** / **Density (g/mL)** | Used for the solvent-formula method.                                                                                 |
+| **Direct density (e-/ A^3)**             | Used for the direct-value method.                                                                                    |
+| **Reference solvent file**               | Used for the reference-structure method.                                                                             |
+| **Apply Electron Density Contrast**      | Applies the active contrast settings to the current profile.                                                         |
+| **Apply to All**                         | Reuses the same solvent settings across the target stoichiometry rows while preserving each row's own cutoff result. |
+| **Active contrast**                      | Read-only summary of the active solvent subtraction.                                                                 |
+| **Notes**                                | Read-only status for cutoff detection and residual behavior.                                                         |
 
 ### Fourier Transform
 
-The Fourier Transform section converts the smeared radial density profile into
-a q-space scattering estimate using a spherical Born approximation for a
-radially averaged density. In this implementation the transform is evaluated on
-the selected real-space interval after the profile is resampled onto a uniform
-grid. The preview plot shows exactly what profile enters the numerical
-integration.
+The **Fourier Transform** section converts the active density profile into a
+Born-approximation scattering estimate. The preview panel always shows the
+resampled and windowed real-space data that will be used.
 
-The transform assumes spherical symmetry at the level of the plotted profile,
-so it should be interpreted as a first-pass reciprocal-space estimate rather
-than a full anisotropic scattering calculation.
+The default transform domain is **mirrored mode**, which reflects the profile
+about `r = 0` and evaluates the windowed transform over `-rmax` to `rmax`.
+The UI also keeps a **legacy r min to r max transform** toggle for historical
+behavior.
 
-The transform evaluates:
-
-<!-- prettier-ignore-start -->
+The evaluated transform is:
 
 $$
 F(q) =
@@ -176,134 +203,202 @@ F(q) =
 \,\mathrm{d}r
 $$
 
-where $W(r)$ is the optional real-space window function and
-$I(q) = |F(q)|^2$.
+with `I(q) = |F(q)|^2`.
 
-The code explicitly supports $r_\min = 0$. This is numerically well behaved
-for the spherical kernel above because the sinc factor approaches 1 as
-$r \to 0$, while the additional $r^2$ factor keeps the origin contribution
-finite.
+| Field                                            | Description                                                                                                                                                                                |
+| ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **r min / r max**                                | Real-space bounds used for the transform.                                                                                                                                                  |
+| **Legacy r min to r max transform**              | Switches from the default mirrored-domain transform back to the historical one-sided `r min` to `r max` behavior. In mirrored mode, the left bound is shown as `-r max`.                   |
+| **q min / q max / q step**                       | Requested q grid for the output scattering profile.                                                                                                                                        |
+| **Window**                                       | Real-space apodization window. Options are `None`, `Lorch`, `Cosine`, `Hanning`, `Parzen`, `Welch`, `Gaussian`, `Sine`, and `Kaiser-Bessel`.                                               |
+| **Resample pts**                                 | Number of resampled real-space points used by the transform.                                                                                                                               |
+| **Use solvent-subtracted profile**               | Uses the solvent-subtracted smeared density when available.                                                                                                                                |
+| **Log q axis** / **Log intensity axis**          | Plot scaling preferences for the scattering plot.                                                                                                                                          |
+| **Evaluate Fourier Transform**                   | Evaluates the current transform for the active row, or the target batch in cluster mode.                                                                                                   |
+| **Apply to All**                                 | In cluster-folder mode, switches the Fourier settings table into the shared-edit workflow. q settings stay shared while each stoichiometry keeps its own r range and source profile state. |
+| **Fourier settings table**                       | Per-stoichiometry summary and edit surface for Fourier settings in cluster mode.                                                                                                           |
+| **Available r range** / **Sampling** / **Notes** | Read-only diagnostics for transform support, Nyquist limits, oversampling, clamping, and solvent-profile fallback notes.                                                                   |
 
-Window functions are applied over the selected transform interval. The
-interval-centered families such as Hanning, Welch, Gaussian, Parzen, Sine, and
-Kaiser-Bessel are peaked at the midpoint of the chosen range and taper toward
-the interval boundaries. This mirrors the conventional finite-range
-apodisation strategy used in EXAFS workflows, while the Lorch option provides
-the familiar sinc-like damping often used to reduce truncation ripples.
+!!! note "Single-atom cluster rows"
+Single-atom stoichiometry rows do not build an electron-density profile.
+Their Fourier action evaluates a direct Debye scattering trace instead.
 
-A **preview plot** shows the resampled and windowed profile before the
-integral is evaluated. This is useful for checking that the r-range and window
-settings are appropriate before committing to a full transform.
+!!! note "Inherited q-range versus pushed q-range"
+In computed-distribution mode, the tool inherits the project's q-range.
+If you intentionally evaluate a different q-range here, SAXSShell warns
+before push, but the pushed model components still use the transform grid
+exactly as written.
 
-| Field | Description |
-|---|---|
-| **r min (Å)** | Lower bound of the r-range used for the transform. The portion of the profile below this value is excluded. Default: 0.0 Å. |
-| **r max (Å)** | Upper bound of the r-range used for the transform. Should not exceed the mesh rmax or the structural domain. Default: 1.0 Å (auto-updated from the mesh). |
-| **Transform window** | Apodisation function applied to the profile before transformation to reduce truncation ringing. Options: `None` (rectangular, no tapering), `Lorch`, `Cosine`, `Hanning`, `Parzen`, `Welch`, `Gaussian`, `Sine`, and `Kaiser-Bessel`. Default: `None`. |
-| **Resampling points** | Number of uniformly-spaced r points used when interpolating the profile before the numerical integration. Higher values improve transform accuracy. Default: 1024. |
-| **q min (Å⁻¹)** | Minimum q value of the output scattering profile. Default: 0.02 Å⁻¹. |
-| **q max (Å⁻¹)** | Maximum q value of the output scattering profile. The tool may clamp this to the Nyquist limit determined by the resampling step. Default: 10.0 Å⁻¹. |
-| **q step (Å⁻¹)** | Spacing between q grid points in the output profile. Default: 0.02 Å⁻¹. |
-| **Use solvent-subtracted profile** | When checked, the transform uses the solvent-subtracted smeared density if a solvent electron density has already been computed. If no solvent contrast is active, the tool falls back to the ordinary smeared profile and notes that fallback in the preview. |
-| **Log q axis** | When checked, the q axis of the scattering plot uses a logarithmic scale. |
-| **Log intensity axis** | When checked, the intensity axis of the scattering plot uses a logarithmic scale. |
-| **Evaluate Fourier Transform** | Evaluates the transform using the current settings and updates the scattering plot. Requires a completed density calculation. |
-| **Available r range** | Read-only. Reports the r range available from the current profile result, i.e., the actual mesh domain after extending the transform support to the origin. |
-| **Sampling** | Read-only. Reports the resampling step size, the Nyquist q limit derived from that step, and the independent q step size. Warns if the q grid is oversampled relative to the Nyquist limit. |
-| **Notes** | Read-only. Flags any conditions that may affect the transform quality, such as a clamped q max, a q grid that is significantly oversampled, or a fallback from solvent-subtracted to ordinary smeared density. |
+### Push to Model
 
-#### Window guidance
+The **Push to Model** group sits directly below **Fourier Transform** and above
+**Saved Outputs**. It is available only in computed-distribution mode.
 
-- `None` is the sharp-cutoff choice. It preserves the selected interval exactly but is the most prone to ringing from finite-range truncation.
-- `Lorch` is useful when you want a sinc-like damping toward the upper bound and are specifically trying to suppress termination ripples.
-- `Hanning`, `Welch`, `Parzen`, `Gaussian`, `Sine`, and `Kaiser-Bessel` are centered interval windows. They are strongest in the middle of the selected range and taper toward both ends.
-- `Kaiser-Bessel` is often a good general-purpose compromise when you want stronger sidelobe suppression than a simple cosine-family window.
-- If you need low-r features preserved as strongly as possible, keep the transform range physically justified and compare more than one window in the preview before committing to an interpretation.
+| Control           | Description                                                                                                                     |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| **Status text**   | Explains why push is enabled or disabled.                                                                                       |
+| **Push to Model** | Writes the current Born-approximation component traces into the linked computed distribution so the main SAXS UI can load them. |
 
-#### Sampling guidance
+Push remains disabled when:
 
-- Increasing **Resampling points** decreases the uniform $\Delta r$ used in the transform and therefore raises the Nyquist-limited maximum usable q.
-- Decreasing the real-space interval width increases the independent q spacing, so a very fine requested **q step** may oversample the plotted curve without adding independent information.
-- Starting the transform at $r = 0$ is supported, but if the low-r bins are dominated by a center-snapped atom or by strong solvent subtraction, compare the preview carefully before interpreting the high-q tail.
+- The tool is in preview mode.
+- The window is not linked to a computed distribution.
+- Any cluster row is still missing its Fourier transform.
+- The linked distribution already has saved prefit snapshots.
+- The linked distribution already has saved DREAM runs.
 
-<!-- prettier-ignore-end -->
+The push step is independent from calculation and transform persistence. In
+computed-distribution mode, reopening the tool restores saved densities and
+Fourier transforms even if **Push to Model** has never been used.
 
----
+### Debye Scattering Calculation
+
+The **Debye Scattering Calculation** group is a validation workspace for
+comparing the current Born-approximation traces against averaged direct Debye
+scattering traces on the same q-grid.
+
+| Control                        | Description                                                                                                                       |
+| ------------------------------ | --------------------------------------------------------------------------------------------------------------------------------- |
+| **Status text**                | Summarizes which active row or target rows already have Debye averages that match the current Born q-grid.                        |
+| **Calculate Debye Scattering** | Computes an averaged direct Debye scattering trace on the exact q-grid of the current Born transform.                             |
+| **Apply to All Rows**          | In cluster-folder mode, computes Debye averages for every eligible stoichiometry row instead of only the current selection.       |
+| **Open Comparison Plot**       | Opens a separate overlay dialog. Born traces use the left axis and solid lines; Debye traces use the right axis and dashed lines. |
+
+Rows are eligible only when they already have a Born-approximation Fourier
+trace. Single-atom rows are skipped here because they already use direct Debye
+scattering as their main scattering result.
+
+### Saved Output Sets
+
+The **Saved Output Sets** section captures intermediate and final states for
+reload and comparison.
+
+| Control                     | Description                                                                                                                             |
+| --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| **Saved Output Sets table** | Records density, solvent-subtraction, and Fourier entries with context, averaging mode, mesh, smearing, solvent, and Fourier summaries. |
+| **Load Selected**           | Restores one saved entry back into the main UI state.                                                                                   |
+| **Compare Selected**        | Opens a comparison dialog for one or more saved entries with PNG and CSV export tools.                                                  |
+
+Saved Outputs track density, solvent-subtraction, and Fourier snapshots. In
+computed-distribution mode, Debye comparison traces are restored from the
+workspace session state instead of from the Saved Outputs history.
+
+Persistence paths:
+
+- Preview-mode history is stored in the chosen output directory as
+  `electron_density_saved_output_history.json`.
+- Computed-distribution history is stored in the linked distribution as
+  `electron_density_mapping/saved_output_history.json`.
+- Computed-distribution session restore state is stored separately as
+  `electron_density_mapping/workspace_state.json`.
+
+That session state preserves calculated densities, Fourier transforms, and
+Debye scattering comparison traces even if they have not been pushed to the
+model yet. It is cleared only by
+**Reset Calculated Densities**.
 
 ### Status
 
-A scrollable log box that records loaded structures, settings applied, progress
-messages, and any warnings about excluded atoms or transform quality. Useful for
-reviewing what settings were active during a calculation.
+The **Status** panel is the persistent log for:
 
----
+- Input and workspace loading.
+- Contiguous-frame grouping or fallback notes.
+- Calculation progress and completion summaries.
+- Solvent subtraction and Fourier warnings.
+- Export, persistence, and push-to-model messages.
 
-## Right-panel plots
+## Right panel and viewer
 
-The right side of the window contains six stacked panels.
+The right-hand side contains shared plot controls followed by the plot panels
+and the structure viewer.
 
-| Plot                                                  | Description                                                                                                                                                                                    |
-| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Orientation-Averaged Radial Electron Density ρ(r)** | Raw binned profile before smearing. Displayed as a step trace with an optional variance shading band (one standard deviation across ensemble members).                                         |
-| **Gaussian-Smeared Radial Electron Density ρ(r)**     | The same profile after the Gaussian-smearing kernel has been applied. Displayed as a smooth curve with optional variance shading.                                                              |
-| **Solvent-Subtracted Residual**                       | The smeared profile minus the active flat solvent electron density, shown after solvent contrast has been computed. The highest-r crossing used for the solvent cutoff is marked here as well. |
-| **Fourier Transform Preview**                         | Shows the resampled and windowed density data that will be fed into the transform integral. Updates live when the Fourier Transform settings change.                                           |
-| **Scattering Profile I(q)**                           | The resulting Born-approximation intensity after **Evaluate Fourier Transform** is clicked.                                                                                                    |
-| **Structure Viewer**                                  | A 2D projected scatter plot of atom positions from the reference structure, coloured by element. The active center of mass origin is shown as a reference point.                               |
+### Global plot controls
 
-The **Show Variance Shading** checkbox above the plots toggles the standard-deviation
-band on both the raw and smeared profile plots simultaneously.
+- **Show Variance Shading** toggles variance bands on density plots.
+- **Auto-expand plots** expands panels automatically when their data updates.
+- **Show All Cluster Transforms** overlays every ready cluster transform on the
+  active scattering plot.
+- **Expand All / Collapse All** toggles every plot section.
+- **Export Plot Traces** writes the currently displayed raw density, smeared
+  density, Fourier preview, and scattering traces into one CSV export.
 
----
+### Plot panels
 
-## Typical workflow
+| Panel                                                   | Description                                                                                                     |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| **Orientation-Averaged Radial Electron Density rho(r)** | Finite-radius shell-averaged raw density profile used as the basis for the displayed real-space interpretation. |
+| **Gaussian-Smeared Radial Electron Density rho(r)**     | Smoothed density profile after the active smearing setting.                                                     |
+| **Solvent-Subtracted Residual**                         | Residual curve after solvent subtraction, including the active cutoff marker when present.                      |
+| **Fourier Transform Preview**                           | Resampled and windowed density source that will be used for the scattering transform.                           |
+| **Scattering Profile I(q)**                             | Born-approximation or direct Debye scattering result evaluated from the corrected density source.               |
 
-1. Open the tool from the main SAXSShell UI or launch `saxshell` with the
-   `electron-density-mapping` subcommand.
-2. In **Input**, choose a single XYZ or PDB file or a folder of structures.
-   Click **Load Input**.
-3. Review the **Structure summary** field: check the element composition,
-   center of mass, and domain rmax.
-4. In **Mesh Settings**, set **rmax** to at least the reported domain radius.
-   Adjust **rstep**, **Theta divisions**, and **Phi divisions** as needed for
-   the desired resolution.
-5. Choose a **Center mode**. If the center of mass falls in an interstitial
-   void, use **Snap Center to Nearest Atom** to anchor the origin to a real
-   atomic site.
-6. Click **Update Mesh Settings** to apply any field changes.
-7. Set the **Output directory** and **Output basename** if you want to save
-   results to disk.
-8. Click **Run Electron Density Calculation** and wait for the progress bar to
-   complete.
-9. Inspect the raw and smeared ρ(r) plots. Adjust the **Debye-Waller factor**
-   under **Smearing** to control profile smoothness.
-10. If a q-space estimate is needed, configure the **Fourier Transform** section
-    and click **Evaluate Fourier Transform**.
+### Structure Viewer
 
----
+The structure viewer is an interactive **3D** Matplotlib viewer, not a static
+2D preview. It supports:
 
-## Output files
+- Rotate, pan, and zoom interactions.
+- Reset View.
+- Mesh overlay toggling.
+- Mesh contrast, line width, and color controls.
+- Point-atom display mode.
+- Active-origin and zoom readouts over the scene.
+- Preserved zoom and camera state while switching between stoichiometry rows in
+  cluster-folder mode.
 
-When an output directory is specified, two files are written after a successful
-run.
+## Typical workflows
 
-| File                      | Contents                                                                                                                                                                                                             |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `<basename>_profile.csv`  | Radial centers, orientation-averaged density, smeared density, and per-shell electron counts and volumes.                                                                                                            |
-| `<basename>_summary.json` | Metadata including the input path, input mode, element counts, center of mass, active center, center mode, mesh settings, smearing settings, excluded atom/electron counts, and per-member summaries in folder mode. |
+### Standalone preview
 
----
+1. Launch **Open Electron Density Mapping** from the main UI or start the tool
+   from the terminal.
+2. Load a single structure file or a folder of structures.
+3. Review the structure summary and set the mesh.
+4. Run the density calculation.
+5. Adjust smearing, optional solvent subtraction, and optional Fourier settings.
+6. Optionally compute a matching Debye scattering average and open the
+   comparison plot.
+7. Use **Saved Output Sets** to reload or compare intermediate states.
+
+### Computed distribution / Born approximation
+
+1. Open the tool from **Build SAXS Components** with the
+   **Born Approximation (Average)** workflow.
+2. Confirm that the inherited cluster folder, output directory, and q-range are
+   correct.
+3. Review the stoichiometry table and choose whether to run the full batch or
+   **Manual Mode**.
+4. Run the density calculation.
+5. Apply smearing, solvent subtraction, and Fourier settings row-by-row or with
+   **Apply to All**.
+6. Evaluate Fourier transforms for every required row.
+7. Optionally compute Debye scattering averages for the active or target rows
+   and inspect the Born-vs-Debye comparison plot.
+8. Use **Push to Model** only after all desired transforms are complete.
+
+## Output and persistence files
+
+| File                                                                      | When it appears                                                     | Contents                                                                                                                           |
+| ------------------------------------------------------------------------- | ------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `<basename>.csv` / `<basename>.json`                                      | File and folder runs with an output directory                       | Density profile export and JSON summary for the run.                                                                               |
+| `<basename>_<stoichiometry>.csv` / `<basename>_<stoichiometry>.json`      | Cluster-folder runs with an output directory                        | One density export pair per density-based stoichiometry row. Direct-Debye-only rows do not write this pair during the density run. |
+| `electron_density_saved_output_history.json`                              | Preview mode with a writable output directory                       | Saved-output history for reload and comparison.                                                                                    |
+| `saved_output_history.json`                                               | Computed-distribution mode                                          | Distribution-linked saved-output history.                                                                                          |
+| `workspace_state.json`                                                    | Computed-distribution mode after a density or Fourier result exists | Restorable session state for non-pushed calculations.                                                                              |
+| `born_approximation_component_summary.json`                               | After **Push to Model**                                             | Saved pushed component summary for the linked distribution.                                                                        |
+| `md_saxs_map.json` or `md_saxs_map_predicted_structures.json`             | After **Push to Model**                                             | SAXS component registry for the linked distribution.                                                                               |
+| `scattering_components/` or `scattering_components_predicted_structures/` | After **Push to Model**                                             | Per-component Born-approximation scattering traces written as `.txt` files.                                                        |
 
 ## Related pages
 
 - [SAXS Contrast Mode](saxs-contrast-mode.md)
-- [XYZ to PDB Conversion](xyz2pdb-conversion.md)
 - [Cluster Extraction](cluster-extraction.md)
 - [Results and Export](results-and-export.md)
+- [XYZ to PDB Conversion](xyz2pdb-conversion.md)
 
 ## References
 
 - [Larch XAFS Fourier-transform documentation: practical window definitions including Hanning, Parzen, Welch, Gaussian, Sine, and Kaiser-Bessel.](https://xraypy.github.io/xraylarch/xafs_fourier.html)
-- [ORNL X-ray and neutron reflectivity tutorial: kinematic “master formula” discussion linking reciprocal-space scattering to Fourier transforms of real-space interfacial structure.](https://neutrons.ornl.gov/sites/default/files/beamline_04A_xray_neutron_reflectivity_tutorial.pdf)
-- [Steinrück H.-G., Han H.-L., et al. _Fluoroethylene Carbonate Induces Ordered Electrolyte Interface on Silicon and Sapphire Surfaces as Revealed by Sum Frequency Generation Vibrational Spectroscopy and X-ray Reflectivity_. Nano Letters (2018).](https://pubs.acs.org/doi/abs/10.1021/acs.nanolett.8b00298)
+- [ORNL X-ray and neutron reflectivity tutorial: kinematic "master formula" discussion linking reciprocal-space scattering to Fourier transforms of real-space interfacial structure.](https://neutrons.ornl.gov/sites/default/files/beamline_04A_xray_neutron_reflectivity_tutorial.pdf)
+- [Steinruck H.-G., Han H.-L., et al. _Fluoroethylene Carbonate Induces Ordered Electrolyte Interface on Silicon and Sapphire Surfaces as Revealed by Sum Frequency Generation Vibrational Spectroscopy and X-ray Reflectivity_. Nano Letters (2018).](https://pubs.acs.org/doi/abs/10.1021/acs.nanolett.8b00298)
 - [Elam W. T., Ravel B. D., Sieber J. R. _A new atomic database for X-ray spectroscopic calculations_. Radiation Physics and Chemistry (2002). Background reference for the `xraydb` atomic quantities used elsewhere in this tool.](<https://doi.org/10.1016/S0969-806X(01)00327-4>)

--- a/docs/user-guide/gui-overview.md
+++ b/docs/user-guide/gui-overview.md
@@ -13,8 +13,20 @@ The primary SAXS workflow lives in `saxshell saxs`. Its tabs are not isolated:
 the active template, component list, geometry metadata, and saved state all
 move between them.
 
-The new contrast-enabled component build path also adds a linked supporting
-application that can be launched from Project Setup and from the Tools menu.
+Project Setup now separates two linked actions:
+
+- **Create Computed Distribution** saves the current Project Setup snapshot for
+  a specific modeling branch.
+- **Build SAXS Components** follows the selected build mode for that saved
+  distribution.
+
+The linked supporting-application launches are build-mode aware:
+
+- `No Contrast (Debye)` stays in the main SAXS UI and runs the direct Debye
+  component builder.
+- `Contrast (Debye)` opens the contrast workflow window.
+- `Born Approximation (Average)` opens Electron Density Mapping in
+  computed-distribution mode.
 
 ### `saxshell saxs`
 
@@ -23,11 +35,19 @@ template-driven workflows.
 
 ### Project Setup
 
-Defines the project inputs and template choice.
+Defines the project inputs, computed distributions, and component-build choice.
 
-This is the point where the main UI expects cluster-derived SAXS inputs from
-the supporting applications. In practice, that usually means a cluster folder
-prepared through the trajectory, conversion, and cluster-extraction tools.
+This is where you:
+
+- choose the project, datasets, clusters folder, and template
+- set q-range, grid, and excluded-element controls
+- create or load computed distributions
+- optionally compute Debye-Waller factors from PDB cluster folders
+- build SAXS components with the current build mode
+
+The **Active Computed Distribution** panel on this tab summarizes the saved
+distribution identity and whether component, prior, Prefit, and DREAM artifacts
+already exist for that branch.
 
 ### SAXS Prefit
 
@@ -52,6 +72,7 @@ Several newer SAXS UI surfaces follow the same patterns:
 
 - progress bars with text status
 - long-running background tasks
+- distribution or readiness indicators next to optional project-backed steps
 - table-based editing for parameters or cluster geometry metadata
 - plot control toggles for experimental, model, and solvent traces
 
@@ -69,57 +90,104 @@ Several newer SAXS UI surfaces follow the same patterns:
 ## Supporting applications
 
 These applications prepare, analyze, or extend the data that the main SAXS UI
-consumes.
+consumes. The documentation below is grouped the same way as the main
+`Tools` menu.
 
-### `mdtrajectory`
+### MD Extraction
 
-Use this when you need to inspect trajectories, choose an equilibration cutoff,
-and export frames for downstream analysis.
+Use these tools when you need to move from a raw trajectory to a sorted cluster
+folder that the rest of the SAXSShell workflow can consume.
 
-### `xyz2pdb`
+- `mdtrajectory` inspects trajectories, helps choose an equilibration cutoff,
+  and exports frames for downstream analysis.
+- `xyz2pdb` converts extracted XYZ frames into residue-aware PDB files when
+  molecule identity matters downstream.
+- `clusters` builds the stoichiometry-sorted cluster exports used by later
+  workflows.
 
-Use this when exported XYZ frames need molecule identification or residue-aware
-PDB conversion before clustering.
+### Structure Analysis
 
-### `clusters`
+Use these tools when you want to analyze the sorted clusters themselves.
 
-Use this when you need to build cluster-network exports from extracted frames.
+- `bondanalysis` measures bond-pair and angle distributions from the cluster
+  folders.
+- `Debye-Waller Analysis` estimates intra-molecular and inter-molecular
+  Debye-Waller coefficients from sorted PDB cluster folders and saves them in
+  the active project when requested from Project Setup or the Tools menu.
 
-### `clusterdynamics`
+### Cluster Dynamics
 
-Use this when you need time-binned cluster-distribution heatmaps, optional
-energy overlays, and lifetime / association / dissociation summaries from an
-extracted XYZ or PDB frame folder.
+Use these tools when you need time-resolved cluster populations or want to
+extend the observed structure series.
 
-### `clusterdynamicsml`
+- `clusterdynamics` builds time-binned cluster-distribution heatmaps, optional
+  energy overlays, and lifetime / association / dissociation summaries.
+- `clusterdynamicsml` extrapolates larger cluster candidates, generates
+  predicted structures, and compares observed-only versus
+  observed-plus-predicted SAXS models.
 
-Use this when you want to extrapolate larger cluster candidates from the
-observed smaller-cluster dynamics and structure library, generate predicted
-structure files, and compare observed-only versus observed-plus-predicted SAXS
-models.
+### PDF
 
-### `bondanalysis`
+Use this section for pair-distribution workflows tied to the active project.
 
-Use this when you need bond-pair and angle-distribution measurements on the
-cluster folders.
+- `pdfsetup` runs Debyer-backed trajectory-averaged PDF and partial-PDF
+  calculations and stores the saved calculation sets in the project.
+- `saxshell fullrmc` remains the downstream setup path for fullrmc-oriented
+  project artifacts.
 
-### `pdfsetup`
+### Visualization
 
-Use this when you need Debyer-backed trajectory-averaged PDF or partial-PDF
-calculations, saved PDF calculation sets inside a SAXSShell project, and quick
-switching between little `g(r)`, big `G(r)`, and `R(r)` representations.
+Use `blenderxyz` when you need publication-style structure renders that go
+beyond the inline previewer.
 
-### `saxshell fullrmc`
+### SAXS Calculation Preview
 
-Use this when you want to prepare downstream fullrmc or Packmol-oriented
-artifacts from a SAXS project.
+Use these preview-mode tools when you want to inspect SAXS component-building
+settings outside the main computed-distribution flow.
+
+- `SAXS Contrast Mode` is the `Contrast (Debye)` representative-structure
+  workflow.
+- `Electron Density Mapping` is the
+  `Born Approximation (Average)` density-profile and Fourier-transform workflow.
+
+### X-ray Toolkit
+
+Use this section for smaller estimate windows such as volume-fraction, number
+density, attenuation, and fluorescence calculators.
 
 ## Supporting application references
 
-- [Cluster Extraction](cluster-extraction.md)
+### MD Extraction
+
+- [MD Extraction and Cluster Preparation](cluster-extraction.md)
+- [XYZ to PDB Conversion](xyz2pdb-conversion.md)
+
+### Structure Analysis
+
+- [Bond Analysis](bond-analysis.md)
+- [Debye-Waller Analysis](debye-waller-analysis.md)
+
+### Cluster Dynamics
+
 - [Cluster Dynamics](cluster-dynamics.md)
 - [Cluster Dynamics ML](cluster-dynamics-ml.md)
+
+### PDF
+
 - [PDF Calculation](pdf-calculation.md)
+
+### Visualization
+
+- [Blender Structure Renderer](blender-structure-renderer.md)
+
+### SAXS Calculation Preview
+
+- [SAXS Contrast Mode](saxs-contrast-mode.md)
+- [Electron Density Mapping](electron-density-mapping.md)
+
+### X-ray Toolkit
+
+- [X-ray Toolkit](xray-toolkit.md)
 
 ## TODO
 

--- a/docs/user-guide/pdf-calculation.md
+++ b/docs/user-guide/pdf-calculation.md
@@ -1,7 +1,7 @@
 # PDF Calculation
 
 SAXSShell includes a Debyer-backed PDF application exposed as `pdfsetup` and as
-`Tools > Open PDF Calculation` from the main SAXS UI.
+`Tools > PDF > Open PDF Calculation` from the main SAXS UI.
 
 When the tool is opened from the main UI, its saved calculations become part of
 the same project-backed workflow state used by the SAXS tabs.

--- a/docs/user-guide/project-configuration.md
+++ b/docs/user-guide/project-configuration.md
@@ -1,37 +1,63 @@
 # Project Configuration
 
-SAXS projects are file-backed. The application stores enough metadata in the
-project directory to let you reopen a project and continue without rebuilding
-everything from scratch each time.
+SAXS projects are file-backed, but the current UI is centered on
+**computed distributions** inside each project. A project can hold multiple
+distributions that share the same dataset family while differing in template,
+build mode, q-range, excluded elements, or structure-weighting choices.
 
 The project directory is also where the main SAXS UI meets the supporting
-applications: cluster folders, component metadata, saved PDF calculations, and
-fit artifacts all end up tied back to the same project state.
+applications: cluster folders, component metadata, electron-density or
+contrast-mode artifacts, saved PDF calculations, and fit results all end up
+tied back to the same project state.
 
 ## What a project captures
 
 From the current project-manager and Prefit workflow code, a SAXS project can
 persist:
 
-- the selected experimental dataset
-- the cluster directory used to build components
-- the active model template
-- prior-weight metadata
-- SAXS component maps
-- saved Prefit state
-- saved DREAM settings and run artifacts
+- the selected experimental and optional solvent datasets
+- the frames, PDB structures, and clusters directories referenced by the
+  project
+- the active model template and Project Setup controls
+- saved computed distributions under the project's distribution storage
+- prior-weight metadata and SAXS component maps for each distribution
+- saved Prefit state and DREAM run artifacts tied to a specific distribution
 - cluster geometry metadata when the active template needs it
+- saved supporting-application outputs such as PDF calculations,
+  Debye-Waller analyses, contrast-mode artifacts, and electron-density
+  mapping state
+
+## What defines a computed distribution
+
+In Project Setup, **Create Computed Distribution** saves the active modeling
+snapshot. The current UI treats the following settings as part of the
+distribution identity:
+
+- selected template
+- component build mode
+- cluster source folder
+- q-range and grid mode
+- excluded elements
+- observed-only versus observed-plus-predicted structure weighting
+- model-only mode
+
+When experimental-grid mode is active, the experimental data source also feeds
+into that saved identity. This is why two distributions can coexist in one
+project even when they differ only by build mode, for example
+`No Contrast (Debye)` versus `Born Approximation (Average)`.
 
 ## Why this matters
 
-Several behaviors in the UI depend on previously computed project state:
+Several behaviors in the UI depend on previously computed distribution state:
 
-- Prefit can reuse saved cluster-geometry metadata without recomputing it every
-  session.
-- Deprecated templates can still be resolved when an older project names them,
-  even though they are hidden by default in new template pickers.
-- DREAM runtime bundles can be rebuilt from the current saved Prefit workflow
-  state.
+- the Project Setup dropdown can reload earlier computed distributions without
+  overwriting the current one
+- Prefit and DREAM reuse the component maps, prior weights, and saved runtime
+  state from the active distribution
+- supporting tools launched from **Build SAXS Components** inherit the active
+  distribution context, not just the top-level project directory
+- push-to-model actions in linked tools are intentionally locked once that
+  distribution already has saved Prefit snapshots or DREAM runs
 
 ## Template-aware behavior
 
@@ -42,17 +68,23 @@ That means the active template can affect:
 - whether cluster geometry metadata is mandatory
 - which shape approximations are allowed
 - which geometry-derived parameters are generated
+- which computed distribution a later Prefit or DREAM run belongs to
 
 ## Practical guidance
 
 - Keep one project directory per modeling attempt or dataset family.
-- If you significantly change cluster folders, regenerate the component and
-  geometry metadata instead of assuming older saved state is still valid.
-- When comparing templates, treat the saved Prefit state as template-specific.
+- Treat computed distributions as intentional branches of that project rather
+  than as temporary UI state.
+- If you significantly change cluster folders, build mode, q-range, or
+  excluded elements, create a fresh computed distribution instead of assuming
+  older saved state is still valid.
+- When comparing templates, treat Prefit and DREAM state as
+  distribution-specific, not just project-specific.
 
 ## Related pages
 
 - [Project Setup](../getting-started/project-setup.md)
+- [GUI Overview](gui-overview.md)
 - [Cluster Extraction](cluster-extraction.md)
 - [SAXS Prefit](saxs-prefit.md)
 - [pyDREAM Workflow](pydream-workflow.md)

--- a/docs/user-guide/saxs-contrast-mode.md
+++ b/docs/user-guide/saxs-contrast-mode.md
@@ -15,9 +15,9 @@ Use contrast mode when you want the SAXS component build to be tied to:
 
 You can open the contrast workflow in two ways:
 
-- **Project Setup > Component build mode > Contrast Mode**, then click
+- **Project Setup > Component build mode > Contrast (Debye)**, then click
   **Build SAXS Components**
-- **Tools > Open SAXS Contrast Mode**
+- **Tools > SAXS Calculation Preview > Open SAXS Contrast Mode**
 
 When a saved contrast-mode distribution is active, Project Setup also exposes
 **View Representative Structures** below **Build SAXS Components** so you can
@@ -25,7 +25,7 @@ reopen the saved representative-selection, mesh, density, and trace context.
 
 ## Typical workflow
 
-1. In **Project Setup**, choose **Contrast Mode** above
+1. In **Project Setup**, choose **Contrast (Debye)** above
    **Build SAXS Components**.
 2. Open the contrast tool from **Build SAXS Components** or from **Tools**.
 3. Confirm the inherited project folder, cluster folder, template, and q-range.
@@ -58,7 +58,7 @@ distribution is active.
 
 The SAXS component build mode is part of computed-distribution identity. That
 means two distributions can coexist even if everything else matches, as long as
-one is **No Contrast Mode** and the other is **Contrast Mode**.
+one is **No Contrast (Debye)** and the other is **Contrast (Debye)**.
 
 Within contrast mode:
 

--- a/docs/user-guide/xray-toolkit.md
+++ b/docs/user-guide/xray-toolkit.md
@@ -1,0 +1,29 @@
+# X-ray Toolkit
+
+The **X-ray Toolkit** groups SAXSShell's small estimate windows under one Tools
+menu section:
+
+- `Open Volume Fraction Estimate`
+- `Open Number Density Estimate`
+- `Open Attenuation Estimate`
+- `Open Fluorescence Estimate`
+
+Open these utilities from `Tools > X-ray Toolkit` in the main SAXS UI.
+
+## What this section is for
+
+These tools are lightweight helpers for quick calculations that support project
+setup, experiment planning, or interpretation of solution conditions. They are
+useful when you need a fast estimate without launching a larger
+project-backed workflow.
+
+## Current scope
+
+Unlike project-backed tools such as PDF Calculation, Electron Density Mapping,
+or Debye-Waller Analysis, the X-ray Toolkit windows are intended as focused
+calculators rather than long-lived saved analysis workspaces.
+
+## Related pages
+
+- [GUI Overview](gui-overview.md)
+- [Project Configuration](project-configuration.md)

--- a/docs/user-guide/xyz2pdb-conversion.md
+++ b/docs/user-guide/xyz2pdb-conversion.md
@@ -3,7 +3,8 @@
 The `xyz2pdb` tool converts one `XYZ` file or a folder of `XYZ` frames into
 molecule-aware `PDB` files using a reference library and interactive mapping
 definitions. It is available as the standalone `xyz2pdb` application and from
-the main SAXSShell window through `Tools > Open XYZ -> PDB Conversion`.
+the main SAXSShell window through
+`Tools > MD Extraction > Open XYZ -> PDB Conversion`.
 
 ## Purpose
 
@@ -41,7 +42,7 @@ The current interface can:
 
 Open the tool from:
 
-- `Tools > Open XYZ -> PDB Conversion`
+- `Tools > MD Extraction > Open XYZ -> PDB Conversion`
 - the `Open XYZ -> PDB Conversion` button in the project setup workflow
 
 When opened from an active SAXS project, the window is linked to that project.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,13 +77,24 @@ nav:
           - pyDREAM Workflow: user-guide/pydream-workflow.md
           - Results and Export: user-guide/results-and-export.md
       - Supporting Applications:
-          - Blender Structure Renderer: user-guide/blender-structure-renderer.md
-          - Cluster Extraction: user-guide/cluster-extraction.md
-          - Cluster Dynamics: user-guide/cluster-dynamics.md
-          - Cluster Dynamics ML: user-guide/cluster-dynamics-ml.md
-          - Electron Density Mapping: user-guide/electron-density-mapping.md
-          - PDF Calculation: user-guide/pdf-calculation.md
-          - XYZ to PDB Conversion: user-guide/xyz2pdb-conversion.md
+          - MD Extraction:
+              - MD Extraction and Cluster Preparation: user-guide/cluster-extraction.md
+              - XYZ to PDB Conversion: user-guide/xyz2pdb-conversion.md
+          - Structure Analysis:
+              - Bond Analysis: user-guide/bond-analysis.md
+              - Debye-Waller Analysis: user-guide/debye-waller-analysis.md
+          - Cluster Dynamics:
+              - Cluster Dynamics: user-guide/cluster-dynamics.md
+              - Cluster Dynamics ML: user-guide/cluster-dynamics-ml.md
+          - PDF:
+              - PDF Calculation: user-guide/pdf-calculation.md
+          - Visualization:
+              - Blender Structure Renderer: user-guide/blender-structure-renderer.md
+          - SAXS Calculation Preview:
+              - SAXS Contrast Mode: user-guide/saxs-contrast-mode.md
+              - Electron Density Mapping: user-guide/electron-density-mapping.md
+          - X-ray Toolkit:
+              - X-ray Toolkit: user-guide/xray-toolkit.md
   - Tutorials:
       - Example Workflow: tutorials/example-workflow.md
       - MD to SAXS Pipeline: tutorials/md-to-saxs-pipeline.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ clusters = "saxshell.cluster.cli:main"
 mdtrajectory = "saxshell.mdtrajectory.cli:main"
 saxshell = "saxshell.saxshell:main"
 pdfsetup = "saxshell.pdfsetup:main"
+structureviewer = "saxshell.saxs.structure_viewer.cli:main"
 xyz2pdb = "saxshell.xyz2pdb.cli:main"
 
 [tool.setuptools-git-versioning]

--- a/src/saxshell/cluster/cli.py
+++ b/src/saxshell/cluster/cli.py
@@ -202,6 +202,14 @@ def _add_common_cluster_arguments(parser: argparse.ArgumentParser) -> None:
         help="Allow shell atoms to be shared between clusters.",
     )
     parser.add_argument(
+        "--legacy-solvation-shells",
+        action="store_true",
+        help=(
+            "Disable Smart Solvation Shell mode and use the legacy "
+            "per-frame solvent shell extraction path."
+        ),
+    )
+    parser.add_argument(
         "--include-shell-atoms-in-stoichiometry",
         action="store_true",
         help="Include shell atoms when assigning stoichiometry folders.",
@@ -235,6 +243,9 @@ def _build_workflow(args: argparse.Namespace) -> ClusterWorkflow:
             )
         ),
         shared_shells=bool(getattr(args, "shared_shells", False)),
+        smart_solvation_shells=not bool(
+            getattr(args, "legacy_solvation_shells", False)
+        ),
         include_shell_atoms_in_stoichiometry=bool(
             getattr(args, "include_shell_atoms_in_stoichiometry", False)
         ),
@@ -348,6 +359,8 @@ def _format_selection_result(selection: ClusterSelectionResult) -> str:
         f"Frames folder: {selection.summary['input_dir']}",
         f"Mode: {selection.mode_label}",
         f"PBC: {'on' if selection.use_pbc else 'off'}",
+        "Smart solvation shells: "
+        f"{'on' if selection.smart_solvation_shells else 'off'}",
         f"Search mode: {selection.search_mode_label}",
         "Save-state frequency: "
         f"every {selection.save_state_frequency} frames",

--- a/src/saxshell/cluster/clusternetwork.py
+++ b/src/saxshell/cluster/clusternetwork.py
@@ -485,6 +485,7 @@ class ClusterRecord:
     shell_atom_ids: tuple[int, ...]
     stoichiometry: dict[str, int]
     shell_levels: dict[int, int | str | None]
+    detected_shell_atom_ids: tuple[int, ...] = ()
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -494,6 +495,7 @@ class ClusterRecord:
             "node_atom_ids": list(self.node_atom_ids),
             "linker_atom_ids": list(self.linker_atom_ids),
             "shell_atom_ids": list(self.shell_atom_ids),
+            "detected_shell_atom_ids": list(self.detected_shell_atom_ids),
             "stoichiometry": dict(self.stoichiometry),
             "shell_levels": dict(self.shell_levels),
         }
@@ -524,6 +526,13 @@ class ClusterRecord:
             ),
             shell_atom_ids=tuple(
                 int(value) for value in payload.get("shell_atom_ids", [])
+            ),
+            detected_shell_atom_ids=tuple(
+                int(value)
+                for value in payload.get(
+                    "detected_shell_atom_ids",
+                    payload.get("shell_atom_ids", []),
+                )
             ),
             stoichiometry={
                 str(element): int(count)
@@ -583,6 +592,56 @@ class TrajectoryClusterExport:
     already_complete: bool = False
     previously_completed_frames: int = 0
     newly_processed_frames: int = 0
+
+
+@dataclass(slots=True)
+class _SmartShellRunState:
+    """Tracked solvent-shell union for one contiguous solute cluster."""
+
+    solute_atom_ids: tuple[int, ...]
+    last_frame_index: int
+    frame_refs: list[tuple[str, str]]
+    shell_levels: dict[int, int]
+
+
+def _cluster_shell_level_payload(
+    cluster: ClusterRecord,
+) -> dict[int, int]:
+    """Return exported shell levels with integer shell indices only."""
+    return {
+        atom_id: int(level)
+        for atom_id in cluster.shell_atom_ids
+        if isinstance((level := cluster.shell_levels.get(atom_id)), int)
+    }
+
+
+def _update_cluster_record_shell_union(
+    cluster: ClusterRecord,
+    shell_levels: Mapping[int, int],
+    *,
+    elements: Mapping[int, str],
+    include_shell_atoms_in_stoichiometry: bool,
+) -> None:
+    """Replace one cluster record's exported shell union in place."""
+    cluster.shell_atom_ids = tuple(
+        sorted(int(atom_id) for atom_id in shell_levels)
+    )
+    cluster.atom_ids = tuple(
+        sorted(set(cluster.solute_atom_ids).union(cluster.shell_atom_ids))
+    )
+    updated_shell_levels = {
+        atom_id: cluster.shell_levels.get(atom_id)
+        for atom_id in cluster.solute_atom_ids
+    }
+    for atom_id in cluster.shell_atom_ids:
+        updated_shell_levels[atom_id] = int(shell_levels[atom_id])
+    cluster.shell_levels = updated_shell_levels
+    stoichiometry_atom_ids = list(cluster.solute_atom_ids)
+    if include_shell_atoms_in_stoichiometry:
+        stoichiometry_atom_ids.extend(cluster.shell_atom_ids)
+    cluster.stoichiometry = dict(
+        Counter(elements[atom_id] for atom_id in stoichiometry_atom_ids)
+    )
 
 
 @dataclass(slots=True)
@@ -877,11 +936,18 @@ class ClusterNetwork:
         self.clusters: list[set[int]] = []
         self.cluster_labels: list[str] = []
         self.atom_virtual_positions: dict[int, np.ndarray] = {}
+        self._persistent_shell_atom_ids_by_cluster_label: dict[
+            str, set[int]
+        ] = {}
 
         for atom in self.atom_id_map.values():
             atom.cluster_id = None
             atom.shell_level = "free" if atom.atom_type == "shell" else None
             atom.shell_history.clear()
+
+    @staticmethod
+    def _solute_atom_ids_for_cluster(cluster: set[int]) -> tuple[int, ...]:
+        return tuple(sorted(atom_id for atom_id in cluster))
 
     def _pair_cutoff(
         self,
@@ -1205,13 +1271,44 @@ class ClusterNetwork:
                 shell_level=self.shell_levels[atom_id],
             )
 
-    def create_cluster(self, start_id: int) -> set[int]:
+    def _cluster_id_for_solute_atoms(
+        self,
+        solute_atom_ids: tuple[int, ...],
+        preferred_cluster_ids_by_solute_key: (
+            Mapping[tuple[int, ...], str] | None
+        ),
+    ) -> str:
+        """Return one preferred or generated cluster identifier."""
+        if preferred_cluster_ids_by_solute_key is not None:
+            preferred = preferred_cluster_ids_by_solute_key.get(
+                solute_atom_ids
+            )
+            if preferred:
+                if preferred in self.cluster_ids:
+                    raise ValueError(
+                        f"Cluster identifier {preferred!r} is already in use."
+                    )
+                self.cluster_ids.add(preferred)
+                return preferred
+        return self.generate_cluster_id()
+
+    def create_cluster(
+        self,
+        start_id: int,
+        *,
+        core_allowed_atom_types: set[str] | None = None,
+    ) -> set[int]:
         """Build a connected solute cluster starting from one seed
         atom."""
         current_cluster: set[int] = set()
         start_index = self.atom_index_map[start_id]
         start_position = self.original_coordinates[start_index]
         self.atom_virtual_positions[start_id] = start_position
+        allowed_atom_types = (
+            {"node", "linker", "shell"}
+            if core_allowed_atom_types is None
+            else set(core_allowed_atom_types)
+        )
 
         search_stack: deque[tuple[int, np.ndarray]] = deque(
             [(start_id, start_position)]
@@ -1229,7 +1326,7 @@ class ClusterNetwork:
                 parent_id=current_id,
                 parent_virtual_pos=current_virt_pos,
                 shell_level=0,
-                allowed_atom_types={"node", "linker", "shell"},
+                allowed_atom_types=allowed_atom_types,
             ):
                 if self.found_status[neighbor_id]:
                     continue
@@ -1241,6 +1338,49 @@ class ClusterNetwork:
                     search_stack.append((neighbor_id, neighbor_virtual_pos))
 
         return current_cluster
+
+    def include_persistent_shells_for_cluster(
+        self,
+        cluster: set[int],
+        cluster_id: str,
+        shell_levels: Mapping[int, int],
+        *,
+        shared_shells: bool = False,
+    ) -> None:
+        """Inject already-owned shell atoms without rechecking
+        cutoffs."""
+        persistent_ids = (
+            self._persistent_shell_atom_ids_by_cluster_label.setdefault(
+                cluster_id,
+                set(),
+            )
+        )
+        for atom_id, shell_level in sorted(shell_levels.items()):
+            atom_id = int(atom_id)
+            if self.base_atom_types.get(atom_id) != "shell":
+                continue
+            if atom_id in cluster:
+                persistent_ids.add(atom_id)
+                if self.shell_levels.get(atom_id) is None:
+                    self.shell_levels[atom_id] = int(shell_level)
+                continue
+            if not shared_shells and self.found_status.get(atom_id, False):
+                continue
+            if not shared_shells:
+                self.found_status[atom_id] = True
+            cluster.add(atom_id)
+            self.atom_types[atom_id] = "shell"
+            self.shell_levels[atom_id] = int(shell_level)
+            atom_index = self.atom_index_map.get(atom_id)
+            if atom_index is not None:
+                self.atom_virtual_positions[atom_id] = (
+                    self.original_coordinates[atom_index].copy()
+                )
+            self.atom_id_map[atom_id].update_cluster_assignment(
+                cluster_id,
+                shell_level=int(shell_level),
+            )
+            persistent_ids.add(atom_id)
 
     def process_shell_level_for_cluster(
         self,
@@ -1294,25 +1434,102 @@ class ClusterNetwork:
         *,
         shell_levels: Sequence[int] = (1, 2),
         shared_shells: bool = False,
+        core_includes_shell_atoms: bool = True,
+        persistent_shells_by_solute_key: (
+            Mapping[
+                tuple[int, ...],
+                Mapping[int, int],
+            ]
+            | None
+        ) = None,
+        preferred_cluster_ids_by_solute_key: (
+            Mapping[
+                tuple[int, ...],
+                str,
+            ]
+            | None
+        ) = None,
     ) -> list[ClusterRecord]:
         """Find cluster networks for the current structure."""
         self._reset_state()
+        core_allowed_atom_types = (
+            {"node", "linker", "shell"}
+            if core_includes_shell_atoms
+            else {"node", "linker"}
+        )
 
         for atom_id, atom_type in self.base_atom_types.items():
             if atom_type == "node" and not self.found_status[atom_id]:
-                cluster = self.create_cluster(atom_id)
-                cluster_id = self.generate_cluster_id()
+                cluster = self.create_cluster(
+                    atom_id,
+                    core_allowed_atom_types=core_allowed_atom_types,
+                )
+                solute_atom_ids = tuple(
+                    sorted(
+                        member_id
+                        for member_id in cluster
+                        if self.base_atom_types.get(member_id)
+                        in {"node", "linker"}
+                    )
+                )
+                cluster_id = self._cluster_id_for_solute_atoms(
+                    solute_atom_ids,
+                    preferred_cluster_ids_by_solute_key,
+                )
                 self.assign_cluster_id_and_shell_level(cluster, cluster_id)
                 self.clusters.append(cluster)
                 self.cluster_labels.append(cluster_id)
 
         for atom_id, atom_type in self.base_atom_types.items():
             if atom_type == "linker" and not self.found_status[atom_id]:
-                cluster = self.create_cluster(atom_id)
-                cluster_id = self.generate_cluster_id()
+                cluster = self.create_cluster(
+                    atom_id,
+                    core_allowed_atom_types=core_allowed_atom_types,
+                )
+                solute_atom_ids = tuple(
+                    sorted(
+                        member_id
+                        for member_id in cluster
+                        if self.base_atom_types.get(member_id)
+                        in {"node", "linker"}
+                    )
+                )
+                cluster_id = self._cluster_id_for_solute_atoms(
+                    solute_atom_ids,
+                    preferred_cluster_ids_by_solute_key,
+                )
                 self.assign_cluster_id_and_shell_level(cluster, cluster_id)
                 self.clusters.append(cluster)
                 self.cluster_labels.append(cluster_id)
+
+        if not core_includes_shell_atoms:
+            for cluster, cluster_id in zip(self.clusters, self.cluster_labels):
+                solute_atom_ids = tuple(
+                    sorted(
+                        member_id
+                        for member_id in cluster
+                        if self.base_atom_types.get(member_id)
+                        in {"node", "linker"}
+                    )
+                )
+                if persistent_shells_by_solute_key is not None:
+                    persistent_shells = persistent_shells_by_solute_key.get(
+                        solute_atom_ids,
+                        {},
+                    )
+                    if persistent_shells:
+                        self.include_persistent_shells_for_cluster(
+                            cluster,
+                            cluster_id,
+                            persistent_shells,
+                            shared_shells=shared_shells,
+                        )
+                self.process_shell_level_for_cluster(
+                    cluster,
+                    cluster_id,
+                    0,
+                    shared_shells=shared_shells,
+                )
 
         for shell_level in shell_levels:
             if shell_level <= 0:
@@ -1497,6 +1714,17 @@ class ClusterNetwork:
                 and atom_id not in node_atom_ids
                 and atom_id not in linker_atom_ids
             )
+            persistent_shell_atom_ids = (
+                self._persistent_shell_atom_ids_by_cluster_label.get(
+                    cluster_id,
+                    set(),
+                )
+            )
+            detected_shell_atom_ids = tuple(
+                atom_id
+                for atom_id in shell_atom_ids
+                if atom_id not in persistent_shell_atom_ids
+            )
             solute_atom_ids = tuple(sorted(node_atom_ids + linker_atom_ids))
             stoichiometry_atom_ids = list(solute_atom_ids)
             if self.include_shell_atoms_in_stoichiometry:
@@ -1520,6 +1748,7 @@ class ClusterNetwork:
                     shell_atom_ids=shell_atom_ids,
                     stoichiometry=stoichiometry,
                     shell_levels=shell_level_map,
+                    detected_shell_atom_ids=detected_shell_atom_ids,
                 )
             )
         return records
@@ -2265,6 +2494,7 @@ class ExtractedFrameFolderClusterAnalyzer:
         box_dimensions: Sequence[float] | None = None,
         default_cutoff: float | None = None,
         use_pbc: bool = False,
+        smart_solvation_shells: bool = True,
         include_shell_atoms_in_stoichiometry: bool = False,
         search_mode: str = SEARCH_MODE_KDTREE,
         save_state_frequency: int = DEFAULT_SAVE_STATE_FREQUENCY,
@@ -2275,6 +2505,7 @@ class ExtractedFrameFolderClusterAnalyzer:
         self.box_dimensions = box_dimensions
         self.default_cutoff = default_cutoff
         self.use_pbc = bool(use_pbc)
+        self.smart_solvation_shells = bool(smart_solvation_shells)
         self.include_shell_atoms_in_stoichiometry = bool(
             include_shell_atoms_in_stoichiometry
         )
@@ -2374,6 +2605,16 @@ class ExtractedFrameFolderClusterAnalyzer:
         """Analyze extracted frames and write per-cluster output
         files."""
         frame_format, frame_paths = self._validated_frame_paths()
+        if frame_format == "pdb" and self.smart_solvation_shells:
+            return self._export_cluster_pdb_files_with_smart_shells(
+                output_dir,
+                frame_paths=frame_paths,
+                shell_levels=shell_levels,
+                include_shell_levels=include_shell_levels,
+                shared_shells=shared_shells,
+                progress_callback=progress_callback,
+                phase_callback=phase_callback,
+            )
         summary = self.inspect()
         output_dir = Path(output_dir)
         output_dir.mkdir(parents=True, exist_ok=True)
@@ -2615,6 +2856,423 @@ class ExtractedFrameFolderClusterAnalyzer:
             newly_processed_frames=newly_processed_frames,
         )
 
+    def _export_cluster_pdb_files_with_smart_shells(
+        self,
+        output_dir: str | Path,
+        *,
+        frame_paths: Sequence[Path],
+        shell_levels: Sequence[int],
+        include_shell_levels: Sequence[int],
+        shared_shells: bool,
+        progress_callback: Callable[[int, int, str], None] | None,
+        phase_callback: Callable[[str, int, int], None] | None,
+    ) -> TrajectoryClusterExport:
+        """Run the PDB-only smart-shell export path."""
+        summary = self.inspect()
+        output_dir = Path(output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        metadata_path = _metadata_file_path(output_dir)
+        total_frames = len(frame_paths)
+
+        metadata = self._load_or_initialize_metadata(
+            metadata_path=metadata_path,
+            output_dir=output_dir,
+            summary=summary,
+            frame_format="pdb",
+            frame_paths=frame_paths,
+            shell_levels=shell_levels,
+            include_shell_levels=include_shell_levels,
+            shared_shells=shared_shells,
+        )
+        frame_entries = {
+            str(entry["frame_name"]): dict(entry)
+            for entry in metadata.get("frames", [])
+        }
+        previously_processed_frames = sum(
+            1
+            for entry in frame_entries.values()
+            if _frame_entry_is_processed(entry)
+        )
+        previously_completed_frames = sum(
+            1
+            for entry in frame_entries.values()
+            if _frame_entry_is_completed(entry)
+        )
+        resumed = previously_processed_frames > 0
+
+        if progress_callback is not None:
+            progress_callback(
+                previously_processed_frames,
+                total_frames,
+                "resume",
+            )
+        if phase_callback is not None:
+            phase_callback(
+                "extracting",
+                previously_processed_frames,
+                total_frames,
+            )
+
+        if previously_completed_frames >= total_frames:
+            metadata["state"] = "completed"
+            metadata["updated_at"] = _utc_timestamp()
+            metadata["last_error"] = None
+            self._refresh_metadata_progress(
+                metadata, frame_entries, total_frames
+            )
+            self._store_metadata(metadata_path, metadata, frame_entries)
+            frame_results = self._frame_results_from_entries(frame_entries)
+            written_files = self._written_files_from_metadata(
+                output_dir,
+                metadata,
+                frame_entries,
+            )
+            self.last_results = frame_results
+            return TrajectoryClusterExport(
+                written_files=written_files,
+                frame_results=frame_results,
+                metadata_path=metadata_path,
+                resumed=resumed,
+                already_complete=True,
+                previously_completed_frames=previously_processed_frames,
+                newly_processed_frames=0,
+            )
+
+        metadata["state"] = "in_progress"
+        metadata["updated_at"] = _utc_timestamp()
+        metadata["completed_at"] = None
+        metadata["last_error"] = None
+        self._refresh_metadata_progress(
+            metadata,
+            frame_entries,
+            total_frames,
+        )
+        self._store_metadata(metadata_path, metadata, frame_entries)
+
+        newly_processed_frames = 0
+        frames_since_checkpoint = 0
+        last_checkpoint_time = monotonic()
+        sorting_completed_frames = previously_completed_frames
+        stoichiometry_dir_cache: dict[str, Path] = {}
+        atom_elements: dict[int, str] = {}
+        active_runs = self._rebuild_smart_shell_run_states(frame_entries)
+
+        def checkpoint_metadata(*, force: bool = False) -> None:
+            nonlocal frames_since_checkpoint, last_checkpoint_time
+            if not force:
+                if (
+                    frames_since_checkpoint < self.save_state_frequency
+                    and (monotonic() - last_checkpoint_time)
+                    < METADATA_CHECKPOINT_SECONDS
+                ):
+                    return
+            metadata["updated_at"] = _utc_timestamp()
+            self._store_metadata(metadata_path, metadata, frame_entries)
+            frames_since_checkpoint = 0
+            last_checkpoint_time = monotonic()
+
+        try:
+            for frame_index, frame_path in enumerate(frame_paths):
+                existing_entry = frame_entries.get(frame_path.name)
+                if existing_entry is not None and _frame_entry_is_processed(
+                    existing_entry
+                ):
+                    continue
+
+                network = self._build_network(frame_path)
+                if not isinstance(network, ClusterNetwork):
+                    raise ValueError(
+                        "Smart Solvation Shell mode requires PDB frames."
+                    )
+                atom_elements.update(network.elements)
+                clusters = network.find_clusters(
+                    shell_levels=shell_levels,
+                    shared_shells=shared_shells,
+                    core_includes_shell_atoms=False,
+                    persistent_shells_by_solute_key={
+                        run.solute_atom_ids: dict(run.shell_levels)
+                        for run in active_runs.values()
+                    },
+                )
+                frame_result = FrameClusterResult(
+                    frame_index=frame_index,
+                    time_fs=None,
+                    clusters=clusters,
+                )
+                frame_entries[frame_path.name] = {
+                    "frame_name": frame_path.name,
+                    "frame_label": frame_path.stem,
+                    "frame_index": frame_index,
+                    "status": FRAME_STATUS_PROCESSED,
+                    "processed_at": _utc_timestamp(),
+                    "completed_at": None,
+                    "temporary_files": [],
+                    "written_files": [],
+                    "result": frame_result.to_dict(),
+                }
+
+                current_runs: dict[tuple[int, ...], _SmartShellRunState] = {}
+                for cluster in frame_result.clusters:
+                    solute_atom_ids = cluster.solute_atom_ids
+                    prior_run = active_runs.get(solute_atom_ids)
+                    if (
+                        prior_run is not None
+                        and prior_run.last_frame_index == frame_index - 1
+                    ):
+                        run = prior_run
+                    else:
+                        run = _SmartShellRunState(
+                            solute_atom_ids=solute_atom_ids,
+                            last_frame_index=frame_index,
+                            frame_refs=[],
+                            shell_levels={},
+                        )
+                    run.last_frame_index = frame_index
+                    run.frame_refs.append(
+                        (frame_path.name, cluster.cluster_id)
+                    )
+                    for atom_id, shell_level in _cluster_shell_level_payload(
+                        cluster
+                    ).items():
+                        if atom_id not in run.shell_levels:
+                            run.shell_levels[atom_id] = shell_level
+                    current_runs[solute_atom_ids] = run
+
+                for run in current_runs.values():
+                    self._apply_smart_shell_union_to_run(
+                        run,
+                        frame_entries,
+                        elements=atom_elements,
+                    )
+
+                active_runs = current_runs
+                newly_processed_frames += 1
+                metadata["last_error"] = None
+                frames_since_checkpoint += 1
+                checkpoint_metadata()
+
+                if progress_callback is not None:
+                    progress_callback(
+                        previously_processed_frames + newly_processed_frames,
+                        total_frames,
+                        frame_path.stem,
+                    )
+
+            metadata["state"] = "sorting"
+            checkpoint_metadata(force=True)
+            if phase_callback is not None:
+                phase_callback(
+                    "sorting",
+                    sorting_completed_frames,
+                    total_frames,
+                )
+
+            for frame_index, frame_path in enumerate(frame_paths):
+                entry = frame_entries.get(frame_path.name)
+                if entry is None or _frame_entry_is_completed(entry):
+                    continue
+
+                frame_label = str(entry.get("frame_label", frame_path.stem))
+                frame_result = FrameClusterResult.from_dict(
+                    dict(entry["result"])
+                )
+                network = self._build_network(frame_path)
+                if not isinstance(network, ClusterNetwork):
+                    raise ValueError(
+                        "Smart Solvation Shell mode requires PDB frames."
+                    )
+                rerun_clusters = network.find_clusters(
+                    shell_levels=shell_levels,
+                    shared_shells=shared_shells,
+                    core_includes_shell_atoms=False,
+                    persistent_shells_by_solute_key={
+                        cluster.solute_atom_ids: {
+                            atom_id: shell_level
+                            for atom_id, shell_level in _cluster_shell_level_payload(
+                                cluster
+                            ).items()
+                            if atom_id
+                            not in set(cluster.detected_shell_atom_ids)
+                        }
+                        for cluster in frame_result.clusters
+                    },
+                    preferred_cluster_ids_by_solute_key={
+                        cluster.solute_atom_ids: cluster.cluster_id
+                        for cluster in frame_result.clusters
+                    },
+                )
+                self._validate_smart_shell_rerun(
+                    expected_clusters=frame_result.clusters,
+                    actual_clusters=rerun_clusters,
+                    frame_name=frame_path.name,
+                )
+                frame_dir = output_dir / frame_label
+                network.write_cluster_pdb_files(
+                    frame_dir,
+                    frame_label=frame_label,
+                    include_shell_levels=include_shell_levels,
+                )
+                moved_files = _move_cluster_files_to_stoichiometry_dirs(
+                    output_dir,
+                    frame_dir,
+                    frame_label,
+                    frame_result.clusters,
+                    suffix=".pdb",
+                    stoichiometry_dir_cache=stoichiometry_dir_cache,
+                )
+                entry.update(
+                    {
+                        "frame_name": frame_path.name,
+                        "frame_label": frame_label,
+                        "frame_index": frame_index,
+                        "status": FRAME_STATUS_COMPLETED,
+                        "processed_at": entry.get("processed_at"),
+                        "completed_at": _utc_timestamp(),
+                        "temporary_files": [],
+                        "written_files": _relative_output_paths(
+                            output_dir,
+                            moved_files,
+                        ),
+                        "result": frame_result.to_dict(),
+                    }
+                )
+                sorting_completed_frames += 1
+                frames_since_checkpoint += 1
+                checkpoint_metadata()
+                if progress_callback is not None:
+                    progress_callback(
+                        sorting_completed_frames,
+                        total_frames,
+                        frame_label,
+                    )
+        except Exception as exc:
+            metadata["state"] = "failed"
+            metadata["updated_at"] = _utc_timestamp()
+            metadata["last_error"] = str(exc)
+            checkpoint_metadata(force=True)
+            raise
+
+        metadata["state"] = "completed"
+        metadata["updated_at"] = _utc_timestamp()
+        metadata["completed_at"] = _utc_timestamp()
+        metadata["last_error"] = None
+        checkpoint_metadata(force=True)
+
+        frame_results = self._frame_results_from_entries(frame_entries)
+        written_files = self._written_files_from_metadata(
+            output_dir,
+            metadata,
+            frame_entries,
+        )
+        self.last_results = frame_results
+        return TrajectoryClusterExport(
+            written_files=written_files,
+            frame_results=frame_results,
+            metadata_path=metadata_path,
+            resumed=resumed,
+            already_complete=False,
+            previously_completed_frames=previously_processed_frames,
+            newly_processed_frames=newly_processed_frames,
+        )
+
+    def _rebuild_smart_shell_run_states(
+        self,
+        frame_entries: Mapping[str, Mapping[str, object]],
+    ) -> dict[tuple[int, ...], _SmartShellRunState]:
+        """Reconstruct the active contiguous smart-shell runs."""
+        active_runs: dict[tuple[int, ...], _SmartShellRunState] = {}
+        for entry in sorted(frame_entries.values(), key=_entry_sort_key):
+            if not _frame_entry_is_processed(entry) or "result" not in entry:
+                continue
+            frame_result = FrameClusterResult.from_dict(dict(entry["result"]))
+            frame_index = int(
+                entry.get("frame_index", frame_result.frame_index)
+            )
+            frame_name = str(entry["frame_name"])
+            current_runs: dict[tuple[int, ...], _SmartShellRunState] = {}
+            for cluster in frame_result.clusters:
+                solute_atom_ids = cluster.solute_atom_ids
+                prior_run = active_runs.get(solute_atom_ids)
+                if (
+                    prior_run is not None
+                    and prior_run.last_frame_index == frame_index - 1
+                ):
+                    run = prior_run
+                else:
+                    run = _SmartShellRunState(
+                        solute_atom_ids=solute_atom_ids,
+                        last_frame_index=frame_index,
+                        frame_refs=[],
+                        shell_levels={},
+                    )
+                run.last_frame_index = frame_index
+                run.frame_refs.append((frame_name, cluster.cluster_id))
+                run.shell_levels = _cluster_shell_level_payload(cluster)
+                current_runs[solute_atom_ids] = run
+            active_runs = current_runs
+        return active_runs
+
+    def _apply_smart_shell_union_to_run(
+        self,
+        run: _SmartShellRunState,
+        frame_entries: dict[str, dict[str, object]],
+        *,
+        elements: Mapping[int, str],
+    ) -> None:
+        """Update all frame results in one contiguous run to the latest
+        solvent union."""
+        for frame_name, cluster_id in run.frame_refs:
+            entry = frame_entries.get(frame_name)
+            if entry is None or "result" not in entry:
+                continue
+            frame_result = FrameClusterResult.from_dict(dict(entry["result"]))
+            for cluster in frame_result.clusters:
+                if cluster.cluster_id != cluster_id:
+                    continue
+                _update_cluster_record_shell_union(
+                    cluster,
+                    run.shell_levels,
+                    elements=elements,
+                    include_shell_atoms_in_stoichiometry=(
+                        self.include_shell_atoms_in_stoichiometry
+                    ),
+                )
+                break
+            entry["result"] = frame_result.to_dict()
+
+    @staticmethod
+    def _validate_smart_shell_rerun(
+        *,
+        expected_clusters: Sequence[ClusterRecord],
+        actual_clusters: Sequence[ClusterRecord],
+        frame_name: str,
+    ) -> None:
+        """Ensure one smart-shell rerun recreated the stored
+        clusters."""
+        expected_by_id = {
+            cluster.cluster_id: cluster for cluster in expected_clusters
+        }
+        actual_by_id = {
+            cluster.cluster_id: cluster for cluster in actual_clusters
+        }
+        if expected_by_id.keys() != actual_by_id.keys():
+            raise ValueError(
+                "Smart Solvation Shell rerun did not reproduce the stored "
+                f"cluster ids for {frame_name}."
+            )
+        for cluster_id, expected in expected_by_id.items():
+            actual = actual_by_id[cluster_id]
+            if expected.solute_atom_ids != actual.solute_atom_ids:
+                raise ValueError(
+                    "Smart Solvation Shell rerun changed the solute cluster "
+                    f"assignment for {frame_name} ({cluster_id})."
+                )
+            if expected.shell_atom_ids != actual.shell_atom_ids:
+                raise ValueError(
+                    "Smart Solvation Shell rerun changed the solvent shell "
+                    f"membership for {frame_name} ({cluster_id})."
+                )
+
     def export_cluster_pdbs(
         self,
         output_dir: str | Path,
@@ -2796,6 +3454,7 @@ class ExtractedFrameFolderClusterAnalyzer:
                 ),
                 "default_cutoff": self.default_cutoff,
                 "use_pbc": self.use_pbc,
+                "smart_solvation_shells": self.smart_solvation_shells,
                 "include_shell_atoms_in_stoichiometry": (
                     self.include_shell_atoms_in_stoichiometry
                 ),

--- a/src/saxshell/cluster/presets.py
+++ b/src/saxshell/cluster/presets.py
@@ -36,6 +36,7 @@ class ClusterExtractionPreset:
     default_cutoff: float | None = None
     shell_growth_levels: tuple[int, ...] = ()
     shared_shells: bool = False
+    smart_solvation_shells: bool = True
     include_shell_atoms_in_stoichiometry: bool = False
     builtin: bool = False
 
@@ -48,6 +49,7 @@ class ClusterExtractionPreset:
                 int(level) for level in self.shell_growth_levels
             ],
             "shared_shells": bool(self.shared_shells),
+            "smart_solvation_shells": bool(self.smart_solvation_shells),
             "include_shell_atoms_in_stoichiometry": bool(
                 self.include_shell_atoms_in_stoichiometry
             ),
@@ -103,6 +105,9 @@ class ClusterExtractionPreset:
                 options_payload.get("shell_growth_levels")
             ),
             shared_shells=bool(options_payload.get("shared_shells", False)),
+            smart_solvation_shells=bool(
+                options_payload.get("smart_solvation_shells", True)
+            ),
             include_shell_atoms_in_stoichiometry=bool(
                 options_payload.get(
                     "include_shell_atoms_in_stoichiometry",

--- a/src/saxshell/cluster/ui/definitions_panel.py
+++ b/src/saxshell/cluster/ui/definitions_panel.py
@@ -227,6 +227,18 @@ class ClusterDefinitionsPanel(QGroupBox):
         )
         options_layout.addRow("Search mode", self.search_mode_combo)
 
+        self.periodic_save_state_checkbox = QCheckBox("Periodic save-state")
+        self.periodic_save_state_checkbox.setChecked(True)
+        self.periodic_save_state_checkbox.setToolTip(
+            "When enabled, metadata checkpoints are written periodically "
+            "during the run. Disable to only save at the end of the run, "
+            "which can significantly speed up extraction on large datasets."
+        )
+        self.periodic_save_state_checkbox.toggled.connect(
+            self._on_periodic_save_state_toggled
+        )
+        options_layout.addRow("", self.periodic_save_state_checkbox)
+
         self.save_state_frequency_spin = QSpinBox()
         self.save_state_frequency_spin.setRange(1, 10**9)
         self.save_state_frequency_spin.setValue(DEFAULT_SAVE_STATE_FREQUENCY)
@@ -931,7 +943,16 @@ class ClusterDefinitionsPanel(QGroupBox):
         if emit_signal:
             self.settings_changed.emit()
 
+    def _on_periodic_save_state_toggled(self, checked: bool) -> None:
+        self.save_state_frequency_spin.setEnabled(checked)
+        self.settings_changed.emit()
+
+    def periodic_save_state_enabled(self) -> bool:
+        return bool(self.periodic_save_state_checkbox.isChecked())
+
     def save_state_frequency(self) -> int:
+        if not self.periodic_save_state_enabled():
+            return 10**9
         return int(self.save_state_frequency_spin.value())
 
     def set_save_state_frequency(

--- a/src/saxshell/cluster/ui/definitions_panel.py
+++ b/src/saxshell/cluster/ui/definitions_panel.py
@@ -301,6 +301,20 @@ class ClusterDefinitionsPanel(QGroupBox):
         )
         options_layout.addRow("", self.shared_shells_box)
 
+        self.smart_solvation_shells_box = QCheckBox(
+            "Use Smart Solvation Shell mode (PDB only)"
+        )
+        self.smart_solvation_shells_box.setChecked(True)
+        self.smart_solvation_shells_box.setToolTip(
+            "Keep the same solvent molecules in contiguous cluster PDBs "
+            "while preserving the legacy per-frame algorithm when turned "
+            "off. This option is only available for PDB frame folders."
+        )
+        self.smart_solvation_shells_box.toggled.connect(
+            lambda _checked: self.settings_changed.emit()
+        )
+        options_layout.addRow("", self.smart_solvation_shells_box)
+
         self.include_shell_stoichiometry_box = QCheckBox(
             "Include shell atoms in stoichiometry bins"
         )
@@ -976,6 +990,21 @@ class ClusterDefinitionsPanel(QGroupBox):
         if emit_signal:
             self.settings_changed.emit()
 
+    def smart_solvation_shells(self) -> bool:
+        return self.smart_solvation_shells_box.isChecked()
+
+    def set_smart_solvation_shells(
+        self,
+        value: bool,
+        *,
+        emit_signal: bool = True,
+    ) -> None:
+        self.smart_solvation_shells_box.blockSignals(True)
+        self.smart_solvation_shells_box.setChecked(bool(value))
+        self.smart_solvation_shells_box.blockSignals(False)
+        if emit_signal:
+            self.settings_changed.emit()
+
     def include_shell_atoms_in_stoichiometry(self) -> bool:
         return self.include_shell_stoichiometry_box.isChecked()
 
@@ -1066,6 +1095,7 @@ class ClusterDefinitionsPanel(QGroupBox):
             default_cutoff=self.default_cutoff(),
             shell_growth_levels=self.shell_growth_levels(),
             shared_shells=self.shared_shells(),
+            smart_solvation_shells=self.smart_solvation_shells(),
             include_shell_atoms_in_stoichiometry=(
                 self.include_shell_atoms_in_stoichiometry()
             ),
@@ -1152,6 +1182,10 @@ class ClusterDefinitionsPanel(QGroupBox):
             emit_signal=False,
         )
         self.set_shared_shells(preset.shared_shells, emit_signal=False)
+        self.set_smart_solvation_shells(
+            preset.smart_solvation_shells,
+            emit_signal=False,
+        )
         self.set_include_shell_atoms_in_stoichiometry(
             preset.include_shell_atoms_in_stoichiometry,
             emit_signal=False,
@@ -1170,6 +1204,7 @@ class ClusterDefinitionsPanel(QGroupBox):
         if frame_format == "xyz":
             self.setTitle("Cluster Definitions (XYZ mode)")
             self.atom_table.setColumnHidden(2, True)
+            self.smart_solvation_shells_box.setEnabled(False)
             self.mode_hint_label.setText(
                 "XYZ mode uses element-only atom matching. Residue names are "
                 "not available, and shell extraction cannot rebuild full "
@@ -1181,6 +1216,7 @@ class ClusterDefinitionsPanel(QGroupBox):
         self.atom_table.setColumnHidden(2, False)
         if frame_format == "pdb":
             self.setTitle("Cluster Definitions (PDB mode)")
+            self.smart_solvation_shells_box.setEnabled(True)
             self.mode_hint_label.setText(
                 "PDB mode can match atom types by element and residue, and "
                 "shell export can keep complete residue molecules together."
@@ -1189,6 +1225,7 @@ class ClusterDefinitionsPanel(QGroupBox):
             return
 
         self.setTitle("Cluster Definitions")
+        self.smart_solvation_shells_box.setEnabled(False)
         self.mode_hint_label.setText(
             "Select an extracted PDB or XYZ frames folder. The UI will adapt "
             "these rules automatically once the frame-set mode is detected."

--- a/src/saxshell/cluster/ui/main_window.py
+++ b/src/saxshell/cluster/ui/main_window.py
@@ -58,6 +58,12 @@ class ClusterSelectionPreview:
     last_frame_name: str | None
 
 
+def _save_state_frequency_label(frequency: int) -> str:
+    if frequency >= 10**8:
+        return "end of run only"
+    return f"every {frequency} frame(s)"
+
+
 @dataclass(slots=True)
 class ClusterJobConfig:
     """Cluster-analysis settings assembled from the UI."""
@@ -265,7 +271,7 @@ class ClusterExportWorker(QObject):
             )
             self.progress.emit(
                 "Save-state frequency: "
-                f"every {self.config.save_state_frequency} frame(s)."
+                f"{_save_state_frequency_label(self.config.save_state_frequency)}."
             )
             self.progress.emit(
                 f"Writing cluster {output_suffix} files under: "
@@ -714,7 +720,7 @@ class ClusterMainWindow(QMainWindow):
                 "Search mode: "
                 f"{format_search_mode_label(config.search_mode)}\n"
                 "Save-state frequency: "
-                f"every {config.save_state_frequency} frames\n"
+                f"{_save_state_frequency_label(config.save_state_frequency)}\n"
                 f"Stoichiometry bins: {stoichiometry_bins_text}\n"
                 f"Output directory: {config.output_dir}"
             )
@@ -1149,8 +1155,8 @@ class ClusterMainWindow(QMainWindow):
                 "Smart solvation shells: "
                 f"{'on' if self._frame_format == 'pdb' and self.definitions_panel.smart_solvation_shells() else 'off'}\n"
                 f"Search mode: {search_mode_label}\n"
-                "Save-state frequency: every "
-                f"{self.definitions_panel.save_state_frequency()} frames\n"
+                "Save-state frequency: "
+                f"{_save_state_frequency_label(self.definitions_panel.save_state_frequency())}\n"
                 f"Stoichiometry bins: {stoichiometry_bins_text}\n"
                 f"{self._box_dimensions_label()}: {estimated_box_text}\n"
                 f"Atom-type rules: {atom_rule_count}\n"
@@ -1237,8 +1243,8 @@ class ClusterMainWindow(QMainWindow):
             "Smart solvation shells: "
             f"{'on' if self._frame_format == 'pdb' and self.definitions_panel.smart_solvation_shells() else 'off'}",
             f"Search mode: {search_mode_label}",
-            "Save-state frequency: every "
-            f"{self.definitions_panel.save_state_frequency()} frames",
+            "Save-state frequency: "
+            f"{_save_state_frequency_label(self.definitions_panel.save_state_frequency())}",
             f"Stoichiometry bins: {stoichiometry_bins_text}",
             f"Frames in folder: {preview.total_frames}",
             f"Frames selected: {preview.selected_frames}",

--- a/src/saxshell/cluster/ui/main_window.py
+++ b/src/saxshell/cluster/ui/main_window.py
@@ -73,6 +73,7 @@ class ClusterJobConfig:
     shell_levels: tuple[int, ...]
     include_shell_levels: tuple[int, ...]
     shared_shells: bool
+    smart_solvation_shells: bool
     include_shell_atoms_in_stoichiometry: bool
     output_dir: Path
 
@@ -207,6 +208,7 @@ class ClusterExportWorker(QObject):
                 box_dimensions=self.config.box_dimensions,
                 default_cutoff=self.config.default_cutoff,
                 use_pbc=self.config.use_pbc,
+                smart_solvation_shells=self.config.smart_solvation_shells,
                 include_shell_atoms_in_stoichiometry=(
                     self.config.include_shell_atoms_in_stoichiometry
                 ),
@@ -248,6 +250,10 @@ class ClusterExportWorker(QObject):
                 self.progress.emit("Running core-only cluster analysis.")
             self.progress.emit(
                 f"Stoichiometry bins: {stoichiometry_bins_text}."
+            )
+            self.progress.emit(
+                "Smart solvation shells: "
+                f"{'on' if self.config.smart_solvation_shells and frame_format == 'pdb' else 'off'}."
             )
             self.progress.emit(
                 "Periodic boundary conditions: "
@@ -703,6 +709,8 @@ class ClusterMainWindow(QMainWindow):
                 f"Frames folder: {config.frames_dir}\n"
                 f"Mode: {mode_text}\n"
                 f"PBC: {'on' if config.use_pbc else 'off'}\n"
+                "Smart solvation shells: "
+                f"{'on' if config.smart_solvation_shells else 'off'}\n"
                 "Search mode: "
                 f"{format_search_mode_label(config.search_mode)}\n"
                 "Save-state frequency: "
@@ -785,6 +793,10 @@ class ClusterMainWindow(QMainWindow):
             shell_levels=self.definitions_panel.shell_growth_levels(),
             include_shell_levels=self.definitions_panel.include_shell_levels(),
             shared_shells=self.definitions_panel.shared_shells(),
+            smart_solvation_shells=(
+                self._frame_format == "pdb"
+                and self.definitions_panel.smart_solvation_shells()
+            ),
             include_shell_atoms_in_stoichiometry=(
                 self.definitions_panel.include_shell_atoms_in_stoichiometry()
             ),
@@ -1134,6 +1146,8 @@ class ClusterMainWindow(QMainWindow):
                 "of extracted frame files.\n"
                 f"Mode: {mode_text}\n"
                 f"PBC: {'on' if self.definitions_panel.use_pbc() else 'off'}\n"
+                "Smart solvation shells: "
+                f"{'on' if self._frame_format == 'pdb' and self.definitions_panel.smart_solvation_shells() else 'off'}\n"
                 f"Search mode: {search_mode_label}\n"
                 "Save-state frequency: every "
                 f"{self.definitions_panel.save_state_frequency()} frames\n"
@@ -1176,6 +1190,8 @@ class ClusterMainWindow(QMainWindow):
             f"{summary_text}\nAtom-type rules: {atom_rule_count}\n"
             f"Pair-cutoff rules: {pair_rule_count}\n"
             f"Shell levels to grow: {self._shell_growth_text()}\n"
+            "Smart solvation shells: "
+            f"{'on' if self._frame_format == 'pdb' and self.definitions_panel.smart_solvation_shells() else 'off'}\n"
             f"Shared shells: {shared_shells_text}"
         )
         if rule_warning is not None:
@@ -1218,6 +1234,8 @@ class ClusterMainWindow(QMainWindow):
             ),
             f"Mode: {mode_text}",
             f"PBC: {'on' if self.definitions_panel.use_pbc() else 'off'}",
+            "Smart solvation shells: "
+            f"{'on' if self._frame_format == 'pdb' and self.definitions_panel.smart_solvation_shells() else 'off'}",
             f"Search mode: {search_mode_label}",
             "Save-state frequency: every "
             f"{self.definitions_panel.save_state_frequency()} frames",

--- a/src/saxshell/cluster/workflow.py
+++ b/src/saxshell/cluster/workflow.py
@@ -114,6 +114,7 @@ class ClusterSelectionResult:
     resolved_box_dimensions: tuple[float, float, float] | None
     using_auto_box: bool
     use_pbc: bool
+    smart_solvation_shells: bool
     include_shell_atoms_in_stoichiometry: bool
     search_mode: str
     save_state_frequency: int
@@ -168,6 +169,7 @@ class ClusterSelectionResult:
             "resolved_box_dimensions": self.resolved_box_dimensions,
             "using_auto_box": self.using_auto_box,
             "use_pbc": self.use_pbc,
+            "smart_solvation_shells": self.smart_solvation_shells,
             "include_shell_atoms_in_stoichiometry": (
                 self.include_shell_atoms_in_stoichiometry
             ),
@@ -229,6 +231,7 @@ class ClusterWorkflow:
         shell_levels: tuple[int, ...] = (),
         include_shell_levels: tuple[int, ...] = (0,),
         shared_shells: bool = False,
+        smart_solvation_shells: bool = True,
         include_shell_atoms_in_stoichiometry: bool = False,
         search_mode: str = SEARCH_MODE_KDTREE,
         save_state_frequency: int = DEFAULT_SAVE_STATE_FREQUENCY,
@@ -242,6 +245,7 @@ class ClusterWorkflow:
         self.shell_levels = shell_levels
         self.include_shell_levels = include_shell_levels
         self.shared_shells = shared_shells
+        self.smart_solvation_shells = bool(smart_solvation_shells)
         self.include_shell_atoms_in_stoichiometry = bool(
             include_shell_atoms_in_stoichiometry
         )
@@ -297,6 +301,10 @@ class ClusterWorkflow:
         """Preview the selected frames, output directory, and box
         settings."""
         summary = self.inspect()
+        smart_solvation_shells = (
+            str(summary.get("frame_format", "")).lower() == "pdb"
+            and self.smart_solvation_shells
+        )
         resolved_use_pbc = self.use_pbc if use_pbc is None else bool(use_pbc)
         resolved_box = self.resolve_box_dimensions(
             box_dimensions=box_dimensions,
@@ -317,6 +325,7 @@ class ClusterWorkflow:
                 and self.box_dimensions is None
             ),
             use_pbc=resolved_use_pbc,
+            smart_solvation_shells=smart_solvation_shells,
             include_shell_atoms_in_stoichiometry=(
                 self.include_shell_atoms_in_stoichiometry
             ),
@@ -333,6 +342,7 @@ class ClusterWorkflow:
         shell_levels: tuple[int, ...] | None = None,
         include_shell_levels: tuple[int, ...] | None = None,
         shared_shells: bool | None = None,
+        smart_solvation_shells: bool | None = None,
     ) -> ClusterExportResult:
         """Analyze the extracted frames and write cluster files."""
         selection = self.preview_selection(
@@ -346,6 +356,11 @@ class ClusterWorkflow:
         analyzer = self._build_analyzer(
             box_dimensions=selection.resolved_box_dimensions,
             use_pbc=(self.use_pbc if use_pbc is None else bool(use_pbc)),
+            smart_solvation_shells=(
+                self.smart_solvation_shells
+                if smart_solvation_shells is None
+                else bool(smart_solvation_shells)
+            ),
         )
         export = analyzer.export_cluster_files(
             selection.output_dir,
@@ -384,6 +399,7 @@ class ClusterWorkflow:
         *,
         box_dimensions: tuple[float, float, float] | None = None,
         use_pbc: bool | None = None,
+        smart_solvation_shells: bool | None = None,
     ) -> ExtractedFrameFolderClusterAnalyzer:
         return ExtractedFrameFolderClusterAnalyzer(
             frames_dir=self.frames_dir,
@@ -392,6 +408,11 @@ class ClusterWorkflow:
             box_dimensions=box_dimensions,
             default_cutoff=self.default_cutoff,
             use_pbc=self.use_pbc if use_pbc is None else bool(use_pbc),
+            smart_solvation_shells=(
+                self.smart_solvation_shells
+                if smart_solvation_shells is None
+                else bool(smart_solvation_shells)
+            ),
             include_shell_atoms_in_stoichiometry=(
                 self.include_shell_atoms_in_stoichiometry
             ),

--- a/src/saxshell/saxs/contrast/__init__.py
+++ b/src/saxshell/saxs/contrast/__init__.py
@@ -30,6 +30,7 @@ from .representatives import (
     analyze_contrast_representatives,
 )
 from .settings import (
+    COMPONENT_BUILD_MODE_BORN_APPROXIMATION,
     COMPONENT_BUILD_MODE_CONTRAST,
     COMPONENT_BUILD_MODE_NO_CONTRAST,
     ContrastModeLaunchContext,
@@ -40,6 +41,7 @@ from .settings import (
 from .workflow import ContrastWorkflowPreview, build_contrast_workflow_preview
 
 __all__ = [
+    "COMPONENT_BUILD_MODE_BORN_APPROXIMATION",
     "COMPONENT_BUILD_MODE_CONTRAST",
     "COMPONENT_BUILD_MODE_NO_CONTRAST",
     "CONTRAST_SOLVENT_METHOD_NEAT",

--- a/src/saxshell/saxs/contrast/settings.py
+++ b/src/saxshell/saxs/contrast/settings.py
@@ -5,9 +5,11 @@ from pathlib import Path
 
 COMPONENT_BUILD_MODE_NO_CONTRAST = "no_contrast"
 COMPONENT_BUILD_MODE_CONTRAST = "contrast"
+COMPONENT_BUILD_MODE_BORN_APPROXIMATION = "born_approximation"
 _COMPONENT_BUILD_MODE_LABELS = {
-    COMPONENT_BUILD_MODE_NO_CONTRAST: "No Contrast Mode",
-    COMPONENT_BUILD_MODE_CONTRAST: "Contrast Mode",
+    COMPONENT_BUILD_MODE_NO_CONTRAST: "No Contrast (Debye)",
+    COMPONENT_BUILD_MODE_CONTRAST: "Contrast (Debye)",
+    COMPONENT_BUILD_MODE_BORN_APPROXIMATION: "Born Approximation (Average)",
 }
 
 
@@ -18,6 +20,14 @@ def normalize_component_build_mode(value: object) -> str:
         "contrast_mode",
     }:
         return COMPONENT_BUILD_MODE_CONTRAST
+    if normalized in {
+        COMPONENT_BUILD_MODE_BORN_APPROXIMATION,
+        "born_approx",
+        "born_approximation_mode",
+        "born_approximation_average",
+        "average",
+    }:
+        return COMPONENT_BUILD_MODE_BORN_APPROXIMATION
     return COMPONENT_BUILD_MODE_NO_CONTRAST
 
 

--- a/src/saxshell/saxs/contrast/ui/main_window.py
+++ b/src/saxshell/saxs/contrast/ui/main_window.py
@@ -208,8 +208,10 @@ class ContrastModeMainWindow(QMainWindow):
         initial_distribution_id: str | None = None,
         initial_distribution_root_dir: Path | None = None,
         initial_contrast_artifact_dir: Path | None = None,
+        preview_mode: bool = True,
     ) -> None:
         super().__init__()
+        self._preview_mode = bool(preview_mode)
         self._launch_context = ContrastModeLaunchContext.from_values(
             project_dir=initial_project_dir,
             clusters_dir=initial_clusters_dir,
@@ -259,7 +261,7 @@ class ContrastModeMainWindow(QMainWindow):
         self.apply_launch_context(self._launch_context)
 
     def _build_ui(self) -> None:
-        self.setWindowTitle("SAXSShell (Contrast Debye Workflow)")
+        self._apply_preview_mode_title()
         self.setWindowIcon(load_saxshell_icon())
         self.resize(1600, 980)
 
@@ -268,12 +270,8 @@ class ContrastModeMainWindow(QMainWindow):
         root_layout.setContentsMargins(10, 10, 10, 10)
         root_layout.setSpacing(10)
 
-        intro = QLabel(
-            "This dedicated workspace hosts the future contrast-enabled Debye "
-            "workflow. The existing no-contrast SAXS component builder remains "
-            "unchanged while the contrast pipeline is developed in separate "
-            "modules and tested here."
-        )
+        intro = QLabel()
+        self.preview_mode_banner = intro
         intro.setWordWrap(True)
         intro.setFrameShape(QFrame.Shape.StyledPanel)
         root_layout.addWidget(intro)
@@ -293,7 +291,46 @@ class ContrastModeMainWindow(QMainWindow):
         self._reload_solvent_presets(selected_name="Water")
         self._sync_density_method_controls()
         self._update_trace_control_state()
-        self.statusBar().showMessage("Contrast-mode workspace ready")
+        self._refresh_preview_mode_banner()
+        self.statusBar().showMessage(
+            "Contrast-mode preview ready"
+            if self._preview_mode
+            else "Contrast-mode workspace ready"
+        )
+
+    def _apply_preview_mode_title(self) -> None:
+        title = "SAXSShell (Contrast Debye Workflow)"
+        if self._preview_mode:
+            title += " (Preview)"
+        self.setWindowTitle(title)
+
+    def _refresh_preview_mode_banner(self) -> None:
+        if self._preview_mode:
+            self.preview_mode_banner.setText(
+                "Preview Mode: this window is for checking representative "
+                "selection, density settings, and contrast Debye traces before "
+                "building model components. To save component outputs under a "
+                "computed distribution, launch it from Build SAXS Components."
+            )
+            self.preview_mode_banner.setToolTip(
+                "Preview mode does not directly save model components to the "
+                "active computed distribution."
+            )
+        else:
+            self.preview_mode_banner.setText(
+                "Computed Distribution Mode: this window is linked to the "
+                "active computed distribution and can save component artifacts "
+                "back into that distribution."
+            )
+            self.preview_mode_banner.setToolTip(
+                "This workflow was launched from Build SAXS Components and is "
+                "working inside the active computed distribution."
+            )
+
+    def set_preview_mode(self, preview_mode: bool) -> None:
+        self._preview_mode = bool(preview_mode)
+        self._apply_preview_mode_title()
+        self._refresh_preview_mode_banner()
 
     def _build_left_pane(self) -> QScrollArea:
         content = QWidget()
@@ -4502,6 +4539,7 @@ def launch_contrast_mode_ui(
     initial_distribution_id: str | None = None,
     initial_distribution_root_dir: str | Path | None = None,
     initial_contrast_artifact_dir: str | Path | None = None,
+    preview_mode: bool = True,
 ) -> ContrastModeMainWindow:
     app = QApplication.instance()
     if app is None:
@@ -4538,6 +4576,7 @@ def launch_contrast_mode_ui(
             if initial_contrast_artifact_dir is None
             else Path(initial_contrast_artifact_dir).expanduser().resolve()
         ),
+        preview_mode=preview_mode,
     )
     window.show()
     window.raise_()

--- a/src/saxshell/saxs/debye_waller/__init__.py
+++ b/src/saxshell/saxs/debye_waller/__init__.py
@@ -1,0 +1,35 @@
+"""Debye-Waller analysis supporting application."""
+
+from .workflow import (
+    DebyeWallerAggregatedPairSummary,
+    DebyeWallerAnalysisResult,
+    DebyeWallerInputInspection,
+    DebyeWallerOutputArtifacts,
+    DebyeWallerStoichiometryInfoSummary,
+    DebyeWallerWorkflow,
+    build_debye_waller_aggregated_pair_summaries,
+    find_saved_project_debye_waller_analysis,
+    inspect_debye_waller_input,
+    load_debye_waller_analysis_result,
+    project_debye_waller_dir,
+    project_saved_debye_waller_dir,
+    save_debye_waller_analysis_to_project,
+    suggest_output_dir,
+)
+
+__all__ = [
+    "DebyeWallerAggregatedPairSummary",
+    "DebyeWallerAnalysisResult",
+    "DebyeWallerInputInspection",
+    "DebyeWallerOutputArtifacts",
+    "DebyeWallerStoichiometryInfoSummary",
+    "DebyeWallerWorkflow",
+    "build_debye_waller_aggregated_pair_summaries",
+    "find_saved_project_debye_waller_analysis",
+    "inspect_debye_waller_input",
+    "load_debye_waller_analysis_result",
+    "project_debye_waller_dir",
+    "project_saved_debye_waller_dir",
+    "save_debye_waller_analysis_to_project",
+    "suggest_output_dir",
+]

--- a/src/saxshell/saxs/debye_waller/ui/__init__.py
+++ b/src/saxshell/saxs/debye_waller/ui/__init__.py
@@ -1,0 +1,11 @@
+"""Qt UI for Debye-Waller analysis."""
+
+from .main_window import (
+    DebyeWallerAnalysisMainWindow,
+    launch_debye_waller_analysis_ui,
+)
+
+__all__ = [
+    "DebyeWallerAnalysisMainWindow",
+    "launch_debye_waller_analysis_ui",
+]

--- a/src/saxshell/saxs/debye_waller/ui/main_window.py
+++ b/src/saxshell/saxs/debye_waller/ui/main_window.py
@@ -1,0 +1,1470 @@
+from __future__ import annotations
+
+import sys
+from inspect import Parameter, signature
+from pathlib import Path
+from typing import Callable
+
+from PySide6.QtCore import QObject, Qt, QThread, Signal, Slot
+from PySide6.QtWidgets import (
+    QApplication,
+    QFileDialog,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QHeaderView,
+    QLabel,
+    QLineEdit,
+    QMainWindow,
+    QMessageBox,
+    QPlainTextEdit,
+    QProgressBar,
+    QPushButton,
+    QSplitter,
+    QTableWidget,
+    QTableWidgetItem,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
+
+from saxshell.saxs.debye_waller.workflow import (
+    DebyeWallerAggregatedPairSummary,
+    DebyeWallerAnalysisResult,
+    DebyeWallerInputInspection,
+    DebyeWallerStoichiometryInfoSummary,
+    DebyeWallerStoichiometryResult,
+    DebyeWallerWorkflow,
+    build_debye_waller_aggregated_pair_summaries,
+    find_saved_project_debye_waller_analysis,
+    inspect_debye_waller_input,
+    load_debye_waller_analysis_result,
+    save_debye_waller_analysis_to_project,
+    suggest_output_dir,
+)
+from saxshell.saxs.project_manager import (
+    ProjectSettings,
+    SAXSProjectManager,
+    build_project_paths,
+)
+from saxshell.saxs.ui.branding import (
+    configure_saxshell_application,
+    load_saxshell_icon,
+    prepare_saxshell_application_identity,
+)
+from saxshell.saxs.ui.project_status_label import CompactProjectStatusLabel
+
+_OPEN_WINDOWS: list["DebyeWallerAnalysisMainWindow"] = []
+DEBYE_WALLER_WINDOW_LOAD_TOTAL_STEPS = 6
+DebyeWallerStartupProgressCallback = Callable[[int, int, str], None]
+
+
+class DebyeWallerWorker(QObject):
+    log = Signal(str)
+    progress = Signal(int, int)
+    status = Signal(str)
+    stoichiometry_ready = Signal(object)
+    finished = Signal(object)
+    failed = Signal(str)
+
+    def __init__(self, workflow: DebyeWallerWorkflow) -> None:
+        super().__init__()
+        self.workflow = workflow
+
+    @Slot()
+    def run(self) -> None:
+        try:
+            result = self.workflow.run(
+                progress_callback=self._emit_progress,
+                log_callback=self.log.emit,
+                stoichiometry_callback=self.stoichiometry_ready.emit,
+            )
+            self.finished.emit(result)
+        except Exception as exc:
+            self.failed.emit(str(exc))
+
+    def _emit_progress(
+        self,
+        processed: int,
+        total: int,
+        message: str,
+    ) -> None:
+        self.progress.emit(processed, total)
+        self.status.emit(message)
+
+
+def _scope_display_name(scope: str) -> str:
+    if scope == "intra_molecular":
+        return "Intra-molecular"
+    if scope == "inter_molecular":
+        return "Inter-molecular"
+    return str(scope)
+
+
+class DebyeWallerAnalysisMainWindow(QMainWindow):
+    """Standalone UI for trajectory-based Debye-Waller estimation."""
+
+    project_paths_registered = Signal(object)
+    project_analysis_saved = Signal(object)
+
+    def __init__(
+        self,
+        *,
+        initial_project_dir: str | Path | None = None,
+        initial_clusters_dir: str | Path | None = None,
+        initial_output_dir: str | Path | None = None,
+        startup_progress_callback: (
+            DebyeWallerStartupProgressCallback | None
+        ) = None,
+        startup_log_callback: Callable[[str], None] | None = None,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._project_manager = SAXSProjectManager()
+        self._project_dir = (
+            None
+            if initial_project_dir is None
+            else Path(initial_project_dir).expanduser().resolve()
+        )
+        self._project_settings_cache: ProjectSettings | None = None
+        self._project_settings_loaded = False
+        self._run_thread: QThread | None = None
+        self._run_worker: DebyeWallerWorker | None = None
+        self._last_result: DebyeWallerAnalysisResult | None = None
+        self._project_had_saved_analysis_before_run = False
+        self._partial_stoichiometry_results: list[
+            DebyeWallerStoichiometryResult
+        ] = []
+        self._build_ui()
+        self._initialize_startup_state(
+            initial_clusters_dir=initial_clusters_dir,
+            initial_output_dir=initial_output_dir,
+            startup_progress_callback=startup_progress_callback,
+            startup_log_callback=startup_log_callback,
+        )
+
+    def closeEvent(self, event) -> None:
+        if self._run_thread is not None and self._run_thread.isRunning():
+            QMessageBox.warning(
+                self,
+                "Debye-Waller Analysis",
+                "Please wait for the active Debye-Waller run to finish "
+                "before closing this window.",
+            )
+            event.ignore()
+            return
+        super().closeEvent(event)
+
+    def _build_ui(self) -> None:
+        self.setWindowTitle("SAXSShell (Debye-Waller Analysis)")
+        self.setWindowIcon(load_saxshell_icon())
+        self.resize(1380, 880)
+
+        central = QWidget()
+        root = QVBoxLayout(central)
+        root.setContentsMargins(8, 8, 8, 8)
+        root.setSpacing(8)
+
+        splitter = QSplitter(Qt.Orientation.Horizontal)
+        splitter.addWidget(self._build_left_panel())
+        splitter.addWidget(self._build_right_panel())
+        splitter.setSizes([470, 910])
+
+        root.addWidget(splitter)
+        self.setCentralWidget(central)
+
+        self.project_status_label = self._build_project_status_label()
+        if self.project_status_label is not None:
+            self.statusBar().addPermanentWidget(self.project_status_label)
+        self.statusBar().showMessage("Ready")
+
+    def _initialize_startup_state(
+        self,
+        *,
+        initial_clusters_dir: str | Path | None,
+        initial_output_dir: str | Path | None,
+        startup_progress_callback: DebyeWallerStartupProgressCallback | None,
+        startup_log_callback: Callable[[str], None] | None,
+    ) -> None:
+        resolved_initial_clusters_dir = (
+            None
+            if initial_clusters_dir is None
+            else Path(initial_clusters_dir).expanduser().resolve()
+        )
+        resolved_initial_output_dir = (
+            None
+            if initial_output_dir is None
+            else Path(initial_output_dir).expanduser().resolve()
+        )
+        processed_steps = 0
+
+        def advance(
+            message: str,
+            *,
+            log_message: str | None = None,
+        ) -> None:
+            nonlocal processed_steps
+            processed_steps += 1
+            if startup_progress_callback is not None:
+                startup_progress_callback(
+                    processed_steps,
+                    DEBYE_WALLER_WINDOW_LOAD_TOTAL_STEPS,
+                    message,
+                )
+            if (
+                startup_log_callback is not None
+                and log_message is not None
+                and log_message.strip()
+            ):
+                startup_log_callback(log_message.strip())
+
+        advance(
+            "Preparing Debye-Waller analysis window...",
+            log_message="Preparing Debye-Waller analysis window.",
+        )
+        if (
+            self._project_dir is not None
+            and resolved_initial_clusters_dir is None
+        ):
+            advance(
+                "Loading active project settings...",
+                log_message=(
+                    "Loading active project settings from "
+                    f"{self._project_dir}."
+                ),
+            )
+            self._load_project_settings()
+        else:
+            advance(
+                "Resolving Debye-Waller launch settings...",
+                log_message=(
+                    "Resolving Debye-Waller launch settings from the main UI."
+                    if self._project_dir is not None
+                    else "Resolving standalone Debye-Waller launch settings."
+                ),
+            )
+        advance(
+            "Configuring startup folders...",
+            log_message="Configuring Debye-Waller startup folders.",
+        )
+        if resolved_initial_clusters_dir is not None:
+            self.set_clusters_dir(
+                resolved_initial_clusters_dir,
+                register_project=False,
+                refresh_summary=False,
+            )
+        else:
+            self._adopt_project_clusters_reference()
+            self._apply_default_output_dir()
+        if resolved_initial_output_dir is not None:
+            self.set_output_dir(resolved_initial_output_dir)
+
+        advance(
+            "Checking for saved project analysis...",
+            log_message="Checking the active project for saved Debye-Waller results.",
+        )
+        restored_saved_result = False
+        summary_path = (
+            None
+            if self._project_dir is None
+            else find_saved_project_debye_waller_analysis(self._project_dir)
+        )
+        if summary_path is not None and summary_path.is_file():
+            advance(
+                "Loading saved project analysis...",
+                log_message=(
+                    "Loading any saved Debye-Waller analysis linked to the "
+                    "active project."
+                ),
+            )
+            restored_saved_result = (
+                self._restore_saved_project_analysis_if_available(
+                    register_project=False,
+                    summary_path=summary_path,
+                )
+            )
+        else:
+            advance(
+                "Inspecting selected clusters folder...",
+                log_message="Inspecting the selected Debye-Waller clusters folder.",
+            )
+        if not restored_saved_result:
+            self._refresh_summary()
+
+        advance(
+            "Finalizing Debye-Waller window...",
+            log_message="Debye-Waller analysis window is ready.",
+        )
+        self._refresh_project_save_controls()
+        self._refresh_project_status_label()
+
+    def _build_left_panel(self) -> QWidget:
+        left = QWidget()
+        layout = QVBoxLayout(left)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(10)
+
+        header_group = QGroupBox("Debye-Waller Analysis (beta)")
+        header_layout = QVBoxLayout(header_group)
+        header_notice = QLabel(
+            "Estimate contiguous-segment intra- and inter-molecular "
+            "thermal-displacement coefficients from sorted PDB cluster files "
+            "using PDB-based molecule grouping."
+        )
+        header_notice.setWordWrap(True)
+        header_layout.addWidget(header_notice)
+        layout.addWidget(header_group)
+
+        layout.addWidget(self._build_paths_group())
+        layout.addWidget(self._build_run_group())
+        layout.addStretch(1)
+        return left
+
+    def _build_right_panel(self) -> QWidget:
+        right = QWidget()
+        layout = QVBoxLayout(right)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(10)
+
+        summary_group = QGroupBox("Selection Summary")
+        summary_layout = QVBoxLayout(summary_group)
+        self.summary_box = QPlainTextEdit()
+        self.summary_box.setReadOnly(True)
+        self.summary_box.setMinimumHeight(180)
+        summary_layout.addWidget(self.summary_box)
+        layout.addWidget(summary_group)
+
+        self.results_tabs = QTabWidget()
+        self.stoichiometry_info_table = self._build_table(
+            (
+                "Stoichiometry",
+                "Frames",
+                "Frame Sets",
+                "Avg Frames/Set",
+                "Atoms/Frame Avg",
+                "Mols/Frame Avg",
+                "Solvent-like/Frame Avg",
+                "Shared Sites/Set Avg",
+                "Residue Names",
+                "Elements",
+                "Solvent-like Mol",
+                "Most Common Mol",
+            )
+        )
+        self.aggregated_pair_table = self._build_table(
+            (
+                "Scope",
+                "Type Def.",
+                "Pair",
+                "Stoichs",
+                "Segments",
+                "Mean Sigma (A)",
+                "Std Sigma (A)",
+                "Mean B (A^2)",
+                "Std B (A^2)",
+                "Mean Pair Count",
+            )
+        )
+        self.pair_summary_table = self._build_table(
+            (
+                "Stoichiometry",
+                "Scope",
+                "Type Def.",
+                "Pair",
+                "Segments",
+                "Mean Sigma (A)",
+                "Std Sigma (A)",
+                "Mean B (A^2)",
+                "Std B (A^2)",
+                "Mean Pair Count",
+            )
+        )
+        self.scope_summary_table = self._build_table(
+            (
+                "Stoichiometry",
+                "Scope",
+                "Rows",
+                "Mean Sigma (A)",
+                "Std Sigma (A)",
+                "Mean B (A^2)",
+                "Std B (A^2)",
+                "Mean Pair Count",
+            )
+        )
+        self.segment_table = self._build_table(
+            (
+                "Stoichiometry",
+                "Segment",
+                "Frames",
+                "Scope",
+                "Type Def.",
+                "Pair",
+                "Sigma (A)",
+                "B (A^2)",
+                "Pair Count",
+            )
+        )
+        self.log_box = QPlainTextEdit()
+        self.log_box.setReadOnly(True)
+        self.results_tabs.addTab(
+            self.stoichiometry_info_table, "Stoichiometries"
+        )
+        self.results_tabs.addTab(
+            self.aggregated_pair_table, "Aggregated Pairs"
+        )
+        self.results_tabs.addTab(self.pair_summary_table, "Pair Types")
+        self.results_tabs.addTab(self.scope_summary_table, "Scopes")
+        self.results_tabs.addTab(self.segment_table, "Segments")
+        self.results_tabs.addTab(self.log_box, "Log")
+        layout.addWidget(self.results_tabs)
+
+        return right
+
+    def _build_paths_group(self) -> QGroupBox:
+        group = QGroupBox("Paths")
+        layout = QFormLayout(group)
+
+        self.clusters_dir_edit = QLineEdit()
+        self.clusters_dir_edit.editingFinished.connect(
+            self._on_clusters_dir_edited
+        )
+        browse_clusters_button = QPushButton("Browse...")
+        browse_clusters_button.clicked.connect(self._browse_clusters_dir)
+        clusters_row = QHBoxLayout()
+        clusters_row.addWidget(self.clusters_dir_edit, 1)
+        clusters_row.addWidget(browse_clusters_button)
+        layout.addRow("Sorted clusters folder", self._wrap_row(clusters_row))
+
+        self.output_dir_edit = QLineEdit()
+        browse_output_button = QPushButton("Browse...")
+        browse_output_button.clicked.connect(self._browse_output_dir)
+        output_row = QHBoxLayout()
+        output_row.addWidget(self.output_dir_edit, 1)
+        output_row.addWidget(browse_output_button)
+        layout.addRow("Output folder", self._wrap_row(output_row))
+
+        self.output_basename_edit = QLineEdit("debye_waller_analysis")
+        layout.addRow("Output basename", self.output_basename_edit)
+
+        self.paths_hint_label = QLabel(
+            "PDB-only input. XYZ cluster files are rejected so the tool can "
+            "use PDB residue/sequence/segment metadata for intra/inter "
+            "molecule classification."
+        )
+        self.paths_hint_label.setWordWrap(True)
+        layout.addRow("", self.paths_hint_label)
+        return group
+
+    def _build_run_group(self) -> QGroupBox:
+        group = QGroupBox("Run")
+        layout = QVBoxLayout(group)
+
+        self.progress_label = QLabel("Progress: idle")
+        self.progress_bar = QProgressBar()
+        self.progress_bar.setRange(0, 1)
+        self.progress_bar.setValue(0)
+        self.run_button = QPushButton("Run Debye-Waller Analysis")
+        self.run_button.clicked.connect(self.run_analysis)
+        self.save_project_button = QPushButton(
+            "Save Current Analysis to Project"
+        )
+        self.save_project_button.clicked.connect(
+            self._save_current_analysis_to_project
+        )
+        self.save_project_button.setEnabled(False)
+
+        layout.addWidget(self.progress_label)
+        layout.addWidget(self.progress_bar)
+        layout.addWidget(self.run_button)
+        layout.addWidget(self.save_project_button)
+        return group
+
+    def _build_table(self, headers: tuple[str, ...]) -> QTableWidget:
+        table = QTableWidget(0, len(headers))
+        table.setHorizontalHeaderLabels(list(headers))
+        table.setSortingEnabled(False)
+        header = table.horizontalHeader()
+        if header is not None:
+            header.setSectionResizeMode(
+                QHeaderView.ResizeMode.ResizeToContents
+            )
+            header.setStretchLastSection(True)
+        return table
+
+    def _wrap_row(self, layout: QHBoxLayout) -> QWidget:
+        widget = QWidget()
+        widget.setLayout(layout)
+        return widget
+
+    def _load_project_settings(
+        self,
+        *,
+        force_reload: bool = False,
+    ) -> ProjectSettings | None:
+        if self._project_dir is None:
+            return None
+        if self._project_settings_loaded and not force_reload:
+            return self._project_settings_cache
+        project_file = build_project_paths(self._project_dir).project_file
+        if not project_file.is_file():
+            self._project_settings_cache = None
+            self._project_settings_loaded = True
+            return None
+        try:
+            self._project_settings_cache = self._project_manager.load_project(
+                self._project_dir
+            )
+        except Exception:
+            self._project_settings_cache = None
+            self._project_settings_loaded = False
+            return None
+        self._project_settings_loaded = True
+        return self._project_settings_cache
+
+    def _refresh_project_status_label(self) -> None:
+        if self.project_status_label is None:
+            return
+        status_text = self._project_status_text()
+        if status_text is not None:
+            self.project_status_label.set_full_text(status_text)
+        self.project_status_label.setToolTip(
+            self._project_status_tooltip() or ""
+        )
+
+    def _project_status_text(self) -> str | None:
+        if self._project_dir is None:
+            return None
+        return f"Active project: {self._project_dir}"
+
+    def _project_status_tooltip(self) -> str | None:
+        if self._project_dir is None:
+            return None
+        project_name = (
+            self._project_dir.name
+            if self._project_settings_cache is None
+            else self._project_settings_cache.project_name.strip()
+            or self._project_dir.name
+        )
+        return (
+            f"Active project: {project_name}\n"
+            f"{self._project_dir}\n\n"
+            "This window inherits the active clusters folder when launched "
+            "from the main SAXS UI."
+        )
+
+    def _build_project_status_label(
+        self,
+    ) -> CompactProjectStatusLabel | None:
+        status_text = self._project_status_text()
+        if status_text is None:
+            return None
+        label = CompactProjectStatusLabel(self.statusBar())
+        label.setToolTip(self._project_status_tooltip() or "")
+        label.set_full_text(status_text)
+        return label
+
+    def _clusters_dir_path(self) -> Path | None:
+        text = self.clusters_dir_edit.text().strip()
+        if not text:
+            return None
+        return Path(text).expanduser().resolve()
+
+    def _project_clusters_dir(self) -> Path | None:
+        settings = self._load_project_settings()
+        if settings is None:
+            return None
+        return settings.resolved_clusters_dir
+
+    def _output_dir_path(self) -> Path | None:
+        text = self.output_dir_edit.text().strip()
+        if not text:
+            return None
+        return Path(text).expanduser().resolve()
+
+    def _output_basename(self) -> str:
+        text = self.output_basename_edit.text().strip()
+        return text or "debye_waller_analysis"
+
+    def _set_clusters_dir_text(self, path: str | Path | None) -> None:
+        self.clusters_dir_edit.setText(
+            "" if path is None else str(Path(path).expanduser().resolve())
+        )
+
+    def _set_output_dir_text(self, path: str | Path | None) -> None:
+        self.output_dir_edit.setText(
+            "" if path is None else str(Path(path).expanduser().resolve())
+        )
+
+    @staticmethod
+    def _normalized_registered_path_value(
+        value: str | Path | None,
+    ) -> str | None:
+        if value is None:
+            return None
+        text = str(value).strip()
+        if not text:
+            return None
+        return str(Path(text).expanduser().resolve())
+
+    def _save_project_without_registered_path_refresh(
+        self,
+        settings: ProjectSettings,
+    ) -> None:
+        save_project = self._project_manager.save_project
+        try:
+            save_signature = signature(save_project)
+        except (TypeError, ValueError):
+            save_signature = None
+        if save_signature is not None:
+            supports_refresh_flag = (
+                "refresh_registered_paths" in save_signature.parameters
+                or any(
+                    parameter.kind == Parameter.VAR_KEYWORD
+                    for parameter in save_signature.parameters.values()
+                )
+            )
+            if not supports_refresh_flag:
+                save_project(settings)
+                return
+        save_project(
+            settings,
+            refresh_registered_paths=False,
+        )
+
+    def set_clusters_dir(
+        self,
+        path: str | Path | None,
+        *,
+        register_project: bool = True,
+        refresh_summary: bool = True,
+    ) -> None:
+        self._set_clusters_dir_text(path)
+        self._apply_default_output_dir()
+        if register_project:
+            self._register_project_clusters_dir()
+        if refresh_summary:
+            self._refresh_summary()
+
+    def set_output_dir(self, path: str | Path | None) -> None:
+        self._set_output_dir_text(path)
+
+    def _adopt_project_clusters_reference(self) -> None:
+        if self.clusters_dir_edit.text().strip():
+            return
+        clusters_dir = self._project_clusters_dir()
+        if clusters_dir is None:
+            return
+        self._set_clusters_dir_text(clusters_dir)
+
+    def _apply_default_output_dir(self) -> None:
+        if self.output_dir_edit.text().strip():
+            return
+        clusters_dir = self._clusters_dir_path()
+        if clusters_dir is None:
+            if self._project_dir is None:
+                return
+            suggested = suggest_output_dir(
+                self._project_dir, project_dir=self._project_dir
+            )
+        else:
+            suggested = suggest_output_dir(
+                clusters_dir,
+                project_dir=self._project_dir,
+            )
+        self.output_dir_edit.setText(str(suggested))
+
+    def _browse_clusters_dir(self) -> None:
+        start_dir = self.clusters_dir_edit.text().strip() or (
+            "" if self._project_dir is None else str(self._project_dir)
+        )
+        chosen_dir = QFileDialog.getExistingDirectory(
+            self,
+            "Select Sorted Clusters Folder",
+            start_dir,
+        )
+        if chosen_dir:
+            self.set_clusters_dir(chosen_dir)
+
+    def _browse_output_dir(self) -> None:
+        start_dir = self.output_dir_edit.text().strip() or (
+            "" if self._project_dir is None else str(self._project_dir)
+        )
+        chosen_dir = QFileDialog.getExistingDirectory(
+            self,
+            "Select Debye-Waller Output Folder",
+            start_dir,
+        )
+        if chosen_dir:
+            self.set_output_dir(chosen_dir)
+
+    def _on_clusters_dir_edited(self) -> None:
+        self._apply_default_output_dir()
+        self._register_project_clusters_dir()
+        self._refresh_summary()
+
+    def _register_project_clusters_dir(self) -> None:
+        settings = self._load_project_settings()
+        clusters_dir = self._clusters_dir_path()
+        changed = False
+        if settings is not None:
+            try:
+                resolved_clusters_dir = (
+                    None
+                    if clusters_dir is None
+                    else str(clusters_dir.expanduser().resolve())
+                )
+                previous_clusters_dir = self._normalized_registered_path_value(
+                    settings.clusters_dir
+                )
+                if previous_clusters_dir != resolved_clusters_dir:
+                    changed = True
+                    settings.clusters_dir = resolved_clusters_dir
+                    settings.clusters_dir_snapshot = None
+                    self._save_project_without_registered_path_refresh(
+                        settings
+                    )
+                self._project_settings_cache = settings
+                self._project_settings_loaded = True
+            except Exception:
+                pass
+        if self._project_dir is not None and changed:
+            self.project_paths_registered.emit(
+                {
+                    "project_dir": str(self._project_dir),
+                    "clusters_dir": (
+                        None
+                        if clusters_dir is None
+                        else str(clusters_dir.expanduser().resolve())
+                    ),
+                }
+            )
+
+    def _refresh_project_save_controls(self) -> None:
+        self.save_project_button.setEnabled(
+            self._project_dir is not None and self._last_result is not None
+        )
+
+    def _emit_project_analysis_saved(
+        self,
+        result: DebyeWallerAnalysisResult,
+    ) -> None:
+        if self._project_dir is None or result.artifacts is None:
+            return
+        self.project_analysis_saved.emit(
+            {
+                "project_dir": str(self._project_dir),
+                "clusters_dir": str(result.clusters_dir),
+                "summary_path": str(result.artifacts.summary_json_path),
+            }
+        )
+
+    def _populate_result_tables(
+        self,
+        result: DebyeWallerAnalysisResult,
+    ) -> None:
+        self._populate_aggregated_pair_table(result.aggregated_pair_summaries)
+        self._populate_stoichiometry_info_table_from_stoichiometries(
+            result.stoichiometry_results
+        )
+        self._populate_pair_summary_table_from_stoichiometries(
+            result.stoichiometry_results
+        )
+        self._populate_scope_summary_table_from_stoichiometries(
+            result.stoichiometry_results
+        )
+        self._populate_segment_table_from_stoichiometries(
+            result.stoichiometry_results
+        )
+
+    def _restore_saved_project_analysis_if_available(
+        self,
+        *,
+        register_project: bool = True,
+        summary_path: Path | None = None,
+    ) -> bool:
+        if self._project_dir is None:
+            return False
+        if summary_path is None:
+            summary_path = find_saved_project_debye_waller_analysis(
+                self._project_dir
+            )
+        if summary_path is None or not summary_path.is_file():
+            return False
+        try:
+            result = load_debye_waller_analysis_result(summary_path)
+        except Exception:
+            return False
+
+        self._last_result = result
+        self._partial_stoichiometry_results = list(
+            result.stoichiometry_results
+        )
+        self.set_clusters_dir(
+            result.clusters_dir,
+            register_project=register_project,
+            refresh_summary=False,
+        )
+        self.set_output_dir(result.output_dir)
+        if result.artifacts is not None:
+            self.output_basename_edit.setText(
+                result.artifacts.summary_json_path.stem
+            )
+        self._populate_result_tables(result)
+        self.summary_box.setPlainText(self._describe_result(result))
+        self.log_box.setPlainText(
+            "\n".join(
+                [
+                    "Loaded saved Debye-Waller analysis from the active project.",
+                    f"Summary JSON: {summary_path}",
+                ]
+            )
+        )
+        self.progress_bar.setRange(0, 1)
+        self.progress_bar.setValue(1)
+        self.progress_label.setText("Progress: loaded saved project analysis")
+        self.statusBar().showMessage(
+            "Loaded saved Debye-Waller analysis from project"
+        )
+        self._refresh_project_save_controls()
+        return True
+
+    @Slot()
+    def _save_current_analysis_to_project(self) -> None:
+        if self._project_dir is None or self._last_result is None:
+            return
+        saved_result = save_debye_waller_analysis_to_project(
+            self._last_result,
+            self._project_dir,
+        )
+        self._last_result = saved_result
+        self._partial_stoichiometry_results = list(
+            saved_result.stoichiometry_results
+        )
+        self.set_output_dir(saved_result.output_dir)
+        if saved_result.artifacts is not None:
+            self.output_basename_edit.setText(
+                saved_result.artifacts.summary_json_path.stem
+            )
+            self._append_log(
+                "Saved the current Debye-Waller analysis to the active project."
+            )
+            self._append_log(
+                f"Project summary JSON: {saved_result.artifacts.summary_json_path}"
+            )
+        self.summary_box.setPlainText(self._describe_result(saved_result))
+        self.statusBar().showMessage(
+            "Saved Debye-Waller analysis to active project"
+        )
+        self._project_had_saved_analysis_before_run = True
+        self._emit_project_analysis_saved(saved_result)
+        self._refresh_project_save_controls()
+
+    def _describe_inspection(
+        self,
+        inspection: DebyeWallerInputInspection | None,
+    ) -> str:
+        lines = [
+            "Debye-Waller Analysis",
+            "",
+            "This tool expects sorted cluster frames in PDB format and uses "
+            "PDB residue/sequence/segment grouping to separate intra- and "
+            "inter-molecular pair statistics.",
+        ]
+        if self._project_dir is not None:
+            lines.extend(
+                [
+                    "",
+                    f"Active project: {self._project_dir}",
+                ]
+            )
+            project_clusters_dir = self._project_clusters_dir()
+            if (
+                project_clusters_dir is not None
+                and self.clusters_dir_edit.text().strip()
+                and project_clusters_dir == self._clusters_dir_path()
+            ):
+                lines.append(
+                    "Using the clusters folder reference inherited from the "
+                    "active project."
+                )
+        clusters_dir = self._clusters_dir_path()
+        if clusters_dir is None:
+            lines.extend(
+                [
+                    "",
+                    "No clusters folder is currently selected.",
+                ]
+            )
+            return "\n".join(lines)
+
+        lines.extend(
+            [
+                "",
+                f"Sorted clusters folder: {clusters_dir}",
+            ]
+        )
+        if inspection is None:
+            lines.append("Selection has not been inspected yet.")
+            return "\n".join(lines)
+
+        lines.extend(
+            [
+                f"Detected stoichiometry bins: {inspection.stoichiometry_count}",
+                f"Detected structure files: {inspection.total_structure_files}",
+            ]
+        )
+        if inspection.stoichiometry_labels:
+            preview_labels = "\n".join(
+                f"- {label}" for label in inspection.stoichiometry_labels[:10]
+            )
+            lines.extend(
+                [
+                    "",
+                    "Stoichiometry labels:",
+                    preview_labels,
+                ]
+            )
+            remaining = len(inspection.stoichiometry_labels) - min(
+                len(inspection.stoichiometry_labels), 10
+            )
+            if remaining > 0:
+                lines.append(f"... and {remaining} more.")
+        if inspection.invalid_xyz_files:
+            lines.extend(
+                [
+                    "",
+                    "XYZ input detected. This tool will refuse to run until "
+                    "those files are converted to PDB:",
+                    *[
+                        f"- {path}"
+                        for path in inspection.invalid_xyz_files[:10]
+                    ],
+                ]
+            )
+        else:
+            lines.extend(
+                [
+                    "",
+                    "Input validation: PDB-only input detected.",
+                ]
+            )
+        output_dir = self._output_dir_path()
+        if output_dir is not None:
+            lines.extend(
+                [
+                    "",
+                    f"Output folder: {output_dir}",
+                    f"Output basename: {self._output_basename()}",
+                ]
+            )
+        return "\n".join(lines)
+
+    def _refresh_summary(self) -> None:
+        inspection = None
+        clusters_dir = self._clusters_dir_path()
+        if clusters_dir is not None and clusters_dir.exists():
+            try:
+                inspection = inspect_debye_waller_input(clusters_dir)
+            except Exception:
+                inspection = None
+        self.summary_box.setPlainText(self._describe_inspection(inspection))
+
+    def _append_log(self, message: str) -> None:
+        current = self.log_box.toPlainText()
+        if current:
+            self.log_box.appendPlainText(message)
+        else:
+            self.log_box.setPlainText(message)
+
+    @Slot()
+    def run_analysis(self) -> None:
+        clusters_dir = self._clusters_dir_path()
+        output_dir = self._output_dir_path()
+        if clusters_dir is None:
+            QMessageBox.warning(
+                self,
+                "Debye-Waller Analysis",
+                "Select a sorted clusters folder before running the analysis.",
+            )
+            return
+        if output_dir is None:
+            QMessageBox.warning(
+                self,
+                "Debye-Waller Analysis",
+                "Select an output folder before running the analysis.",
+            )
+            return
+
+        workflow = DebyeWallerWorkflow(
+            clusters_dir,
+            project_dir=self._project_dir,
+            output_dir=output_dir,
+            output_basename=self._output_basename(),
+        )
+        self._project_had_saved_analysis_before_run = (
+            self._project_dir is not None
+            and find_saved_project_debye_waller_analysis(self._project_dir)
+            is not None
+        )
+        self._partial_stoichiometry_results = []
+        self._last_result = None
+        self.stoichiometry_info_table.setRowCount(0)
+        self.aggregated_pair_table.setRowCount(0)
+        self.pair_summary_table.setRowCount(0)
+        self.scope_summary_table.setRowCount(0)
+        self.segment_table.setRowCount(0)
+        self.log_box.setPlainText("")
+        self.results_tabs.setCurrentWidget(self.log_box)
+        self._append_log(f"Starting Debye-Waller analysis for {clusters_dir}.")
+        self.run_button.setEnabled(False)
+        self._refresh_project_save_controls()
+        self.progress_label.setText(
+            "Progress: validating input and preparing the run"
+        )
+        self.progress_bar.setRange(0, 0)
+        self.progress_bar.setValue(0)
+        self.summary_box.setPlainText(
+            "\n".join(
+                [
+                    "Debye-Waller Analysis",
+                    "",
+                    "Run in progress.",
+                    f"Sorted clusters folder: {clusters_dir}",
+                    f"Output folder: {output_dir}",
+                    "",
+                    "Waiting for contiguous frame sets and coefficient rows...",
+                ]
+            )
+        )
+
+        thread = QThread(self)
+        worker = DebyeWallerWorker(workflow)
+        worker.moveToThread(thread)
+        thread.started.connect(worker.run)
+        worker.log.connect(self._append_log)
+        worker.progress.connect(self._update_progress)
+        worker.status.connect(self._update_status)
+        worker.stoichiometry_ready.connect(self._update_partial_results)
+        worker.finished.connect(self._finish_run)
+        worker.finished.connect(self._cleanup_run_thread)
+        worker.failed.connect(self._fail_run)
+        worker.failed.connect(self._cleanup_run_thread)
+        self._run_thread = thread
+        self._run_worker = worker
+        thread.start()
+
+    @Slot(int, int)
+    def _update_progress(self, processed: int, total: int) -> None:
+        safe_total = max(int(total), 1)
+        self.progress_bar.setRange(0, safe_total)
+        self.progress_bar.setValue(min(max(int(processed), 0), safe_total))
+
+    @Slot(str)
+    def _update_status(self, message: str) -> None:
+        self.progress_label.setText(f"Progress: {message}")
+        self.statusBar().showMessage(message)
+
+    @Slot(object)
+    def _update_partial_results(self, payload: object) -> None:
+        if not isinstance(payload, DebyeWallerStoichiometryResult):
+            return
+        for index, existing in enumerate(self._partial_stoichiometry_results):
+            if existing.label == payload.label:
+                self._partial_stoichiometry_results[index] = payload
+                break
+        else:
+            self._partial_stoichiometry_results.append(payload)
+        self._populate_aggregated_pair_table(
+            build_debye_waller_aggregated_pair_summaries(
+                self._partial_stoichiometry_results
+            )
+        )
+        self._populate_stoichiometry_info_table_from_stoichiometries(
+            self._partial_stoichiometry_results
+        )
+        self._populate_pair_summary_table_from_stoichiometries(
+            self._partial_stoichiometry_results
+        )
+        self._populate_scope_summary_table_from_stoichiometries(
+            self._partial_stoichiometry_results
+        )
+        self._populate_segment_table_from_stoichiometries(
+            self._partial_stoichiometry_results
+        )
+        self.summary_box.setPlainText(
+            self._describe_partial_progress(
+                self._partial_stoichiometry_results
+            )
+        )
+
+    @Slot(object)
+    def _finish_run(self, payload: object) -> None:
+        if not isinstance(payload, DebyeWallerAnalysisResult):
+            self._fail_run(
+                "The Debye-Waller workflow returned an invalid payload."
+            )
+            return
+        self._last_result = payload
+        self.run_button.setEnabled(True)
+        self.progress_bar.setRange(0, 1)
+        self.progress_bar.setValue(1)
+        self.progress_label.setText("Progress: complete")
+        self.statusBar().showMessage("Debye-Waller analysis complete")
+        self._append_log("Debye-Waller analysis finished successfully.")
+        if payload.artifacts is not None:
+            self._append_log(
+                f"Summary JSON: {payload.artifacts.summary_json_path}"
+            )
+        self._populate_result_tables(payload)
+        self.summary_box.setPlainText(self._describe_result(payload))
+        if (
+            self._project_dir is not None
+            and not self._project_had_saved_analysis_before_run
+        ):
+            saved_result = save_debye_waller_analysis_to_project(
+                payload,
+                self._project_dir,
+            )
+            self._last_result = saved_result
+            self.set_output_dir(saved_result.output_dir)
+            if saved_result.artifacts is not None:
+                self.output_basename_edit.setText(
+                    saved_result.artifacts.summary_json_path.stem
+                )
+                self._append_log(
+                    "Auto-saved the first Debye-Waller analysis for this "
+                    "project."
+                )
+                self._append_log(
+                    f"Project summary JSON: {saved_result.artifacts.summary_json_path}"
+                )
+            self.summary_box.setPlainText(self._describe_result(saved_result))
+            self._project_had_saved_analysis_before_run = True
+            self._emit_project_analysis_saved(saved_result)
+        self._refresh_project_save_controls()
+
+    @Slot(str)
+    def _fail_run(self, message: str) -> None:
+        self.run_button.setEnabled(True)
+        self.progress_bar.setRange(0, 1)
+        self.progress_bar.setValue(0)
+        self.progress_label.setText("Progress: failed")
+        self.statusBar().showMessage("Debye-Waller analysis failed")
+        self._append_log(f"Run failed: {message}")
+        self._refresh_project_save_controls()
+        QMessageBox.critical(self, "Debye-Waller Analysis", message)
+
+    @Slot(object)
+    def _cleanup_run_thread(self, _payload: object) -> None:
+        if self._run_thread is None:
+            return
+        self._run_thread.quit()
+        self._run_thread.wait()
+        if self._run_worker is not None:
+            self._run_worker.deleteLater()
+        self._run_thread.deleteLater()
+        self._run_worker = None
+        self._run_thread = None
+
+    def _describe_result(self, result: DebyeWallerAnalysisResult) -> str:
+        lines = [
+            "Debye-Waller Analysis",
+            "",
+            f"Created: {result.created_at}",
+            f"Clusters folder: {result.clusters_dir}",
+            f"Output folder: {result.output_dir}",
+            "",
+            f"Stoichiometry results: {len(result.stoichiometry_results)}",
+            f"Aggregated pair rows: {len(result.aggregated_pair_summaries)}",
+            f"Pair-type summary rows: "
+            f"{sum(len(entry.pair_summaries) for entry in result.stoichiometry_results)}",
+            f"Scope summary rows: "
+            f"{sum(len(entry.scope_summaries) for entry in result.stoichiometry_results)}",
+            f"Segment rows: "
+            f"{sum(len(entry.segment_statistics) for entry in result.stoichiometry_results)}",
+        ]
+        if result.artifacts is not None:
+            lines.extend(
+                [
+                    "",
+                    "Artifacts:",
+                    f"- {result.artifacts.summary_json_path}",
+                    f"- {result.artifacts.aggregated_pair_summary_csv_path}",
+                    f"- {result.artifacts.pair_summary_csv_path}",
+                    f"- {result.artifacts.scope_summary_csv_path}",
+                    f"- {result.artifacts.segment_csv_path}",
+                ]
+            )
+        for stoichiometry in result.stoichiometry_results:
+            lines.extend(
+                [
+                    "",
+                    f"{stoichiometry.label}: "
+                    f"{len(stoichiometry.contiguous_frame_sets)} frame set(s), "
+                    f"{len(stoichiometry.pair_summaries)} pair-type row(s), "
+                    f"{len(stoichiometry.scope_summaries)} scope row(s).",
+                ]
+            )
+            for note in stoichiometry.notes[:4]:
+                lines.append(f"  note: {note}")
+            remaining_notes = max(len(stoichiometry.notes) - 4, 0)
+            if remaining_notes:
+                lines.append(f"  ... and {remaining_notes} more note(s).")
+        return "\n".join(lines)
+
+    def _describe_partial_progress(
+        self,
+        stoichiometry_results: (
+            list[DebyeWallerStoichiometryResult]
+            | tuple[DebyeWallerStoichiometryResult, ...]
+        ),
+    ) -> str:
+        completed_labels = len(stoichiometry_results)
+        lines = [
+            "Debye-Waller Analysis",
+            "",
+            "Run in progress.",
+            f"Completed stoichiometry labels: {completed_labels}",
+            "Tables update as each contiguous frame set finishes.",
+            "",
+            f"Aggregated pair rows: "
+            f"{len(build_debye_waller_aggregated_pair_summaries(stoichiometry_results))}",
+            f"Pair-type summary rows: "
+            f"{sum(len(entry.pair_summaries) for entry in stoichiometry_results)}",
+            f"Scope summary rows: "
+            f"{sum(len(entry.scope_summaries) for entry in stoichiometry_results)}",
+            f"Segment rows: "
+            f"{sum(len(entry.segment_statistics) for entry in stoichiometry_results)}",
+        ]
+        for stoichiometry in stoichiometry_results[-5:]:
+            info_summary = stoichiometry.info_summary
+            lines.extend(
+                [
+                    "",
+                    f"{stoichiometry.label}: "
+                    f"{len(stoichiometry.contiguous_frame_sets)} frame set(s), "
+                    f"{len(stoichiometry.segment_statistics)} segment row(s), "
+                    f"{0.0 if info_summary is None else info_summary.average_atoms_per_frame:.1f} "
+                    "atom(s)/frame.",
+                ]
+            )
+        return "\n".join(lines)
+
+    def _populate_stoichiometry_info_table_from_stoichiometries(
+        self,
+        stoichiometry_results: (
+            list[DebyeWallerStoichiometryResult]
+            | tuple[DebyeWallerStoichiometryResult, ...]
+        ),
+    ) -> None:
+        rows: list[DebyeWallerStoichiometryInfoSummary] = []
+        for stoichiometry in stoichiometry_results:
+            if stoichiometry.info_summary is not None:
+                rows.append(stoichiometry.info_summary)
+        self.stoichiometry_info_table.setSortingEnabled(False)
+        self.stoichiometry_info_table.setRowCount(len(rows))
+        for row_index, row in enumerate(rows):
+            values = (
+                row.stoichiometry_label,
+                f"{row.processed_frame_count}/{row.total_frame_count}",
+                f"{row.processed_frame_set_count}/{row.total_frame_set_count}",
+                f"{float(row.average_frames_per_set):.2f}",
+                f"{float(row.average_atoms_per_frame):.2f}",
+                f"{float(row.average_molecules_per_frame):.2f}",
+                f"{float(row.average_solvent_like_molecules_per_frame):.2f}",
+                f"{float(row.average_shared_atom_sites_per_set):.2f}",
+                ", ".join(row.unique_residue_names) or "n/a",
+                ", ".join(row.unique_elements) or "n/a",
+                row.solvent_like_molecule_signature or "n/a",
+                row.most_common_molecule_signature or "n/a",
+            )
+            for column_index, value in enumerate(values):
+                self.stoichiometry_info_table.setItem(
+                    row_index,
+                    column_index,
+                    QTableWidgetItem(str(value)),
+                )
+        self.stoichiometry_info_table.resizeColumnsToContents()
+        self.stoichiometry_info_table.setSortingEnabled(True)
+
+    def _populate_aggregated_pair_table(
+        self,
+        rows: (
+            list[DebyeWallerAggregatedPairSummary]
+            | tuple[DebyeWallerAggregatedPairSummary, ...]
+        ),
+    ) -> None:
+        self.aggregated_pair_table.setSortingEnabled(False)
+        self.aggregated_pair_table.setRowCount(len(rows))
+        for row_index, row in enumerate(rows):
+            values = (
+                _scope_display_name(row.scope),
+                row.type_definition,
+                row.pair_label,
+                str(row.stoichiometry_count),
+                str(row.segment_count),
+                f"{float(row.sigma_mean):.6f}",
+                f"{float(row.sigma_std):.6f}",
+                f"{float(row.b_factor_mean):.6f}",
+                f"{float(row.b_factor_std):.6f}",
+                f"{float(row.mean_pair_count):.2f}",
+            )
+            for column_index, value in enumerate(values):
+                self.aggregated_pair_table.setItem(
+                    row_index,
+                    column_index,
+                    QTableWidgetItem(str(value)),
+                )
+        self.aggregated_pair_table.resizeColumnsToContents()
+        self.aggregated_pair_table.setSortingEnabled(True)
+
+    def _populate_pair_summary_table_from_stoichiometries(
+        self,
+        stoichiometry_results: (
+            list[DebyeWallerStoichiometryResult]
+            | tuple[DebyeWallerStoichiometryResult, ...]
+        ),
+    ) -> None:
+        rows = [
+            summary
+            for stoichiometry in stoichiometry_results
+            for summary in stoichiometry.pair_summaries
+        ]
+        self.pair_summary_table.setSortingEnabled(False)
+        self.pair_summary_table.setRowCount(len(rows))
+        for row_index, row in enumerate(rows):
+            values = (
+                row.stoichiometry_label,
+                _scope_display_name(row.scope),
+                row.type_definition,
+                row.pair_label,
+                str(row.segment_count),
+                f"{float(row.sigma_mean):.6f}",
+                f"{float(row.sigma_std):.6f}",
+                f"{float(row.b_factor_mean):.6f}",
+                f"{float(row.b_factor_std):.6f}",
+                f"{float(row.mean_pair_count):.2f}",
+            )
+            for column_index, value in enumerate(values):
+                self.pair_summary_table.setItem(
+                    row_index,
+                    column_index,
+                    QTableWidgetItem(str(value)),
+                )
+        self.pair_summary_table.resizeColumnsToContents()
+        self.pair_summary_table.setSortingEnabled(True)
+
+    def _populate_scope_summary_table_from_stoichiometries(
+        self,
+        stoichiometry_results: (
+            list[DebyeWallerStoichiometryResult]
+            | tuple[DebyeWallerStoichiometryResult, ...]
+        ),
+    ) -> None:
+        rows = [
+            summary
+            for stoichiometry in stoichiometry_results
+            for summary in stoichiometry.scope_summaries
+        ]
+        self.scope_summary_table.setSortingEnabled(False)
+        self.scope_summary_table.setRowCount(len(rows))
+        for row_index, row in enumerate(rows):
+            values = (
+                row.stoichiometry_label,
+                _scope_display_name(row.scope),
+                str(row.segment_count),
+                f"{float(row.sigma_mean):.6f}",
+                f"{float(row.sigma_std):.6f}",
+                f"{float(row.b_factor_mean):.6f}",
+                f"{float(row.b_factor_std):.6f}",
+                f"{float(row.mean_pair_count):.2f}",
+            )
+            for column_index, value in enumerate(values):
+                self.scope_summary_table.setItem(
+                    row_index,
+                    column_index,
+                    QTableWidgetItem(str(value)),
+                )
+        self.scope_summary_table.resizeColumnsToContents()
+        self.scope_summary_table.setSortingEnabled(True)
+
+    def _populate_segment_table_from_stoichiometries(
+        self,
+        stoichiometry_results: (
+            list[DebyeWallerStoichiometryResult]
+            | tuple[DebyeWallerStoichiometryResult, ...]
+        ),
+    ) -> None:
+        rows = [
+            summary
+            for stoichiometry in stoichiometry_results
+            for summary in stoichiometry.segment_statistics
+        ]
+        self.segment_table.setSortingEnabled(False)
+        self.segment_table.setRowCount(len(rows))
+        for row_index, row in enumerate(rows):
+            frame_text = (
+                f"{row.frame_start}-{row.frame_end} "
+                f"({row.frame_count} frame(s))"
+            )
+            values = (
+                row.stoichiometry_label,
+                f"{row.segment_index}: {row.series_label}",
+                frame_text,
+                _scope_display_name(row.scope),
+                row.type_definition,
+                row.pair_label,
+                f"{float(row.sigma):.6f}",
+                f"{float(row.b_factor):.6f}",
+                str(row.pair_count),
+            )
+            for column_index, value in enumerate(values):
+                self.segment_table.setItem(
+                    row_index,
+                    column_index,
+                    QTableWidgetItem(str(value)),
+                )
+        self.segment_table.resizeColumnsToContents()
+        self.segment_table.setSortingEnabled(True)
+
+
+def _release_window(window: DebyeWallerAnalysisMainWindow) -> None:
+    if window in _OPEN_WINDOWS:
+        _OPEN_WINDOWS.remove(window)
+
+
+def launch_debye_waller_analysis_ui(
+    *,
+    initial_project_dir: str | Path | None = None,
+    initial_clusters_dir: str | Path | None = None,
+    initial_output_dir: str | Path | None = None,
+    startup_progress_callback: (
+        DebyeWallerStartupProgressCallback | None
+    ) = None,
+    startup_log_callback: Callable[[str], None] | None = None,
+) -> DebyeWallerAnalysisMainWindow:
+    app = QApplication.instance()
+    if app is None:
+        prepare_saxshell_application_identity()
+        app = QApplication(sys.argv)
+    configure_saxshell_application(app)
+
+    window = DebyeWallerAnalysisMainWindow(
+        initial_project_dir=initial_project_dir,
+        initial_clusters_dir=initial_clusters_dir,
+        initial_output_dir=initial_output_dir,
+        startup_progress_callback=startup_progress_callback,
+        startup_log_callback=startup_log_callback,
+    )
+    window.show()
+    window.raise_()
+    _OPEN_WINDOWS.append(window)
+    window.destroyed.connect(lambda _obj=None: _release_window(window))
+    return window
+
+
+__all__ = [
+    "DEBYE_WALLER_WINDOW_LOAD_TOTAL_STEPS",
+    "DebyeWallerAnalysisMainWindow",
+    "launch_debye_waller_analysis_ui",
+]

--- a/src/saxshell/saxs/debye_waller/workflow.py
+++ b/src/saxshell/saxs/debye_waller/workflow.py
@@ -1,0 +1,2226 @@
+from __future__ import annotations
+
+import csv
+import json
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Callable
+
+import numpy as np
+
+from saxshell.saxs.debye.profiles import (
+    b_factor_from_sigma,
+    discover_cluster_bins,
+)
+from saxshell.saxs.project_manager import build_project_paths
+
+DebyeWallerProgressCallback = Callable[[int, int, str], None]
+DebyeWallerLogCallback = Callable[[str], None]
+DebyeWallerStoichiometryCallback = Callable[
+    ["DebyeWallerStoichiometryResult"], None
+]
+_FRAME_ID_PATTERN = re.compile(r"frame_(\d+)", re.IGNORECASE)
+
+
+def _natural_sort_key(value: str) -> list[object]:
+    return [
+        int(token) if token.isdigit() else token.lower()
+        for token in re.split(r"(\d+)", str(value))
+        if token
+    ]
+
+
+def _safe_float_mean(values: list[float] | tuple[float, ...]) -> float:
+    if not values:
+        return 0.0
+    return float(np.mean(np.asarray(values, dtype=float)))
+
+
+def _safe_float_std(values: list[float] | tuple[float, ...]) -> float:
+    if len(values) <= 1:
+        return 0.0
+    return float(np.std(np.asarray(values, dtype=float), ddof=0))
+
+
+def _safe_output_basename(value: str) -> str:
+    safe_value = re.sub(r"[^A-Za-z0-9._-]+", "_", str(value).strip())
+    return safe_value.strip("._") or "debye_waller_analysis"
+
+
+def _scope_display_name(scope: str) -> str:
+    if scope == "intra_molecular":
+        return "Intra-molecular"
+    if scope == "inter_molecular":
+        return "Inter-molecular"
+    return str(scope)
+
+
+def _frame_set_range_label(
+    frame_set: "DebyeWallerContiguousFrameSetSummary",
+) -> str:
+    if frame_set.frame_start is None or frame_set.frame_end is None:
+        return f"{frame_set.frame_count} frame(s)"
+    if frame_set.frame_start == frame_set.frame_end:
+        return (
+            f"frame {frame_set.frame_start} "
+            f"({frame_set.frame_count} frame(s))"
+        )
+    return (
+        f"frames {frame_set.frame_start}-{frame_set.frame_end} "
+        f"({frame_set.frame_count} frame(s))"
+    )
+
+
+@dataclass(slots=True, frozen=True)
+class DebyeWallerInputInspection:
+    clusters_dir: Path
+    stoichiometry_labels: tuple[str, ...]
+    total_structure_files: int
+    invalid_xyz_files: tuple[Path, ...]
+
+    @property
+    def stoichiometry_count(self) -> int:
+        return len(self.stoichiometry_labels)
+
+    @property
+    def is_pdb_only(self) -> bool:
+        return not self.invalid_xyz_files
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "clusters_dir": str(self.clusters_dir),
+            "stoichiometry_labels": list(self.stoichiometry_labels),
+            "total_structure_files": int(self.total_structure_files),
+            "invalid_xyz_files": [
+                str(path) for path in self.invalid_xyz_files
+            ],
+            "is_pdb_only": bool(self.is_pdb_only),
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class DebyeWallerContiguousFrameSetSummary:
+    series_label: str
+    frame_ids: tuple[int, ...]
+    frame_labels: tuple[str, ...]
+    file_paths: tuple[Path, ...]
+
+    @property
+    def frame_count(self) -> int:
+        return len(self.file_paths)
+
+    @property
+    def frame_start(self) -> int | None:
+        return None if not self.frame_ids else int(self.frame_ids[0])
+
+    @property
+    def frame_end(self) -> int | None:
+        return None if not self.frame_ids else int(self.frame_ids[-1])
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "series_label": self.series_label,
+            "frame_ids": [int(value) for value in self.frame_ids],
+            "frame_labels": [str(value) for value in self.frame_labels],
+            "file_paths": [str(path) for path in self.file_paths],
+            "frame_count": int(self.frame_count),
+            "frame_start": self.frame_start,
+            "frame_end": self.frame_end,
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class DebyeWallerSegmentStatistic:
+    stoichiometry_label: str
+    structure: str
+    motif: str
+    source_dir: Path
+    segment_index: int
+    series_label: str
+    frame_start: int | None
+    frame_end: int | None
+    frame_count: int
+    scope: str
+    type_definition: str
+    pair_label_a: str
+    pair_label_b: str
+    pair_label: str
+    pair_count: int
+    mean_distance_a: float
+    sigma: float
+    sigma_squared: float
+    b_factor: float
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "stoichiometry_label": self.stoichiometry_label,
+            "structure": self.structure,
+            "motif": self.motif,
+            "source_dir": str(self.source_dir),
+            "segment_index": int(self.segment_index),
+            "series_label": self.series_label,
+            "frame_start": self.frame_start,
+            "frame_end": self.frame_end,
+            "frame_count": int(self.frame_count),
+            "scope": self.scope,
+            "type_definition": self.type_definition,
+            "pair_label_a": self.pair_label_a,
+            "pair_label_b": self.pair_label_b,
+            "pair_label": self.pair_label,
+            "pair_count": int(self.pair_count),
+            "mean_distance_a": float(self.mean_distance_a),
+            "sigma": float(self.sigma),
+            "sigma_squared": float(self.sigma_squared),
+            "b_factor": float(self.b_factor),
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class DebyeWallerPairSummary:
+    stoichiometry_label: str
+    structure: str
+    motif: str
+    source_dir: Path
+    scope: str
+    type_definition: str
+    pair_label_a: str
+    pair_label_b: str
+    pair_label: str
+    segment_count: int
+    mean_pair_count: float
+    mean_distance_a: float
+    sigma_mean: float
+    sigma_std: float
+    sigma_squared_mean: float
+    sigma_squared_std: float
+    b_factor_mean: float
+    b_factor_std: float
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "stoichiometry_label": self.stoichiometry_label,
+            "structure": self.structure,
+            "motif": self.motif,
+            "source_dir": str(self.source_dir),
+            "scope": self.scope,
+            "type_definition": self.type_definition,
+            "pair_label_a": self.pair_label_a,
+            "pair_label_b": self.pair_label_b,
+            "pair_label": self.pair_label,
+            "segment_count": int(self.segment_count),
+            "mean_pair_count": float(self.mean_pair_count),
+            "mean_distance_a": float(self.mean_distance_a),
+            "sigma_mean": float(self.sigma_mean),
+            "sigma_std": float(self.sigma_std),
+            "sigma_squared_mean": float(self.sigma_squared_mean),
+            "sigma_squared_std": float(self.sigma_squared_std),
+            "b_factor_mean": float(self.b_factor_mean),
+            "b_factor_std": float(self.b_factor_std),
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class DebyeWallerScopeSummary:
+    stoichiometry_label: str
+    structure: str
+    motif: str
+    source_dir: Path
+    scope: str
+    segment_count: int
+    mean_pair_count: float
+    sigma_mean: float
+    sigma_std: float
+    sigma_squared_mean: float
+    sigma_squared_std: float
+    b_factor_mean: float
+    b_factor_std: float
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "stoichiometry_label": self.stoichiometry_label,
+            "structure": self.structure,
+            "motif": self.motif,
+            "source_dir": str(self.source_dir),
+            "scope": self.scope,
+            "segment_count": int(self.segment_count),
+            "mean_pair_count": float(self.mean_pair_count),
+            "sigma_mean": float(self.sigma_mean),
+            "sigma_std": float(self.sigma_std),
+            "sigma_squared_mean": float(self.sigma_squared_mean),
+            "sigma_squared_std": float(self.sigma_squared_std),
+            "b_factor_mean": float(self.b_factor_mean),
+            "b_factor_std": float(self.b_factor_std),
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class DebyeWallerAggregatedPairSummary:
+    scope: str
+    type_definition: str
+    pair_label_a: str
+    pair_label_b: str
+    pair_label: str
+    stoichiometry_count: int
+    segment_count: int
+    mean_pair_count: float
+    mean_distance_a: float
+    sigma_mean: float
+    sigma_std: float
+    sigma_squared_mean: float
+    sigma_squared_std: float
+    b_factor_mean: float
+    b_factor_std: float
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "scope": self.scope,
+            "type_definition": self.type_definition,
+            "pair_label_a": self.pair_label_a,
+            "pair_label_b": self.pair_label_b,
+            "pair_label": self.pair_label,
+            "stoichiometry_count": int(self.stoichiometry_count),
+            "segment_count": int(self.segment_count),
+            "mean_pair_count": float(self.mean_pair_count),
+            "mean_distance_a": float(self.mean_distance_a),
+            "sigma_mean": float(self.sigma_mean),
+            "sigma_std": float(self.sigma_std),
+            "sigma_squared_mean": float(self.sigma_squared_mean),
+            "sigma_squared_std": float(self.sigma_squared_std),
+            "b_factor_mean": float(self.b_factor_mean),
+            "b_factor_std": float(self.b_factor_std),
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class DebyeWallerStoichiometryInfoSummary:
+    stoichiometry_label: str
+    structure: str
+    motif: str
+    source_dir: Path
+    input_file_count: int
+    processed_frame_count: int
+    total_frame_count: int
+    processed_frame_set_count: int
+    total_frame_set_count: int
+    average_frames_per_set: float
+    min_frames_per_set: int
+    max_frames_per_set: int
+    average_atoms_per_frame: float
+    average_molecules_per_frame: float
+    average_solvent_like_molecules_per_frame: float
+    average_shared_atom_sites_per_set: float
+    unique_residue_name_count: int
+    unique_residue_names: tuple[str, ...]
+    unique_element_count: int
+    unique_elements: tuple[str, ...]
+    most_common_molecule_signature: str
+    solvent_like_molecule_signature: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "stoichiometry_label": self.stoichiometry_label,
+            "structure": self.structure,
+            "motif": self.motif,
+            "source_dir": str(self.source_dir),
+            "input_file_count": int(self.input_file_count),
+            "processed_frame_count": int(self.processed_frame_count),
+            "total_frame_count": int(self.total_frame_count),
+            "processed_frame_set_count": int(self.processed_frame_set_count),
+            "total_frame_set_count": int(self.total_frame_set_count),
+            "average_frames_per_set": float(self.average_frames_per_set),
+            "min_frames_per_set": int(self.min_frames_per_set),
+            "max_frames_per_set": int(self.max_frames_per_set),
+            "average_atoms_per_frame": float(self.average_atoms_per_frame),
+            "average_molecules_per_frame": float(
+                self.average_molecules_per_frame
+            ),
+            "average_solvent_like_molecules_per_frame": float(
+                self.average_solvent_like_molecules_per_frame
+            ),
+            "average_shared_atom_sites_per_set": float(
+                self.average_shared_atom_sites_per_set
+            ),
+            "unique_residue_name_count": int(self.unique_residue_name_count),
+            "unique_residue_names": [
+                str(value) for value in self.unique_residue_names
+            ],
+            "unique_element_count": int(self.unique_element_count),
+            "unique_elements": [str(value) for value in self.unique_elements],
+            "most_common_molecule_signature": self.most_common_molecule_signature,
+            "solvent_like_molecule_signature": self.solvent_like_molecule_signature,
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class DebyeWallerStoichiometryResult:
+    label: str
+    structure: str
+    motif: str
+    source_dir: Path
+    input_file_count: int
+    contiguous_frame_sets: tuple[DebyeWallerContiguousFrameSetSummary, ...]
+    pair_summaries: tuple[DebyeWallerPairSummary, ...]
+    scope_summaries: tuple[DebyeWallerScopeSummary, ...]
+    segment_statistics: tuple[DebyeWallerSegmentStatistic, ...]
+    info_summary: DebyeWallerStoichiometryInfoSummary | None = None
+    notes: tuple[str, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "label": self.label,
+            "structure": self.structure,
+            "motif": self.motif,
+            "source_dir": str(self.source_dir),
+            "input_file_count": int(self.input_file_count),
+            "contiguous_frame_sets": [
+                entry.to_dict() for entry in self.contiguous_frame_sets
+            ],
+            "pair_summaries": [
+                entry.to_dict() for entry in self.pair_summaries
+            ],
+            "scope_summaries": [
+                entry.to_dict() for entry in self.scope_summaries
+            ],
+            "segment_statistics": [
+                entry.to_dict() for entry in self.segment_statistics
+            ],
+            "info_summary": (
+                None
+                if self.info_summary is None
+                else self.info_summary.to_dict()
+            ),
+            "notes": [str(note) for note in self.notes],
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class DebyeWallerOutputArtifacts:
+    output_dir: Path
+    summary_json_path: Path
+    aggregated_pair_summary_csv_path: Path
+    pair_summary_csv_path: Path
+    scope_summary_csv_path: Path
+    segment_csv_path: Path
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "output_dir": str(self.output_dir),
+            "summary_json_path": str(self.summary_json_path),
+            "aggregated_pair_summary_csv_path": str(
+                self.aggregated_pair_summary_csv_path
+            ),
+            "pair_summary_csv_path": str(self.pair_summary_csv_path),
+            "scope_summary_csv_path": str(self.scope_summary_csv_path),
+            "segment_csv_path": str(self.segment_csv_path),
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class DebyeWallerAnalysisResult:
+    created_at: str
+    clusters_dir: Path
+    project_dir: Path | None
+    output_dir: Path
+    inspection: DebyeWallerInputInspection
+    stoichiometry_results: tuple[DebyeWallerStoichiometryResult, ...]
+    aggregated_pair_summaries: tuple[
+        DebyeWallerAggregatedPairSummary, ...
+    ] = ()
+    notes: tuple[str, ...] = ()
+    artifacts: DebyeWallerOutputArtifacts | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "created_at": self.created_at,
+            "clusters_dir": str(self.clusters_dir),
+            "project_dir": (
+                None if self.project_dir is None else str(self.project_dir)
+            ),
+            "output_dir": str(self.output_dir),
+            "inspection": self.inspection.to_dict(),
+            "stoichiometry_results": [
+                entry.to_dict() for entry in self.stoichiometry_results
+            ],
+            "aggregated_pair_summaries": [
+                entry.to_dict() for entry in self.aggregated_pair_summaries
+            ],
+            "notes": [str(note) for note in self.notes],
+            "artifacts": (
+                None if self.artifacts is None else self.artifacts.to_dict()
+            ),
+        }
+
+
+_PROJECT_DEBYE_WALLER_DIRNAME = "debye_waller"
+_PROJECT_DEBYE_WALLER_SAVED_DIRNAME = "saved_analysis"
+_PROJECT_DEBYE_WALLER_SAVED_BASENAME = "debye_waller_analysis"
+
+
+@dataclass(slots=True, frozen=True)
+class _ContiguousFrameRecord:
+    file_path: Path
+    frame_id: int
+    frame_label: str
+    series_key: str
+    series_label: str
+
+
+@dataclass(slots=True, frozen=True)
+class _PDBAtomRecord:
+    site_key: tuple[str, str, str, str, str, str]
+    molecule_key: tuple[str, str, str]
+    element: str
+    residue_name: str
+    atom_name: str
+    coordinates: np.ndarray
+
+
+@dataclass(slots=True, frozen=True)
+class _DebyeWallerFrameMetadata:
+    atom_count: int
+    molecule_count: int
+    dominant_molecule_count: int
+    solvent_like_molecule_count: int
+    residue_names: tuple[str, ...]
+    elements: tuple[str, ...]
+    molecule_signature_counts: tuple[tuple[str, int], ...]
+
+
+def inspect_debye_waller_input(
+    clusters_dir: str | Path,
+) -> DebyeWallerInputInspection:
+    resolved_clusters_dir = Path(clusters_dir).expanduser().resolve()
+    cluster_bins = discover_cluster_bins(resolved_clusters_dir)
+    labels = tuple(
+        (
+            cluster_bin.structure
+            if cluster_bin.motif == "no_motif"
+            else f"{cluster_bin.structure}/{cluster_bin.motif}"
+        )
+        for cluster_bin in cluster_bins
+    )
+    invalid_xyz_files = tuple(
+        sorted(
+            (
+                file_path
+                for cluster_bin in cluster_bins
+                for file_path in cluster_bin.files
+                if file_path.suffix.lower() == ".xyz"
+            ),
+            key=lambda path: _natural_sort_key(str(path)),
+        )
+    )
+    total_files = sum(len(cluster_bin.files) for cluster_bin in cluster_bins)
+    return DebyeWallerInputInspection(
+        clusters_dir=resolved_clusters_dir,
+        stoichiometry_labels=labels,
+        total_structure_files=int(total_files),
+        invalid_xyz_files=invalid_xyz_files,
+    )
+
+
+def suggest_output_dir(
+    selection_path: str | Path,
+    *,
+    project_dir: str | Path | None = None,
+) -> Path:
+    if project_dir is not None:
+        paths = build_project_paths(project_dir)
+        return paths.exported_data_dir / "debye_waller"
+    resolved = Path(selection_path).expanduser().resolve()
+    base_dir = resolved if resolved.is_dir() else resolved.parent
+    return base_dir / "debye_waller"
+
+
+def _frame_series_label(prefix: str, suffix: str) -> str:
+    parts = [
+        part for part in (prefix.strip("_- "), suffix.strip("_- ")) if part
+    ]
+    if not parts:
+        return "default"
+    return " ".join(parts)
+
+
+def _parse_contiguous_frame_record(
+    file_path: str | Path,
+) -> _ContiguousFrameRecord | None:
+    resolved = Path(file_path).expanduser().resolve()
+    stem = str(resolved.stem)
+    match = _FRAME_ID_PATTERN.search(stem)
+    if match is None:
+        return None
+    frame_label = str(match.group(1))
+    prefix = stem[: match.start()]
+    suffix = stem[match.end() :]
+    return _ContiguousFrameRecord(
+        file_path=resolved,
+        frame_id=int(frame_label),
+        frame_label=frame_label,
+        series_key=f"{prefix}::{suffix}",
+        series_label=_frame_series_label(prefix, suffix),
+    )
+
+
+def _detect_contiguous_frame_sets(
+    structure_files: tuple[Path, ...],
+) -> tuple[tuple[DebyeWallerContiguousFrameSetSummary, ...], str | None]:
+    if not structure_files:
+        return tuple(), None
+    records: list[_ContiguousFrameRecord] = []
+    for file_path in structure_files:
+        parsed = _parse_contiguous_frame_record(file_path)
+        if parsed is None:
+            return (
+                tuple(),
+                "Contiguous-frame averaging requires every input file to "
+                "contain a frame_<NNNN> identifier.",
+            )
+        records.append(parsed)
+
+    series_map: dict[str, list[_ContiguousFrameRecord]] = {}
+    for record in sorted(
+        records,
+        key=lambda item: (item.series_key, item.frame_id, item.file_path.name),
+    ):
+        series_map.setdefault(record.series_key, []).append(record)
+
+    contiguous_sets: list[DebyeWallerContiguousFrameSetSummary] = []
+    for series_records in series_map.values():
+        current_records: list[_ContiguousFrameRecord] = []
+        for record in series_records:
+            if (
+                current_records
+                and record.frame_id != current_records[-1].frame_id + 1
+            ):
+                contiguous_sets.append(
+                    DebyeWallerContiguousFrameSetSummary(
+                        series_label=str(current_records[0].series_label),
+                        frame_ids=tuple(
+                            int(entry.frame_id) for entry in current_records
+                        ),
+                        frame_labels=tuple(
+                            str(entry.frame_label) for entry in current_records
+                        ),
+                        file_paths=tuple(
+                            entry.file_path for entry in current_records
+                        ),
+                    )
+                )
+                current_records = []
+            current_records.append(record)
+        if current_records:
+            contiguous_sets.append(
+                DebyeWallerContiguousFrameSetSummary(
+                    series_label=str(current_records[0].series_label),
+                    frame_ids=tuple(
+                        int(entry.frame_id) for entry in current_records
+                    ),
+                    frame_labels=tuple(
+                        str(entry.frame_label) for entry in current_records
+                    ),
+                    file_paths=tuple(
+                        entry.file_path for entry in current_records
+                    ),
+                )
+            )
+    return tuple(contiguous_sets), None
+
+
+def _pdb_record_name(line: str) -> str:
+    return line[:6].strip().upper()
+
+
+def _pdb_altloc_rank(value: str) -> int:
+    altloc = value.strip().upper()
+    if not altloc:
+        return 0
+    if altloc == "A":
+        return 1
+    if altloc == "1":
+        return 2
+    return 3
+
+
+def _normalized_element_symbol(raw_value: str) -> str:
+    text = str(raw_value or "").strip()
+    if not text:
+        return ""
+    return text[:1].upper() + text[1:].lower()
+
+
+def _pdb_atom_element(line: str) -> str:
+    if len(line) >= 78:
+        element = _normalized_element_symbol(line[76:78].strip())
+        if element:
+            return element
+    atom_name_field = line[12:16] if len(line) >= 16 else ""
+    letters = "".join(
+        character for character in atom_name_field if character.isalpha()
+    )
+    if not letters:
+        return "X"
+    if atom_name_field[:1].isalpha() and len(letters) >= 2:
+        return _normalized_element_symbol(letters[:2])
+    return _normalized_element_symbol(letters[:1])
+
+
+def _pdb_residue_name(line: str) -> str:
+    return (line[17:20] if len(line) >= 20 else "").strip()
+
+
+def _pdb_sequence_id(line: str) -> str:
+    return (line[22:27] if len(line) >= 27 else "").strip()
+
+
+def _pdb_segment_id(line: str) -> str:
+    return (line[72:76] if len(line) >= 76 else "").strip()
+
+
+def _pdb_atom_site_key(line: str) -> tuple[str, str, str, str, str, str]:
+    return (
+        _pdb_segment_id(line),
+        (line[21:22] if len(line) >= 22 else "").strip(),
+        _pdb_sequence_id(line),
+        (line[26:27] if len(line) >= 27 else "").strip(),
+        _pdb_residue_name(line),
+        (line[12:16] if len(line) >= 16 else "").strip(),
+    )
+
+
+def _pdb_molecule_key(line: str) -> tuple[str, str, str]:
+    # Mirror fullrmc's automatic molecule grouping:
+    # contiguous atoms with the same residue, sequence, and segment belong
+    # to the same molecule.
+    return (
+        _pdb_residue_name(line),
+        _pdb_sequence_id(line),
+        _pdb_segment_id(line),
+    )
+
+
+def _load_pdb_atom_records(path: str | Path) -> tuple[_PDBAtomRecord, ...]:
+    pdb_path = Path(path).expanduser().resolve()
+    chosen_sites: dict[
+        tuple[str, str, str, str, str, str],
+        tuple[int, str],
+    ] = {}
+    site_order: list[tuple[str, str, str, str, str, str]] = []
+    lines = pdb_path.read_text(encoding="utf-8", errors="ignore").splitlines()
+    for line in lines:
+        record_name = _pdb_record_name(line)
+        if record_name == "ENDMDL" and chosen_sites:
+            break
+        if record_name not in {"ATOM", "HETATM"}:
+            continue
+        site_key = _pdb_atom_site_key(line)
+        altloc_rank = _pdb_altloc_rank(line[16:17] if len(line) >= 17 else "")
+        current = chosen_sites.get(site_key)
+        if current is None:
+            chosen_sites[site_key] = (altloc_rank, line)
+            site_order.append(site_key)
+        elif altloc_rank < current[0]:
+            chosen_sites[site_key] = (altloc_rank, line)
+
+    records: list[_PDBAtomRecord] = []
+    for site_key in site_order:
+        _altloc_rank, line = chosen_sites[site_key]
+        try:
+            x_coord = float(line[30:38].strip())
+            y_coord = float(line[38:46].strip())
+            z_coord = float(line[46:54].strip())
+        except ValueError as exc:
+            raise ValueError(
+                f"Could not parse coordinates for atom site {site_key!r} "
+                f"in {pdb_path.name}."
+            ) from exc
+        records.append(
+            _PDBAtomRecord(
+                site_key=site_key,
+                molecule_key=_pdb_molecule_key(line),
+                element=_pdb_atom_element(line),
+                residue_name=_pdb_residue_name(line),
+                atom_name=site_key[-1],
+                coordinates=np.asarray(
+                    [x_coord, y_coord, z_coord], dtype=float
+                ),
+            )
+        )
+    if not records:
+        raise ValueError(f"No atoms were parsed from {pdb_path}.")
+    return tuple(records)
+
+
+def _hill_formula_from_counts(counts: Counter[str]) -> str:
+    if not counts:
+        return "unknown"
+    ordered_symbols: list[str] = []
+    if "C" in counts:
+        ordered_symbols.append("C")
+        if "H" in counts:
+            ordered_symbols.append("H")
+    ordered_symbols.extend(
+        symbol
+        for symbol in sorted(counts)
+        if symbol not in {"C", "H"} and symbol
+    )
+    if "C" not in counts and "H" in counts:
+        ordered_symbols.insert(0, "H")
+    parts: list[str] = []
+    for symbol in ordered_symbols:
+        count = int(counts[symbol])
+        parts.append(symbol if count == 1 else f"{symbol}{count}")
+    return "".join(parts) or "unknown"
+
+
+def _molecule_signature(records: list[_PDBAtomRecord]) -> str:
+    if not records:
+        return "unknown"
+    residue_name = str(records[0].residue_name).strip() or "UNK"
+    element_counts: Counter[str] = Counter()
+    for record in records:
+        symbol = _normalized_element_symbol(record.element) or "X"
+        element_counts[symbol] += 1
+    return f"{residue_name}:{_hill_formula_from_counts(element_counts)}"
+
+
+def _summarize_frame_metadata(
+    records: tuple[_PDBAtomRecord, ...],
+) -> _DebyeWallerFrameMetadata:
+    molecule_map: dict[tuple[str, str, str], list[_PDBAtomRecord]] = (
+        defaultdict(list)
+    )
+    residue_names: set[str] = set()
+    elements: set[str] = set()
+    for record in records:
+        molecule_map[record.molecule_key].append(record)
+        residue_name = str(record.residue_name).strip()
+        if residue_name:
+            residue_names.add(residue_name)
+        element = _normalized_element_symbol(record.element)
+        if element:
+            elements.add(element)
+
+    signature_counts: Counter[str] = Counter()
+    for molecule_records in molecule_map.values():
+        signature_counts[_molecule_signature(molecule_records)] += 1
+
+    dominant_signature = ""
+    dominant_count = 0
+    if signature_counts:
+        dominant_signature, dominant_count = sorted(
+            signature_counts.items(),
+            key=lambda item: (-item[1], item[0]),
+        )[0]
+
+    return _DebyeWallerFrameMetadata(
+        atom_count=len(records),
+        molecule_count=len(molecule_map),
+        dominant_molecule_count=int(dominant_count),
+        solvent_like_molecule_count=(
+            int(dominant_count) if int(dominant_count) > 1 else 0
+        ),
+        residue_names=tuple(sorted(residue_names)),
+        elements=tuple(sorted(elements)),
+        molecule_signature_counts=tuple(
+            (str(signature), int(count))
+            for signature, count in sorted(signature_counts.items())
+        ),
+    )
+
+
+def _build_stoichiometry_info_summary(
+    *,
+    label: str,
+    structure: str,
+    motif: str,
+    source_dir: Path,
+    input_file_count: int,
+    frame_sets: tuple[DebyeWallerContiguousFrameSetSummary, ...],
+    processed_frame_metadata: list[_DebyeWallerFrameMetadata],
+    processed_aligned_atom_counts: list[int],
+) -> DebyeWallerStoichiometryInfoSummary:
+    total_frame_count = sum(
+        int(frame_set.frame_count) for frame_set in frame_sets
+    )
+    total_frame_set_count = len(frame_sets)
+    frame_set_sizes = [int(frame_set.frame_count) for frame_set in frame_sets]
+    processed_frame_count = len(processed_frame_metadata)
+
+    unique_residue_names: set[str] = set()
+    unique_elements: set[str] = set()
+    overall_signature_counts: Counter[str] = Counter()
+    repeated_signature_counts: Counter[str] = Counter()
+    for metadata in processed_frame_metadata:
+        unique_residue_names.update(metadata.residue_names)
+        unique_elements.update(metadata.elements)
+        for signature, count in metadata.molecule_signature_counts:
+            overall_signature_counts[str(signature)] += int(count)
+            if int(count) > 1:
+                repeated_signature_counts[str(signature)] += int(count)
+
+    most_common_molecule_signature = ""
+    if overall_signature_counts:
+        most_common_molecule_signature = sorted(
+            overall_signature_counts.items(),
+            key=lambda item: (-item[1], item[0]),
+        )[0][0]
+
+    solvent_like_molecule_signature = ""
+    average_solvent_like_molecules_per_frame = 0.0
+    if repeated_signature_counts:
+        solvent_like_molecule_signature, solvent_like_total = sorted(
+            repeated_signature_counts.items(),
+            key=lambda item: (-item[1], item[0]),
+        )[0]
+        if processed_frame_count > 0:
+            average_solvent_like_molecules_per_frame = float(
+                solvent_like_total / processed_frame_count
+            )
+
+    return DebyeWallerStoichiometryInfoSummary(
+        stoichiometry_label=label,
+        structure=structure,
+        motif=motif,
+        source_dir=source_dir,
+        input_file_count=int(input_file_count),
+        processed_frame_count=int(processed_frame_count),
+        total_frame_count=int(total_frame_count),
+        processed_frame_set_count=int(len(processed_aligned_atom_counts)),
+        total_frame_set_count=int(total_frame_set_count),
+        average_frames_per_set=(
+            float(total_frame_count / total_frame_set_count)
+            if total_frame_set_count > 0
+            else 0.0
+        ),
+        min_frames_per_set=min(frame_set_sizes, default=0),
+        max_frames_per_set=max(frame_set_sizes, default=0),
+        average_atoms_per_frame=_safe_float_mean(
+            [
+                float(metadata.atom_count)
+                for metadata in processed_frame_metadata
+            ]
+        ),
+        average_molecules_per_frame=_safe_float_mean(
+            [
+                float(metadata.molecule_count)
+                for metadata in processed_frame_metadata
+            ]
+        ),
+        average_solvent_like_molecules_per_frame=(
+            average_solvent_like_molecules_per_frame
+        ),
+        average_shared_atom_sites_per_set=_safe_float_mean(
+            [float(value) for value in processed_aligned_atom_counts]
+        ),
+        unique_residue_name_count=len(unique_residue_names),
+        unique_residue_names=tuple(sorted(unique_residue_names)),
+        unique_element_count=len(unique_elements),
+        unique_elements=tuple(sorted(unique_elements)),
+        most_common_molecule_signature=most_common_molecule_signature,
+        solvent_like_molecule_signature=solvent_like_molecule_signature,
+    )
+
+
+def _intra_atom_label(record: _PDBAtomRecord) -> str:
+    residue_name = str(record.residue_name).strip()
+    atom_name = str(record.atom_name).strip()
+    if residue_name:
+        return f"{residue_name}:{atom_name}"
+    return atom_name
+
+
+def _aggregate_pair_sigma(pair_sigmas: list[float]) -> float:
+    if not pair_sigmas:
+        return 0.0
+    sigma_values = np.asarray(pair_sigmas, dtype=float)
+    return float(np.sqrt(np.mean(np.square(sigma_values), dtype=float)))
+
+
+def _compute_segment_statistics(
+    *,
+    label: str,
+    structure: str,
+    motif: str,
+    source_dir: Path,
+    segment_index: int,
+    frame_set: DebyeWallerContiguousFrameSetSummary,
+) -> tuple[
+    list[DebyeWallerSegmentStatistic],
+    list[str],
+    tuple[_DebyeWallerFrameMetadata, ...],
+    int,
+]:
+    frame_records = [
+        _load_pdb_atom_records(file_path) for file_path in frame_set.file_paths
+    ]
+    frame_metadata = tuple(
+        _summarize_frame_metadata(records) for records in frame_records
+    )
+    if frame_set.frame_count < 2:
+        return (
+            [],
+            [
+                f"Skipped contiguous frame set {segment_index} for {label} "
+                "because at least two frames are required to estimate "
+                "pair-disorder statistics."
+            ],
+            frame_metadata,
+            0,
+        )
+
+    first_frame = frame_records[0]
+    common_site_keys = set(
+        first_frame_record.site_key for first_frame_record in first_frame
+    )
+    for records in frame_records[1:]:
+        common_site_keys &= {record.site_key for record in records}
+    ordered_site_keys = [
+        record.site_key
+        for record in first_frame
+        if record.site_key in common_site_keys
+    ]
+    if len(ordered_site_keys) < 2:
+        return (
+            [],
+            [
+                f"Skipped contiguous frame set {segment_index} for {label} "
+                "because fewer than two aligned atoms were shared across the "
+                "segment."
+            ],
+            frame_metadata,
+            len(ordered_site_keys),
+        )
+
+    notes: list[str] = []
+    if len(ordered_site_keys) != len(first_frame):
+        notes.append(
+            f"Frame set {segment_index} for {label} aligned "
+            f"{len(ordered_site_keys)}/{len(first_frame)} atom sites shared "
+            "across every frame."
+        )
+
+    frame_maps = [
+        {record.site_key: record for record in records}
+        for records in frame_records
+    ]
+    reference_records = [
+        frame_maps[0][site_key] for site_key in ordered_site_keys
+    ]
+    coordinate_cube = np.asarray(
+        [
+            [frame_map[site_key].coordinates for site_key in ordered_site_keys]
+            for frame_map in frame_maps
+        ],
+        dtype=float,
+    )
+    intra_labels = [_intra_atom_label(record) for record in reference_records]
+    elements = [
+        _normalized_element_symbol(record.element)
+        for record in reference_records
+    ]
+    molecule_keys = [record.molecule_key for record in reference_records]
+
+    grouped_pair_sigmas: dict[
+        tuple[str, str, str, str, str],
+        list[float],
+    ] = defaultdict(list)
+    grouped_pair_distances: dict[
+        tuple[str, str, str, str, str],
+        list[float],
+    ] = defaultdict(list)
+
+    atom_count = len(reference_records)
+    for left_index in range(atom_count - 1):
+        left_coords = coordinate_cube[:, left_index, :]
+        left_molecule = molecule_keys[left_index]
+        for right_index in range(left_index + 1, atom_count):
+            deltas = left_coords - coordinate_cube[:, right_index, :]
+            distances = np.linalg.norm(deltas, axis=1)
+            pair_mean_distance = float(np.mean(distances, dtype=float))
+            pair_sigma = float(np.std(distances, ddof=0))
+            if left_molecule == molecule_keys[right_index]:
+                scope = "intra_molecular"
+                type_definition = "name"
+                pair_label_a, pair_label_b = sorted(
+                    (intra_labels[left_index], intra_labels[right_index])
+                )
+            else:
+                scope = "inter_molecular"
+                type_definition = "element"
+                pair_label_a, pair_label_b = sorted(
+                    (elements[left_index], elements[right_index])
+                )
+            grouped_key = (
+                scope,
+                type_definition,
+                pair_label_a,
+                pair_label_b,
+                f"{pair_label_a}-{pair_label_b}",
+            )
+            grouped_pair_sigmas[grouped_key].append(pair_sigma)
+            grouped_pair_distances[grouped_key].append(pair_mean_distance)
+
+    rows: list[DebyeWallerSegmentStatistic] = []
+    for grouped_key in sorted(
+        grouped_pair_sigmas,
+        key=lambda item: (item[0], item[1], item[2], item[3], item[4]),
+    ):
+        pair_sigmas = grouped_pair_sigmas[grouped_key]
+        pair_mean_distance = _safe_float_mean(
+            grouped_pair_distances[grouped_key]
+        )
+        sigma = _aggregate_pair_sigma(pair_sigmas)
+        rows.append(
+            DebyeWallerSegmentStatistic(
+                stoichiometry_label=label,
+                structure=structure,
+                motif=motif,
+                source_dir=source_dir,
+                segment_index=int(segment_index),
+                series_label=frame_set.series_label,
+                frame_start=frame_set.frame_start,
+                frame_end=frame_set.frame_end,
+                frame_count=int(frame_set.frame_count),
+                scope=grouped_key[0],
+                type_definition=grouped_key[1],
+                pair_label_a=grouped_key[2],
+                pair_label_b=grouped_key[3],
+                pair_label=grouped_key[4],
+                pair_count=len(pair_sigmas),
+                mean_distance_a=pair_mean_distance,
+                sigma=sigma,
+                sigma_squared=float(sigma * sigma),
+                b_factor=b_factor_from_sigma(sigma),
+            )
+        )
+    return rows, notes, frame_metadata, len(ordered_site_keys)
+
+
+def _build_pair_summaries(
+    *,
+    label: str,
+    structure: str,
+    motif: str,
+    source_dir: Path,
+    segment_rows: list[DebyeWallerSegmentStatistic],
+) -> list[DebyeWallerPairSummary]:
+    grouped_rows: dict[
+        tuple[str, str, str, str, str],
+        list[DebyeWallerSegmentStatistic],
+    ] = defaultdict(list)
+    for row in segment_rows:
+        grouped_rows[
+            (
+                row.scope,
+                row.type_definition,
+                row.pair_label_a,
+                row.pair_label_b,
+                row.pair_label,
+            )
+        ].append(row)
+
+    summaries: list[DebyeWallerPairSummary] = []
+    for grouped_key in sorted(grouped_rows):
+        rows = grouped_rows[grouped_key]
+        sigma_values = [float(row.sigma) for row in rows]
+        sigma_squared_values = [float(row.sigma_squared) for row in rows]
+        b_values = [float(row.b_factor) for row in rows]
+        pair_counts = [float(row.pair_count) for row in rows]
+        mean_distances = [float(row.mean_distance_a) for row in rows]
+        summaries.append(
+            DebyeWallerPairSummary(
+                stoichiometry_label=label,
+                structure=structure,
+                motif=motif,
+                source_dir=source_dir,
+                scope=grouped_key[0],
+                type_definition=grouped_key[1],
+                pair_label_a=grouped_key[2],
+                pair_label_b=grouped_key[3],
+                pair_label=grouped_key[4],
+                segment_count=len(rows),
+                mean_pair_count=_safe_float_mean(pair_counts),
+                mean_distance_a=_safe_float_mean(mean_distances),
+                sigma_mean=_safe_float_mean(sigma_values),
+                sigma_std=_safe_float_std(sigma_values),
+                sigma_squared_mean=_safe_float_mean(sigma_squared_values),
+                sigma_squared_std=_safe_float_std(sigma_squared_values),
+                b_factor_mean=_safe_float_mean(b_values),
+                b_factor_std=_safe_float_std(b_values),
+            )
+        )
+    return summaries
+
+
+def _build_scope_summaries(
+    *,
+    label: str,
+    structure: str,
+    motif: str,
+    source_dir: Path,
+    segment_rows: list[DebyeWallerSegmentStatistic],
+) -> list[DebyeWallerScopeSummary]:
+    grouped_rows: dict[str, list[DebyeWallerSegmentStatistic]] = defaultdict(
+        list
+    )
+    for row in segment_rows:
+        grouped_rows[row.scope].append(row)
+
+    scope_summaries: list[DebyeWallerScopeSummary] = []
+    for scope in sorted(grouped_rows):
+        rows = grouped_rows[scope]
+        sigma_values = [float(row.sigma) for row in rows]
+        sigma_squared_values = [float(row.sigma_squared) for row in rows]
+        b_values = [float(row.b_factor) for row in rows]
+        pair_counts = [float(row.pair_count) for row in rows]
+        scope_summaries.append(
+            DebyeWallerScopeSummary(
+                stoichiometry_label=label,
+                structure=structure,
+                motif=motif,
+                source_dir=source_dir,
+                scope=scope,
+                segment_count=len(rows),
+                mean_pair_count=_safe_float_mean(pair_counts),
+                sigma_mean=_safe_float_mean(sigma_values),
+                sigma_std=_safe_float_std(sigma_values),
+                sigma_squared_mean=_safe_float_mean(sigma_squared_values),
+                sigma_squared_std=_safe_float_std(sigma_squared_values),
+                b_factor_mean=_safe_float_mean(b_values),
+                b_factor_std=_safe_float_std(b_values),
+            )
+        )
+    return scope_summaries
+
+
+def build_debye_waller_aggregated_pair_summaries(
+    stoichiometry_results: (
+        tuple[DebyeWallerStoichiometryResult, ...]
+        | list[DebyeWallerStoichiometryResult]
+    ),
+) -> tuple[DebyeWallerAggregatedPairSummary, ...]:
+    grouped_rows: dict[
+        tuple[str, str, str, str, str],
+        list[DebyeWallerSegmentStatistic],
+    ] = defaultdict(list)
+    contributing_stoichiometries: dict[
+        tuple[str, str, str, str, str],
+        set[str],
+    ] = defaultdict(set)
+    for stoichiometry in stoichiometry_results:
+        seen_keys: set[tuple[str, str, str, str, str]] = set()
+        for row in stoichiometry.segment_statistics:
+            grouped_key = (
+                row.scope,
+                row.type_definition,
+                row.pair_label_a,
+                row.pair_label_b,
+                row.pair_label,
+            )
+            grouped_rows[grouped_key].append(row)
+            if grouped_key not in seen_keys:
+                contributing_stoichiometries[grouped_key].add(
+                    stoichiometry.label
+                )
+                seen_keys.add(grouped_key)
+
+    summaries: list[DebyeWallerAggregatedPairSummary] = []
+    for grouped_key in sorted(grouped_rows):
+        rows = grouped_rows[grouped_key]
+        sigma_values = [float(row.sigma) for row in rows]
+        sigma_squared_values = [float(row.sigma_squared) for row in rows]
+        b_values = [float(row.b_factor) for row in rows]
+        pair_counts = [float(row.pair_count) for row in rows]
+        mean_distances = [float(row.mean_distance_a) for row in rows]
+        summaries.append(
+            DebyeWallerAggregatedPairSummary(
+                scope=grouped_key[0],
+                type_definition=grouped_key[1],
+                pair_label_a=grouped_key[2],
+                pair_label_b=grouped_key[3],
+                pair_label=grouped_key[4],
+                stoichiometry_count=len(
+                    contributing_stoichiometries[grouped_key]
+                ),
+                segment_count=len(rows),
+                mean_pair_count=_safe_float_mean(pair_counts),
+                mean_distance_a=_safe_float_mean(mean_distances),
+                sigma_mean=_safe_float_mean(sigma_values),
+                sigma_std=_safe_float_std(sigma_values),
+                sigma_squared_mean=_safe_float_mean(sigma_squared_values),
+                sigma_squared_std=_safe_float_std(sigma_squared_values),
+                b_factor_mean=_safe_float_mean(b_values),
+                b_factor_std=_safe_float_std(b_values),
+            )
+        )
+    return tuple(summaries)
+
+
+def write_debye_waller_outputs(
+    result: DebyeWallerAnalysisResult,
+    output_dir: str | Path,
+    *,
+    basename: str = "debye_waller_analysis",
+) -> DebyeWallerOutputArtifacts:
+    resolved_output_dir = Path(output_dir).expanduser().resolve()
+    resolved_output_dir.mkdir(parents=True, exist_ok=True)
+    safe_basename = _safe_output_basename(basename)
+
+    summary_json_path = resolved_output_dir / f"{safe_basename}.json"
+    aggregated_pair_summary_csv_path = (
+        resolved_output_dir / f"{safe_basename}_aggregated_pairs.csv"
+    )
+    pair_summary_csv_path = resolved_output_dir / f"{safe_basename}_pairs.csv"
+    scope_summary_csv_path = (
+        resolved_output_dir / f"{safe_basename}_scopes.csv"
+    )
+    segment_csv_path = resolved_output_dir / f"{safe_basename}_segments.csv"
+
+    aggregated_pair_rows = [
+        summary.to_dict() for summary in result.aggregated_pair_summaries
+    ]
+    pair_rows = [
+        summary.to_dict()
+        for stoichiometry in result.stoichiometry_results
+        for summary in stoichiometry.pair_summaries
+    ]
+    scope_rows = [
+        summary.to_dict()
+        for stoichiometry in result.stoichiometry_results
+        for summary in stoichiometry.scope_summaries
+    ]
+    segment_rows = [
+        summary.to_dict()
+        for stoichiometry in result.stoichiometry_results
+        for summary in stoichiometry.segment_statistics
+    ]
+
+    with pair_summary_csv_path.open(
+        "w", encoding="utf-8", newline=""
+    ) as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "stoichiometry_label",
+                "structure",
+                "motif",
+                "source_dir",
+                "scope",
+                "type_definition",
+                "pair_label_a",
+                "pair_label_b",
+                "pair_label",
+                "segment_count",
+                "mean_pair_count",
+                "mean_distance_a",
+                "sigma_mean",
+                "sigma_std",
+                "sigma_squared_mean",
+                "sigma_squared_std",
+                "b_factor_mean",
+                "b_factor_std",
+            ],
+        )
+        writer.writeheader()
+        writer.writerows(pair_rows)
+
+    with scope_summary_csv_path.open(
+        "w",
+        encoding="utf-8",
+        newline="",
+    ) as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "stoichiometry_label",
+                "structure",
+                "motif",
+                "source_dir",
+                "scope",
+                "segment_count",
+                "mean_pair_count",
+                "sigma_mean",
+                "sigma_std",
+                "sigma_squared_mean",
+                "sigma_squared_std",
+                "b_factor_mean",
+                "b_factor_std",
+            ],
+        )
+        writer.writeheader()
+        writer.writerows(scope_rows)
+
+    with segment_csv_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "stoichiometry_label",
+                "structure",
+                "motif",
+                "source_dir",
+                "segment_index",
+                "series_label",
+                "frame_start",
+                "frame_end",
+                "frame_count",
+                "scope",
+                "type_definition",
+                "pair_label_a",
+                "pair_label_b",
+                "pair_label",
+                "pair_count",
+                "mean_distance_a",
+                "sigma",
+                "sigma_squared",
+                "b_factor",
+            ],
+        )
+        writer.writeheader()
+        writer.writerows(segment_rows)
+
+    with aggregated_pair_summary_csv_path.open(
+        "w",
+        encoding="utf-8",
+        newline="",
+    ) as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "scope",
+                "type_definition",
+                "pair_label_a",
+                "pair_label_b",
+                "pair_label",
+                "stoichiometry_count",
+                "segment_count",
+                "mean_pair_count",
+                "mean_distance_a",
+                "sigma_mean",
+                "sigma_std",
+                "sigma_squared_mean",
+                "sigma_squared_std",
+                "b_factor_mean",
+                "b_factor_std",
+            ],
+        )
+        writer.writeheader()
+        writer.writerows(aggregated_pair_rows)
+
+    output_payload = result.to_dict()
+    output_payload["artifacts"] = {
+        "output_dir": str(resolved_output_dir),
+        "summary_json_path": str(summary_json_path),
+        "aggregated_pair_summary_csv_path": str(
+            aggregated_pair_summary_csv_path
+        ),
+        "pair_summary_csv_path": str(pair_summary_csv_path),
+        "scope_summary_csv_path": str(scope_summary_csv_path),
+        "segment_csv_path": str(segment_csv_path),
+    }
+    summary_json_path.write_text(
+        json.dumps(output_payload, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+    return DebyeWallerOutputArtifacts(
+        output_dir=resolved_output_dir,
+        summary_json_path=summary_json_path,
+        aggregated_pair_summary_csv_path=aggregated_pair_summary_csv_path,
+        pair_summary_csv_path=pair_summary_csv_path,
+        scope_summary_csv_path=scope_summary_csv_path,
+        segment_csv_path=segment_csv_path,
+    )
+
+
+def project_debye_waller_dir(project_dir: str | Path) -> Path:
+    return (
+        build_project_paths(project_dir).exported_data_dir
+        / _PROJECT_DEBYE_WALLER_DIRNAME
+    )
+
+
+def project_saved_debye_waller_dir(project_dir: str | Path) -> Path:
+    return (
+        project_debye_waller_dir(project_dir)
+        / _PROJECT_DEBYE_WALLER_SAVED_DIRNAME
+    )
+
+
+def _is_debye_waller_analysis_payload(payload: object) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    inspection = payload.get("inspection")
+    stoichiometry_results = payload.get("stoichiometry_results")
+    return isinstance(inspection, dict) and isinstance(
+        stoichiometry_results,
+        list,
+    )
+
+
+def _load_contiguous_frame_set_summary(
+    payload: dict[str, object],
+) -> DebyeWallerContiguousFrameSetSummary:
+    return DebyeWallerContiguousFrameSetSummary(
+        series_label=str(payload.get("series_label", "")),
+        frame_ids=tuple(
+            int(value) for value in (payload.get("frame_ids") or [])
+        ),
+        frame_labels=tuple(
+            str(value) for value in (payload.get("frame_labels") or [])
+        ),
+        file_paths=tuple(
+            Path(str(value)).expanduser().resolve()
+            for value in (payload.get("file_paths") or [])
+        ),
+    )
+
+
+def _load_segment_statistic(
+    payload: dict[str, object],
+) -> DebyeWallerSegmentStatistic:
+    return DebyeWallerSegmentStatistic(
+        stoichiometry_label=str(payload.get("stoichiometry_label", "")),
+        structure=str(payload.get("structure", "")),
+        motif=str(payload.get("motif", "")),
+        source_dir=Path(str(payload.get("source_dir", ".")))
+        .expanduser()
+        .resolve(),
+        segment_index=int(payload.get("segment_index", 0) or 0),
+        series_label=str(payload.get("series_label", "")),
+        frame_start=(
+            None
+            if payload.get("frame_start") in (None, "")
+            else int(payload.get("frame_start"))
+        ),
+        frame_end=(
+            None
+            if payload.get("frame_end") in (None, "")
+            else int(payload.get("frame_end"))
+        ),
+        frame_count=int(payload.get("frame_count", 0) or 0),
+        scope=str(payload.get("scope", "")),
+        type_definition=str(payload.get("type_definition", "")),
+        pair_label_a=str(payload.get("pair_label_a", "")),
+        pair_label_b=str(payload.get("pair_label_b", "")),
+        pair_label=str(payload.get("pair_label", "")),
+        pair_count=int(payload.get("pair_count", 0) or 0),
+        mean_distance_a=float(payload.get("mean_distance_a", 0.0) or 0.0),
+        sigma=float(payload.get("sigma", 0.0) or 0.0),
+        sigma_squared=float(payload.get("sigma_squared", 0.0) or 0.0),
+        b_factor=float(payload.get("b_factor", 0.0) or 0.0),
+    )
+
+
+def _load_pair_summary(
+    payload: dict[str, object],
+) -> DebyeWallerPairSummary:
+    return DebyeWallerPairSummary(
+        stoichiometry_label=str(payload.get("stoichiometry_label", "")),
+        structure=str(payload.get("structure", "")),
+        motif=str(payload.get("motif", "")),
+        source_dir=Path(str(payload.get("source_dir", ".")))
+        .expanduser()
+        .resolve(),
+        scope=str(payload.get("scope", "")),
+        type_definition=str(payload.get("type_definition", "")),
+        pair_label_a=str(payload.get("pair_label_a", "")),
+        pair_label_b=str(payload.get("pair_label_b", "")),
+        pair_label=str(payload.get("pair_label", "")),
+        segment_count=int(payload.get("segment_count", 0) or 0),
+        mean_pair_count=float(payload.get("mean_pair_count", 0.0) or 0.0),
+        mean_distance_a=float(payload.get("mean_distance_a", 0.0) or 0.0),
+        sigma_mean=float(payload.get("sigma_mean", 0.0) or 0.0),
+        sigma_std=float(payload.get("sigma_std", 0.0) or 0.0),
+        sigma_squared_mean=float(
+            payload.get("sigma_squared_mean", 0.0) or 0.0
+        ),
+        sigma_squared_std=float(payload.get("sigma_squared_std", 0.0) or 0.0),
+        b_factor_mean=float(payload.get("b_factor_mean", 0.0) or 0.0),
+        b_factor_std=float(payload.get("b_factor_std", 0.0) or 0.0),
+    )
+
+
+def _load_scope_summary(
+    payload: dict[str, object],
+) -> DebyeWallerScopeSummary:
+    return DebyeWallerScopeSummary(
+        stoichiometry_label=str(payload.get("stoichiometry_label", "")),
+        structure=str(payload.get("structure", "")),
+        motif=str(payload.get("motif", "")),
+        source_dir=Path(str(payload.get("source_dir", ".")))
+        .expanduser()
+        .resolve(),
+        scope=str(payload.get("scope", "")),
+        segment_count=int(payload.get("segment_count", 0) or 0),
+        mean_pair_count=float(payload.get("mean_pair_count", 0.0) or 0.0),
+        sigma_mean=float(payload.get("sigma_mean", 0.0) or 0.0),
+        sigma_std=float(payload.get("sigma_std", 0.0) or 0.0),
+        sigma_squared_mean=float(
+            payload.get("sigma_squared_mean", 0.0) or 0.0
+        ),
+        sigma_squared_std=float(payload.get("sigma_squared_std", 0.0) or 0.0),
+        b_factor_mean=float(payload.get("b_factor_mean", 0.0) or 0.0),
+        b_factor_std=float(payload.get("b_factor_std", 0.0) or 0.0),
+    )
+
+
+def _load_aggregated_pair_summary(
+    payload: dict[str, object],
+) -> DebyeWallerAggregatedPairSummary:
+    return DebyeWallerAggregatedPairSummary(
+        scope=str(payload.get("scope", "")),
+        type_definition=str(payload.get("type_definition", "")),
+        pair_label_a=str(payload.get("pair_label_a", "")),
+        pair_label_b=str(payload.get("pair_label_b", "")),
+        pair_label=str(payload.get("pair_label", "")),
+        stoichiometry_count=int(payload.get("stoichiometry_count", 0) or 0),
+        segment_count=int(payload.get("segment_count", 0) or 0),
+        mean_pair_count=float(payload.get("mean_pair_count", 0.0) or 0.0),
+        mean_distance_a=float(payload.get("mean_distance_a", 0.0) or 0.0),
+        sigma_mean=float(payload.get("sigma_mean", 0.0) or 0.0),
+        sigma_std=float(payload.get("sigma_std", 0.0) or 0.0),
+        sigma_squared_mean=float(
+            payload.get("sigma_squared_mean", 0.0) or 0.0
+        ),
+        sigma_squared_std=float(payload.get("sigma_squared_std", 0.0) or 0.0),
+        b_factor_mean=float(payload.get("b_factor_mean", 0.0) or 0.0),
+        b_factor_std=float(payload.get("b_factor_std", 0.0) or 0.0),
+    )
+
+
+def _load_stoichiometry_info_summary(
+    payload: dict[str, object] | None,
+) -> DebyeWallerStoichiometryInfoSummary | None:
+    if not isinstance(payload, dict):
+        return None
+    return DebyeWallerStoichiometryInfoSummary(
+        stoichiometry_label=str(payload.get("stoichiometry_label", "")),
+        structure=str(payload.get("structure", "")),
+        motif=str(payload.get("motif", "")),
+        source_dir=Path(str(payload.get("source_dir", ".")))
+        .expanduser()
+        .resolve(),
+        input_file_count=int(payload.get("input_file_count", 0) or 0),
+        processed_frame_count=int(
+            payload.get("processed_frame_count", 0) or 0
+        ),
+        total_frame_count=int(payload.get("total_frame_count", 0) or 0),
+        processed_frame_set_count=int(
+            payload.get("processed_frame_set_count", 0) or 0
+        ),
+        total_frame_set_count=int(
+            payload.get("total_frame_set_count", 0) or 0
+        ),
+        average_frames_per_set=float(
+            payload.get("average_frames_per_set", 0.0) or 0.0
+        ),
+        min_frames_per_set=int(payload.get("min_frames_per_set", 0) or 0),
+        max_frames_per_set=int(payload.get("max_frames_per_set", 0) or 0),
+        average_atoms_per_frame=float(
+            payload.get("average_atoms_per_frame", 0.0) or 0.0
+        ),
+        average_molecules_per_frame=float(
+            payload.get("average_molecules_per_frame", 0.0) or 0.0
+        ),
+        average_solvent_like_molecules_per_frame=float(
+            payload.get("average_solvent_like_molecules_per_frame", 0.0) or 0.0
+        ),
+        average_shared_atom_sites_per_set=float(
+            payload.get("average_shared_atom_sites_per_set", 0.0) or 0.0
+        ),
+        unique_residue_name_count=int(
+            payload.get("unique_residue_name_count", 0) or 0
+        ),
+        unique_residue_names=tuple(
+            str(value) for value in (payload.get("unique_residue_names") or [])
+        ),
+        unique_element_count=int(payload.get("unique_element_count", 0) or 0),
+        unique_elements=tuple(
+            str(value) for value in (payload.get("unique_elements") or [])
+        ),
+        most_common_molecule_signature=str(
+            payload.get("most_common_molecule_signature", "")
+        ),
+        solvent_like_molecule_signature=str(
+            payload.get("solvent_like_molecule_signature", "")
+        ),
+    )
+
+
+def _load_stoichiometry_result(
+    payload: dict[str, object],
+) -> DebyeWallerStoichiometryResult:
+    return DebyeWallerStoichiometryResult(
+        label=str(payload.get("label", "")),
+        structure=str(payload.get("structure", "")),
+        motif=str(payload.get("motif", "")),
+        source_dir=Path(str(payload.get("source_dir", ".")))
+        .expanduser()
+        .resolve(),
+        input_file_count=int(payload.get("input_file_count", 0) or 0),
+        contiguous_frame_sets=tuple(
+            _load_contiguous_frame_set_summary(entry)
+            for entry in (payload.get("contiguous_frame_sets") or [])
+            if isinstance(entry, dict)
+        ),
+        pair_summaries=tuple(
+            _load_pair_summary(entry)
+            for entry in (payload.get("pair_summaries") or [])
+            if isinstance(entry, dict)
+        ),
+        scope_summaries=tuple(
+            _load_scope_summary(entry)
+            for entry in (payload.get("scope_summaries") or [])
+            if isinstance(entry, dict)
+        ),
+        segment_statistics=tuple(
+            _load_segment_statistic(entry)
+            for entry in (payload.get("segment_statistics") or [])
+            if isinstance(entry, dict)
+        ),
+        info_summary=_load_stoichiometry_info_summary(
+            payload.get("info_summary")
+        ),
+        notes=tuple(str(note) for note in (payload.get("notes") or [])),
+    )
+
+
+def _load_input_inspection(
+    payload: dict[str, object],
+) -> DebyeWallerInputInspection:
+    return DebyeWallerInputInspection(
+        clusters_dir=Path(str(payload.get("clusters_dir", ".")))
+        .expanduser()
+        .resolve(),
+        stoichiometry_labels=tuple(
+            str(value) for value in (payload.get("stoichiometry_labels") or [])
+        ),
+        total_structure_files=int(
+            payload.get("total_structure_files", 0) or 0
+        ),
+        invalid_xyz_files=tuple(
+            Path(str(value)).expanduser().resolve()
+            for value in (payload.get("invalid_xyz_files") or [])
+        ),
+    )
+
+
+def _load_output_artifacts(
+    payload: dict[str, object] | None,
+) -> DebyeWallerOutputArtifacts | None:
+    if not isinstance(payload, dict):
+        return None
+    summary_json_path = (
+        Path(str(payload.get("summary_json_path", "."))).expanduser().resolve()
+    )
+    return DebyeWallerOutputArtifacts(
+        output_dir=Path(str(payload.get("output_dir", ".")))
+        .expanduser()
+        .resolve(),
+        summary_json_path=summary_json_path,
+        aggregated_pair_summary_csv_path=Path(
+            str(
+                payload.get(
+                    "aggregated_pair_summary_csv_path",
+                    summary_json_path.with_name(
+                        f"{summary_json_path.stem}_aggregated_pairs.csv"
+                    ),
+                )
+            )
+        )
+        .expanduser()
+        .resolve(),
+        pair_summary_csv_path=Path(
+            str(payload.get("pair_summary_csv_path", "."))
+        )
+        .expanduser()
+        .resolve(),
+        scope_summary_csv_path=Path(
+            str(payload.get("scope_summary_csv_path", "."))
+        )
+        .expanduser()
+        .resolve(),
+        segment_csv_path=Path(str(payload.get("segment_csv_path", ".")))
+        .expanduser()
+        .resolve(),
+    )
+
+
+def load_debye_waller_analysis_result(
+    summary_path: str | Path,
+) -> DebyeWallerAnalysisResult:
+    resolved_summary_path = Path(summary_path).expanduser().resolve()
+    payload = json.loads(resolved_summary_path.read_text(encoding="utf-8"))
+    if not _is_debye_waller_analysis_payload(payload):
+        raise ValueError(
+            f"{resolved_summary_path} does not contain a Debye-Waller analysis payload."
+        )
+    inspection_payload = payload.get("inspection")
+    stoichiometry_results = tuple(
+        _load_stoichiometry_result(entry)
+        for entry in (payload.get("stoichiometry_results") or [])
+        if isinstance(entry, dict)
+    )
+    aggregated_pair_payloads = tuple(
+        _load_aggregated_pair_summary(entry)
+        for entry in (payload.get("aggregated_pair_summaries") or [])
+        if isinstance(entry, dict)
+    )
+    return DebyeWallerAnalysisResult(
+        created_at=str(payload.get("created_at", "")),
+        clusters_dir=Path(str(payload.get("clusters_dir", ".")))
+        .expanduser()
+        .resolve(),
+        project_dir=(
+            None
+            if payload.get("project_dir") in (None, "")
+            else Path(str(payload.get("project_dir"))).expanduser().resolve()
+        ),
+        output_dir=Path(str(payload.get("output_dir", ".")))
+        .expanduser()
+        .resolve(),
+        inspection=_load_input_inspection(
+            inspection_payload if isinstance(inspection_payload, dict) else {}
+        ),
+        stoichiometry_results=stoichiometry_results,
+        aggregated_pair_summaries=(
+            aggregated_pair_payloads
+            if aggregated_pair_payloads
+            else build_debye_waller_aggregated_pair_summaries(
+                stoichiometry_results
+            )
+        ),
+        notes=tuple(str(note) for note in (payload.get("notes") or [])),
+        artifacts=_load_output_artifacts(payload.get("artifacts")),
+    )
+
+
+def find_saved_project_debye_waller_analysis(
+    project_dir: str | Path,
+) -> Path | None:
+    root_dir = project_debye_waller_dir(project_dir)
+    if not root_dir.is_dir():
+        return None
+    preferred_path = (
+        project_saved_debye_waller_dir(project_dir)
+        / f"{_PROJECT_DEBYE_WALLER_SAVED_BASENAME}.json"
+    )
+    candidates: list[Path] = []
+    if preferred_path.is_file():
+        candidates.append(preferred_path)
+    candidates.extend(
+        sorted(
+            (
+                path
+                for path in root_dir.rglob("*.json")
+                if path.is_file() and path != preferred_path
+            ),
+            key=lambda path: (
+                -path.stat().st_mtime,
+                path.name.lower(),
+            ),
+        )
+    )
+    for candidate in candidates:
+        try:
+            load_debye_waller_analysis_result(candidate)
+        except Exception:
+            continue
+        return candidate
+    return None
+
+
+def save_debye_waller_analysis_to_project(
+    result: DebyeWallerAnalysisResult,
+    project_dir: str | Path,
+) -> DebyeWallerAnalysisResult:
+    resolved_project_dir = Path(project_dir).expanduser().resolve()
+    saved_dir = project_saved_debye_waller_dir(resolved_project_dir)
+    base_result = DebyeWallerAnalysisResult(
+        created_at=result.created_at,
+        clusters_dir=result.clusters_dir,
+        project_dir=resolved_project_dir,
+        output_dir=saved_dir,
+        inspection=result.inspection,
+        stoichiometry_results=result.stoichiometry_results,
+        aggregated_pair_summaries=result.aggregated_pair_summaries,
+        notes=result.notes,
+        artifacts=None,
+    )
+    artifacts = write_debye_waller_outputs(
+        base_result,
+        saved_dir,
+        basename=_PROJECT_DEBYE_WALLER_SAVED_BASENAME,
+    )
+    return DebyeWallerAnalysisResult(
+        created_at=base_result.created_at,
+        clusters_dir=base_result.clusters_dir,
+        project_dir=base_result.project_dir,
+        output_dir=base_result.output_dir,
+        inspection=base_result.inspection,
+        stoichiometry_results=base_result.stoichiometry_results,
+        aggregated_pair_summaries=base_result.aggregated_pair_summaries,
+        notes=base_result.notes,
+        artifacts=artifacts,
+    )
+
+
+class DebyeWallerWorkflow:
+    """Estimate segment-aware Debye-Waller coefficients from cluster
+    PDBs."""
+
+    def __init__(
+        self,
+        clusters_dir: str | Path,
+        *,
+        project_dir: str | Path | None = None,
+        output_dir: str | Path | None = None,
+        output_basename: str = "debye_waller_analysis",
+    ) -> None:
+        self.clusters_dir = Path(clusters_dir).expanduser().resolve()
+        self.project_dir = (
+            None
+            if project_dir is None
+            else Path(project_dir).expanduser().resolve()
+        )
+        self.output_dir = (
+            suggest_output_dir(self.clusters_dir, project_dir=self.project_dir)
+            if output_dir is None
+            else Path(output_dir).expanduser().resolve()
+        )
+        self.output_basename = _safe_output_basename(output_basename)
+
+    def inspect(self) -> DebyeWallerInputInspection:
+        return inspect_debye_waller_input(self.clusters_dir)
+
+    def run(
+        self,
+        *,
+        progress_callback: DebyeWallerProgressCallback | None = None,
+        log_callback: DebyeWallerLogCallback | None = None,
+        stoichiometry_callback: DebyeWallerStoichiometryCallback | None = None,
+    ) -> DebyeWallerAnalysisResult:
+        inspection = self.inspect()
+        cluster_bins = discover_cluster_bins(self.clusters_dir)
+        if not cluster_bins:
+            raise ValueError(
+                "No recognized stoichiometry folders were found in the "
+                "selected clusters directory."
+            )
+        if inspection.invalid_xyz_files:
+            file_list = "\n".join(
+                f"- {path}" for path in inspection.invalid_xyz_files[:10]
+            )
+            raise ValueError(
+                "Debye-Waller analysis requires PDB cluster files only. "
+                "Remove or convert the following XYZ inputs before running:\n"
+                f"{file_list}"
+            )
+
+        total_steps = len(cluster_bins) + 1
+        if progress_callback is not None:
+            progress_callback(
+                0,
+                total_steps,
+                "Inspecting sorted PDB cluster bins and validating input.",
+            )
+        if log_callback is not None:
+            log_callback("Starting Debye-Waller analysis.")
+            log_callback(
+                "Validated "
+                f"{inspection.total_structure_files} structure file(s) across "
+                f"{len(cluster_bins)} stoichiometry label(s) in "
+                f"{self.clusters_dir}."
+            )
+            log_callback(
+                "Output will be written to "
+                f"{self.output_dir} with basename "
+                f"{self.output_basename}."
+            )
+
+        stoichiometry_results: list[DebyeWallerStoichiometryResult] = []
+        global_notes: list[str] = [
+            "Intra/inter molecule membership follows fullrmc-style PDB "
+            "grouping by residue name, sequence identifier, and segment "
+            "identifier.",
+            "Intra-molecular pair types are grouped by residue-qualified atom "
+            "names, while inter-molecular pair types are grouped by element "
+            "pairs.",
+        ]
+
+        for step_index, cluster_bin in enumerate(cluster_bins, start=1):
+            label = (
+                cluster_bin.structure
+                if cluster_bin.motif == "no_motif"
+                else f"{cluster_bin.structure}/{cluster_bin.motif}"
+            )
+            message = (
+                f"Preparing Debye-Waller evaluation for {label} "
+                f"({len(cluster_bin.files)} frame files)."
+            )
+            if progress_callback is not None:
+                progress_callback(step_index, total_steps, message)
+            if log_callback is not None:
+                log_callback(message)
+
+            frame_sets, contiguous_note = _detect_contiguous_frame_sets(
+                tuple(cluster_bin.files)
+            )
+            notes: list[str] = []
+            if contiguous_note is not None:
+                notes.append(contiguous_note)
+            if not frame_sets:
+                notes.append(
+                    f"No contiguous frame sets were detected for {label}."
+                )
+            if log_callback is not None:
+                log_callback(
+                    f"{label}: found {len(frame_sets)} contiguous frame set(s)."
+                )
+                for frame_set_index, frame_set in enumerate(
+                    frame_sets,
+                    start=1,
+                ):
+                    log_callback(
+                        f"{label}: frame set {frame_set_index}/"
+                        f"{len(frame_sets)} spans "
+                        f"{_frame_set_range_label(frame_set)} in "
+                        f"series '{frame_set.series_label}'."
+                    )
+                if contiguous_note is not None:
+                    log_callback(f"{label}: {contiguous_note}")
+
+            segment_rows: list[DebyeWallerSegmentStatistic] = []
+            processed_frame_metadata: list[_DebyeWallerFrameMetadata] = []
+            processed_aligned_atom_counts: list[int] = []
+            partial_result: DebyeWallerStoichiometryResult | None = None
+            for segment_index, frame_set in enumerate(frame_sets, start=1):
+                if progress_callback is not None:
+                    progress_callback(
+                        step_index,
+                        total_steps,
+                        f"{label}: analyzing frame set {segment_index}/"
+                        f"{len(frame_sets)} spanning "
+                        f"{_frame_set_range_label(frame_set)}.",
+                    )
+                if log_callback is not None:
+                    log_callback(
+                        f"{label}: analyzing frame set {segment_index}/"
+                        f"{len(frame_sets)} spanning "
+                        f"{_frame_set_range_label(frame_set)}."
+                    )
+                (
+                    computed_rows,
+                    segment_notes,
+                    frame_metadata,
+                    aligned_atom_count,
+                ) = _compute_segment_statistics(
+                    label=label,
+                    structure=cluster_bin.structure,
+                    motif=cluster_bin.motif,
+                    source_dir=cluster_bin.source_dir,
+                    segment_index=segment_index,
+                    frame_set=frame_set,
+                )
+                segment_rows.extend(computed_rows)
+                notes.extend(segment_notes)
+                processed_frame_metadata.extend(frame_metadata)
+                processed_aligned_atom_counts.append(aligned_atom_count)
+                partial_result = DebyeWallerStoichiometryResult(
+                    label=label,
+                    structure=cluster_bin.structure,
+                    motif=cluster_bin.motif,
+                    source_dir=cluster_bin.source_dir,
+                    input_file_count=len(cluster_bin.files),
+                    contiguous_frame_sets=frame_sets,
+                    pair_summaries=tuple(
+                        _build_pair_summaries(
+                            label=label,
+                            structure=cluster_bin.structure,
+                            motif=cluster_bin.motif,
+                            source_dir=cluster_bin.source_dir,
+                            segment_rows=segment_rows,
+                        )
+                    ),
+                    scope_summaries=tuple(
+                        _build_scope_summaries(
+                            label=label,
+                            structure=cluster_bin.structure,
+                            motif=cluster_bin.motif,
+                            source_dir=cluster_bin.source_dir,
+                            segment_rows=segment_rows,
+                        )
+                    ),
+                    segment_statistics=tuple(
+                        sorted(
+                            segment_rows,
+                            key=lambda row: (
+                                row.segment_index,
+                                row.scope,
+                                row.type_definition,
+                                row.pair_label,
+                            ),
+                        )
+                    ),
+                    info_summary=_build_stoichiometry_info_summary(
+                        label=label,
+                        structure=cluster_bin.structure,
+                        motif=cluster_bin.motif,
+                        source_dir=cluster_bin.source_dir,
+                        input_file_count=len(cluster_bin.files),
+                        frame_sets=frame_sets,
+                        processed_frame_metadata=processed_frame_metadata,
+                        processed_aligned_atom_counts=processed_aligned_atom_counts,
+                    ),
+                    notes=tuple(notes),
+                )
+                if log_callback is not None:
+                    if computed_rows:
+                        log_callback(
+                            f"{label}: frame set {segment_index} produced "
+                            f"{len(computed_rows)} segment-level "
+                            "coefficient row(s)."
+                        )
+                        log_callback(
+                            f"{label}: accumulated "
+                            f"{len(partial_result.pair_summaries)} pair-type "
+                            f"summary row(s), "
+                            f"{len(partial_result.scope_summaries)} scope "
+                            f"summary row(s), and "
+                            f"{len(partial_result.segment_statistics)} "
+                            "segment row(s) so far."
+                        )
+                    else:
+                        log_callback(
+                            f"{label}: frame set {segment_index} produced no "
+                            "usable pair-disorder rows."
+                        )
+                    info_summary = partial_result.info_summary
+                    if info_summary is not None:
+                        residue_preview = ", ".join(
+                            info_summary.unique_residue_names[:4]
+                        )
+                        if len(info_summary.unique_residue_names) > 4:
+                            residue_preview += ", ..."
+                        log_callback(
+                            f"{label}: metadata so far -> "
+                            f"{info_summary.processed_frame_count}/"
+                            f"{info_summary.total_frame_count} frame(s) "
+                            f"profiled, "
+                            f"{info_summary.average_atoms_per_frame:.1f} "
+                            "atom(s)/frame, "
+                            f"{info_summary.average_molecules_per_frame:.1f} "
+                            "molecule group(s)/frame, residues "
+                            f"{residue_preview or 'n/a'}."
+                        )
+                if (
+                    stoichiometry_callback is not None
+                    and partial_result is not None
+                ):
+                    stoichiometry_callback(partial_result)
+
+            stoichiometry_result = partial_result
+            if stoichiometry_result is None:
+                stoichiometry_result = DebyeWallerStoichiometryResult(
+                    label=label,
+                    structure=cluster_bin.structure,
+                    motif=cluster_bin.motif,
+                    source_dir=cluster_bin.source_dir,
+                    input_file_count=len(cluster_bin.files),
+                    contiguous_frame_sets=frame_sets,
+                    pair_summaries=tuple(),
+                    scope_summaries=tuple(),
+                    segment_statistics=tuple(),
+                    info_summary=_build_stoichiometry_info_summary(
+                        label=label,
+                        structure=cluster_bin.structure,
+                        motif=cluster_bin.motif,
+                        source_dir=cluster_bin.source_dir,
+                        input_file_count=len(cluster_bin.files),
+                        frame_sets=frame_sets,
+                        processed_frame_metadata=processed_frame_metadata,
+                        processed_aligned_atom_counts=processed_aligned_atom_counts,
+                    ),
+                    notes=tuple(notes),
+                )
+            stoichiometry_results.append(stoichiometry_result)
+            if log_callback is not None:
+                log_callback(
+                    f"{label}: completed with "
+                    f"{len(stoichiometry_result.pair_summaries)} pair-type "
+                    f"summary row(s), "
+                    f"{len(stoichiometry_result.scope_summaries)} scope "
+                    f"summary row(s), and "
+                    f"{len(stoichiometry_result.segment_statistics)} "
+                    "segment row(s)."
+                )
+            if stoichiometry_callback is not None and partial_result is None:
+                stoichiometry_callback(stoichiometry_result)
+
+        created_at = datetime.now(timezone.utc).isoformat()
+        result = DebyeWallerAnalysisResult(
+            created_at=created_at,
+            clusters_dir=self.clusters_dir,
+            project_dir=self.project_dir,
+            output_dir=self.output_dir,
+            inspection=inspection,
+            stoichiometry_results=tuple(stoichiometry_results),
+            aggregated_pair_summaries=build_debye_waller_aggregated_pair_summaries(
+                stoichiometry_results
+            ),
+            notes=tuple(global_notes),
+            artifacts=None,
+        )
+        artifacts = write_debye_waller_outputs(
+            result,
+            self.output_dir,
+            basename=self.output_basename,
+        )
+        finalized = DebyeWallerAnalysisResult(
+            created_at=result.created_at,
+            clusters_dir=result.clusters_dir,
+            project_dir=result.project_dir,
+            output_dir=result.output_dir,
+            inspection=result.inspection,
+            stoichiometry_results=result.stoichiometry_results,
+            aggregated_pair_summaries=result.aggregated_pair_summaries,
+            notes=result.notes,
+            artifacts=artifacts,
+        )
+        if progress_callback is not None:
+            progress_callback(
+                total_steps,
+                total_steps,
+                "Debye-Waller analysis complete.",
+            )
+        if log_callback is not None:
+            log_callback(
+                "Wrote Debye-Waller outputs to " f"{artifacts.output_dir}."
+            )
+        return finalized
+
+
+__all__ = [
+    "DebyeWallerAggregatedPairSummary",
+    "DebyeWallerAnalysisResult",
+    "DebyeWallerContiguousFrameSetSummary",
+    "DebyeWallerInputInspection",
+    "DebyeWallerOutputArtifacts",
+    "DebyeWallerPairSummary",
+    "DebyeWallerScopeSummary",
+    "DebyeWallerSegmentStatistic",
+    "DebyeWallerStoichiometryInfoSummary",
+    "DebyeWallerStoichiometryResult",
+    "DebyeWallerWorkflow",
+    "DebyeWallerStoichiometryCallback",
+    "inspect_debye_waller_input",
+    "build_debye_waller_aggregated_pair_summaries",
+    "find_saved_project_debye_waller_analysis",
+    "load_debye_waller_analysis_result",
+    "project_debye_waller_dir",
+    "project_saved_debye_waller_dir",
+    "save_debye_waller_analysis_to_project",
+    "suggest_output_dir",
+]

--- a/src/saxshell/saxs/electron_density_mapping/__init__.py
+++ b/src/saxshell/saxs/electron_density_mapping/__init__.py
@@ -1,4 +1,6 @@
 from .workflow import (
+    ElectronDensityDebyeScatteringAverageResult,
+    ElectronDensityDebyeWallerPairTerm,
     ElectronDensityInputInspection,
     ElectronDensityMeshGeometry,
     ElectronDensityMeshSettings,
@@ -6,6 +8,7 @@ from .workflow import (
     ElectronDensityProfileResult,
     ElectronDensityStructure,
     build_electron_density_mesh,
+    compute_average_debye_scattering_profile_for_input,
     compute_electron_density_profile,
     inspect_structure_input,
     load_electron_density_structure,
@@ -15,6 +18,8 @@ from .workflow import (
 )
 
 __all__ = [
+    "ElectronDensityDebyeScatteringAverageResult",
+    "ElectronDensityDebyeWallerPairTerm",
     "ElectronDensityInputInspection",
     "ElectronDensityMeshGeometry",
     "ElectronDensityMeshSettings",
@@ -22,6 +27,7 @@ __all__ = [
     "ElectronDensityProfileResult",
     "ElectronDensityStructure",
     "build_electron_density_mesh",
+    "compute_average_debye_scattering_profile_for_input",
     "compute_electron_density_profile",
     "inspect_structure_input",
     "load_electron_density_structure",

--- a/src/saxshell/saxs/electron_density_mapping/ui/main_window.py
+++ b/src/saxshell/saxs/electron_density_mapping/ui/main_window.py
@@ -1,21 +1,39 @@
 from __future__ import annotations
 
 import csv
+import json
 import sys
+from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
+from typing import Callable
 
 import numpy as np
-from PySide6.QtCore import QObject, Qt, QThread, Signal, Slot
+from PySide6.QtCore import (
+    QItemSelectionModel,
+    QObject,
+    QSettings,
+    Qt,
+    QThread,
+    QTimer,
+    Signal,
+    Slot,
+)
+from PySide6.QtGui import QAction, QCloseEvent, QColor
 from PySide6.QtWidgets import (
     QApplication,
+    QButtonGroup,
     QCheckBox,
+    QColorDialog,
     QComboBox,
+    QDialog,
     QDoubleSpinBox,
     QFileDialog,
     QFormLayout,
     QGridLayout,
     QGroupBox,
     QHBoxLayout,
+    QHeaderView,
     QInputDialog,
     QLabel,
     QLayout,
@@ -28,6 +46,8 @@ from PySide6.QtWidgets import (
     QScrollArea,
     QSpinBox,
     QSplitter,
+    QTableWidget,
+    QTableWidgetItem,
     QToolButton,
     QVBoxLayout,
     QWidget,
@@ -37,6 +57,7 @@ from saxshell.saxs.contrast.electron_density import (
     CONTRAST_SOLVENT_METHOD_DIRECT,
     CONTRAST_SOLVENT_METHOD_NEAT,
     CONTRAST_SOLVENT_METHOD_REFERENCE,
+    ContrastElectronDensityEstimate,
     ContrastSolventDensitySettings,
 )
 from saxshell.saxs.contrast.solvents import (
@@ -45,6 +66,11 @@ from saxshell.saxs.contrast.solvents import (
     load_solvent_presets,
     ordered_solvent_preset_names,
     save_custom_solvent_preset,
+)
+from saxshell.saxs.debye import discover_cluster_bins
+from saxshell.saxs.debye_waller import (
+    find_saved_project_debye_waller_analysis,
+    load_debye_waller_analysis_result,
 )
 from saxshell.saxs.electron_density_mapping.ui.viewer import (
     ElectronDensityFourierPreviewPlot,
@@ -55,6 +81,10 @@ from saxshell.saxs.electron_density_mapping.ui.viewer import (
     ElectronDensityStructureViewer,
 )
 from saxshell.saxs.electron_density_mapping.workflow import (
+    ElectronDensityCalculationCanceled,
+    ElectronDensityContiguousFrameSetSummary,
+    ElectronDensityDebyeScatteringAverageResult,
+    ElectronDensityDebyeWallerPairTerm,
     ElectronDensityFourierTransformPreview,
     ElectronDensityFourierTransformSettings,
     ElectronDensityInputInspection,
@@ -64,27 +94,287 @@ from saxshell.saxs.electron_density_mapping.workflow import (
     ElectronDensityProfileResult,
     ElectronDensityScatteringTransformResult,
     ElectronDensitySmearingSettings,
+    ElectronDensitySolventContrastResult,
     ElectronDensityStructure,
     apply_smearing_to_profile_result,
     apply_solvent_contrast_to_profile_result,
     build_electron_density_mesh,
+    compute_average_debye_scattering_profile_for_input,
     compute_electron_density_profile_for_input,
     compute_electron_density_scattering_profile,
+    compute_single_atom_debye_scattering_profile_for_input,
     inspect_structure_input,
     load_electron_density_structure,
     prepare_electron_density_fourier_transform,
+    prepare_single_atom_debye_scattering_preview,
     recenter_electron_density_structure,
     suggest_output_basename,
     suggest_output_dir,
     write_electron_density_profile_outputs,
 )
+from saxshell.saxs.ui._pane_snap import PaneSnapFilter
 from saxshell.saxs.ui.branding import (
     configure_saxshell_application,
     load_saxshell_icon,
     prepare_saxshell_application_identity,
 )
+from saxshell.saxs.ui.progress_dialog import SAXSProgressDialog
 
 _OPEN_WINDOWS: list["ElectronDensityMappingMainWindow"] = []
+_CLUSTER_TRACE_COLORS = (
+    "#b45309",
+    "#2563eb",
+    "#15803d",
+    "#9333ea",
+    "#dc2626",
+    "#0891b2",
+)
+AUTO_SNAP_PANES_KEY = "auto_snap_panes_enabled"
+_FT_COLUMN_STOICHIOMETRY = 0
+_FT_COLUMN_STATUS = 1
+_FT_COLUMN_PROFILE = 2
+_FT_COLUMN_RMIN = 3
+_FT_COLUMN_RMAX = 4
+_FT_COLUMN_QMIN = 5
+_FT_COLUMN_QMAX = 6
+_FT_COLUMN_QSTEP = 7
+_FT_COLUMN_RESAMPLE = 8
+_FT_COLUMN_WINDOW = 9
+_CLUSTER_GROUP_COLUMN_STOICHIOMETRY = 0
+_CLUSTER_GROUP_COLUMN_FILES = 1
+_CLUSTER_GROUP_COLUMN_AVG_ATOMS = 2
+_CLUSTER_GROUP_COLUMN_CENTER_MODE = 3
+_CLUSTER_GROUP_COLUMN_CENTER_REFERENCE = 4
+_CLUSTER_GROUP_COLUMN_CENTER_ELEMENT = 5
+_CLUSTER_GROUP_COLUMN_DENSITY = 6
+_CLUSTER_GROUP_COLUMN_FOURIER = 7
+_CLUSTER_GROUP_COLUMN_TRACE_COLOR = 8
+_CLUSTER_GROUP_COLUMN_SMEARING = 9
+_CLUSTER_GROUP_COLUMN_SOLVENT = 10
+_CLUSTER_GROUP_COLUMN_CUTOFF = 11
+_CLUSTER_GROUP_COLUMN_FT_SETTINGS = 12
+_CLUSTER_GROUP_COLUMN_REFERENCE_FILE = 13
+
+
+def _quick_structure_atom_count(file_path: Path) -> int | None:
+    resolved = Path(file_path).expanduser().resolve()
+    try:
+        with resolved.open(
+            "r",
+            encoding="utf-8",
+            errors="ignore",
+        ) as handle:
+            if resolved.suffix.lower() == ".xyz":
+                atom_count_line = handle.readline()
+                atom_count = int(atom_count_line.strip())
+                return atom_count if atom_count > 0 else None
+            if resolved.suffix.lower() == ".pdb":
+                atom_count = sum(
+                    1
+                    for line in handle
+                    if line.startswith("ATOM") or line.startswith("HETATM")
+                )
+                return atom_count if atom_count > 0 else None
+    except Exception:
+        return None
+    return None
+
+
+def _cluster_trace_color_for_index(index: int) -> str:
+    return _CLUSTER_TRACE_COLORS[index % len(_CLUSTER_TRACE_COLORS)]
+
+
+@dataclass(slots=True)
+class _ClusterDensityGroupState:
+    key: str
+    display_name: str
+    structure_name: str
+    motif_name: str
+    source_dir: Path
+    inspection: ElectronDensityInputInspection
+    reference_structure: ElectronDensityStructure
+    average_atom_count: float
+    single_atom_only: bool
+    trace_color: str
+    profile_result: ElectronDensityProfileResult | None = None
+    transform_result: ElectronDensityScatteringTransformResult | None = None
+    debye_scattering_result: (
+        ElectronDensityDebyeScatteringAverageResult | None
+    ) = None
+    fourier_settings: ElectronDensityFourierTransformSettings | None = None
+    solvent_density_e_per_a3: float | None = None
+    solvent_cutoff_radius_a: float | None = None
+
+
+@dataclass(slots=True)
+class _SavedOutputEntry:
+    entry_id: str
+    created_at: str
+    entry_kind: str
+    input_path: Path | None
+    output_basename: str
+    preview_mode: bool
+    group_key: str | None
+    group_label: str | None
+    use_contiguous_frame_mode: bool
+    profile_result: ElectronDensityProfileResult
+    fourier_settings: ElectronDensityFourierTransformSettings
+    transform_result: ElectronDensityScatteringTransformResult | None = None
+
+
+@dataclass(slots=True)
+class _ElectronDensityWorkspaceLoadPayload:
+    selection_path: Path
+    cluster_states: tuple[_ClusterDensityGroupState, ...] = ()
+    inspection: ElectronDensityInputInspection | None = None
+    structure: ElectronDensityStructure | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class _DebyeComparisonEntry:
+    entry_id: str
+    label: str
+    color: str
+    born_result: ElectronDensityScatteringTransformResult
+    debye_result: ElectronDensityDebyeScatteringAverageResult
+    info_text: str
+
+
+def _build_cluster_group_states_for_path(
+    path: Path,
+    *,
+    progress_callback: Callable[[int, int, str], None] | None = None,
+) -> list[_ClusterDensityGroupState]:
+    resolved = Path(path).expanduser().resolve()
+    if not resolved.is_dir():
+        return []
+    try:
+        cluster_bins = discover_cluster_bins(resolved)
+    except Exception:
+        return []
+    if not cluster_bins:
+        return []
+
+    total_steps = len(cluster_bins) * 2 + 1
+    if progress_callback is not None:
+        progress_callback(
+            0,
+            total_steps,
+            f"Discovered {len(cluster_bins)} stoichiometry folder"
+            f"{'' if len(cluster_bins) == 1 else 's'} in {resolved.name}.",
+        )
+
+    states: list[_ClusterDensityGroupState] = []
+    for index, cluster_bin in enumerate(cluster_bins, start=1):
+        display_name = (
+            cluster_bin.structure
+            if cluster_bin.motif == "no_motif"
+            else f"{cluster_bin.structure}/{cluster_bin.motif}"
+        )
+        inspect_step = (index - 1) * 2 + 1
+        prepared_step = inspect_step + 1
+        if progress_callback is not None:
+            progress_callback(
+                inspect_step,
+                total_steps,
+                f"Loading cluster {index}/{len(cluster_bins)}: {display_name}.",
+            )
+        try:
+            inspection = inspect_structure_input(cluster_bin.source_dir)
+            reference_structure = load_electron_density_structure(
+                inspection.reference_file
+            )
+        except Exception:
+            continue
+
+        atom_counts: list[int] = []
+        for structure_file in inspection.structure_files:
+            atom_count = _quick_structure_atom_count(structure_file)
+            if atom_count is not None:
+                atom_counts.append(atom_count)
+        if not atom_counts:
+            continue
+
+        single_atom_only = len(atom_counts) == inspection.total_files and all(
+            int(atom_count) == 1 for atom_count in atom_counts
+        )
+        states.append(
+            _ClusterDensityGroupState(
+                key=display_name,
+                display_name=display_name,
+                structure_name=cluster_bin.structure,
+                motif_name=cluster_bin.motif,
+                source_dir=cluster_bin.source_dir,
+                inspection=inspection,
+                reference_structure=reference_structure,
+                average_atom_count=float(np.mean(atom_counts)),
+                single_atom_only=single_atom_only,
+                trace_color=_cluster_trace_color_for_index(index - 1),
+            )
+        )
+        if progress_callback is not None:
+            progress_callback(
+                prepared_step,
+                total_steps,
+                f"Prepared cluster {index}/{len(cluster_bins)}: {display_name}.",
+            )
+    return states
+
+
+def _build_workspace_load_payload(
+    path: Path,
+    *,
+    progress_callback: Callable[[int, int, str], None] | None = None,
+) -> _ElectronDensityWorkspaceLoadPayload:
+    resolved = Path(path).expanduser().resolve()
+    cluster_states = _build_cluster_group_states_for_path(
+        resolved,
+        progress_callback=progress_callback,
+    )
+    if cluster_states:
+        return _ElectronDensityWorkspaceLoadPayload(
+            selection_path=resolved,
+            cluster_states=tuple(cluster_states),
+        )
+
+    total_steps = 4
+    if progress_callback is not None:
+        progress_callback(
+            0,
+            total_steps,
+            f"Inspecting inherited input {resolved.name}.",
+        )
+    inspection = inspect_structure_input(resolved)
+    if progress_callback is not None:
+        file_count = inspection.total_files
+        progress_callback(
+            1,
+            total_steps,
+            f"Found {file_count} structure file"
+            f"{'' if file_count == 1 else 's'} in {resolved.name}.",
+        )
+        progress_callback(
+            2,
+            total_steps,
+            f"Loading reference structure {inspection.reference_file.name}.",
+        )
+    structure = load_electron_density_structure(inspection.reference_file)
+    if progress_callback is not None:
+        progress_callback(
+            3,
+            total_steps,
+            "Preparing the inherited electron-density workspace.",
+        )
+        progress_callback(
+            4,
+            total_steps,
+            f"Loaded {inspection.reference_file.name}.",
+        )
+    return _ElectronDensityWorkspaceLoadPayload(
+        selection_path=resolved,
+        inspection=inspection,
+        structure=structure,
+    )
 
 
 class _CollapsibleSection(QWidget):
@@ -119,17 +409,19 @@ class _CollapsibleSection(QWidget):
         header_layout.addWidget(self._toggle_button)
         header_layout.addStretch(1)
         self._body = body
-        self._body.setVisible(False)
+        self._expanded = False
+        self._body.setVisible(self._expanded)
         layout.addWidget(header)
         layout.addWidget(self._body)
 
     def _toggle(self) -> None:
-        self.set_expanded(not self._body.isVisible())
+        self.set_expanded(not self._expanded)
 
     def set_expanded(self, expanded: bool) -> None:
         requested = bool(expanded)
-        if self._body.isVisible() == requested:
+        if self._expanded == requested:
             return
+        self._expanded = requested
         self._body.setVisible(requested)
         self._toggle_button.setArrowType(
             Qt.ArrowType.DownArrow if requested else Qt.ArrowType.RightArrow
@@ -144,29 +436,1194 @@ class _CollapsibleSection(QWidget):
     def collapse(self) -> None:
         self.set_expanded(False)
 
+    def add_header_widget(self, widget: QWidget) -> None:
+        """Append a widget to the right end of the section header
+        row."""
+        header = self.layout().itemAt(0).widget()
+        header.layout().addWidget(widget)
+
     @property
     def is_expanded(self) -> bool:
-        return self._body.isVisible()
+        return self._expanded
+
+
+class _OverlayFigureWidget(QWidget):
+    """A simple matplotlib figure widget used for multi-trace
+    overlays."""
+
+    def __init__(
+        self,
+        title: str,
+        *,
+        figsize: tuple[float, float] = (8.4, 3.4),
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as _FC
+        from matplotlib.backends.backend_qtagg import (
+            NavigationToolbar2QT as _NT,
+        )
+        from matplotlib.figure import Figure as _Fig
+
+        self._title = title
+        self.figure = _Fig(figsize=figsize)
+        self.canvas = _FC(self.figure)
+        self.toolbar = _NT(self.canvas, self)
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(2)
+        layout.addWidget(self.toolbar)
+        self.canvas.setMinimumHeight(260)
+        layout.addWidget(self.canvas, stretch=1)
+        self._draw_placeholder()
+
+    def _draw_placeholder(self) -> None:
+        self.figure.clear()
+        ax = self.figure.add_subplot(111)
+        ax.text(
+            0.5,
+            0.5,
+            "No visible entries.",
+            ha="center",
+            va="center",
+            transform=ax.transAxes,
+        )
+        ax.set_axis_off()
+        self.canvas.draw_idle()
+
+
+class _SavedOutputComparisonDialog(QDialog):
+    def __init__(
+        self,
+        entries: list[_SavedOutputEntry],
+        *,
+        show_variance_shading: bool,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose, True)
+        self.setWindowTitle("Saved Output Comparison")
+        self.resize(1380, 980)
+        self._entries = tuple(entries)
+        self._entry_plot_widgets = self._entries
+        self._show_variance_shading = bool(show_variance_shading)
+        self._trace_colors: dict[str, str] = {
+            entry.entry_id: _cluster_trace_color_for_index(i)
+            for i, entry in enumerate(entries)
+        }
+        self._trace_visibility: dict[str, bool] = {
+            entry.entry_id: True for entry in entries
+        }
+        self._build_ui()
+        self._refresh_plots()
+
+    # ------------------------------------------------------------------
+    # UI construction
+    # ------------------------------------------------------------------
+
+    def _build_ui(self) -> None:
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(10, 10, 10, 10)
+        outer.setSpacing(8)
+
+        controls = QHBoxLayout()
+        controls.setSpacing(6)
+        summary = QLabel(
+            f"Comparing {len(self._entries)} saved output set"
+            f"{'' if len(self._entries) == 1 else 's'}."
+        )
+        summary.setWordWrap(True)
+        controls.addWidget(summary, stretch=1)
+        self.save_all_png_button = QPushButton("Save All PNGs")
+        self.save_all_png_button.clicked.connect(self._save_all_pngs)
+        controls.addWidget(self.save_all_png_button)
+        self.export_all_csv_button = QPushButton("Export All CSVs")
+        self.export_all_csv_button.clicked.connect(self._export_all_csvs)
+        controls.addWidget(self.export_all_csv_button)
+        self.close_button = QPushButton("Close")
+        self.close_button.clicked.connect(self.close)
+        controls.addWidget(self.close_button)
+        outer.addLayout(controls)
+
+        self.status_label = QLabel(
+            "All selected entries are overlaid on shared axes. "
+            "Use the trace table to show/hide or recolour individual traces."
+        )
+        self.status_label.setWordWrap(True)
+        self.status_label.setStyleSheet("color: #475569;")
+        outer.addWidget(self.status_label)
+
+        splitter = QSplitter(Qt.Orientation.Vertical, self)
+
+        # ---- overlay plot panels ----
+        scroll_area = QScrollArea()
+        scroll_area.setWidgetResizable(True)
+        scroll_area.setHorizontalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAsNeeded
+        )
+        container = QWidget()
+        plot_layout = QVBoxLayout(container)
+        plot_layout.setContentsMargins(4, 4, 4, 4)
+        plot_layout.setSpacing(8)
+
+        self._raw_plot = _OverlayFigureWidget(
+            "Orientation-Averaged Radial Electron Density ρ(r)"
+        )
+        self._smeared_plot = _OverlayFigureWidget(
+            "Gaussian-Smeared Radial Electron Density ρ(r)"
+        )
+        self._residual_plot = _OverlayFigureWidget(
+            "Solvent-Subtracted Residual Δρ(r)"
+        )
+        self._fourier_plot = _OverlayFigureWidget(
+            "Fourier-Transform Preparation (Windowed Source)"
+        )
+        self._scatter_plot = _OverlayFigureWidget("q-Space Scattering Profile")
+        for widget in (
+            self._raw_plot,
+            self._smeared_plot,
+            self._residual_plot,
+            self._fourier_plot,
+            self._scatter_plot,
+        ):
+            plot_layout.addWidget(widget)
+        plot_layout.addStretch(1)
+        scroll_area.setWidget(container)
+        splitter.addWidget(scroll_area)
+
+        # ---- trace table ----
+        table_container = QGroupBox("Active Traces")
+        table_layout = QVBoxLayout(table_container)
+        self._trace_table = QTableWidget(0, 4)
+        self._trace_table.setHorizontalHeaderLabels(
+            ["Visible", "Color", "Label", "Info"]
+        )
+        self._trace_table.verticalHeader().setVisible(False)
+        self._trace_table.setSelectionMode(
+            QTableWidget.SelectionMode.NoSelection
+        )
+        hh = self._trace_table.horizontalHeader()
+        hh.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        hh.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
+        hh.setSectionResizeMode(2, QHeaderView.ResizeMode.Stretch)
+        hh.setSectionResizeMode(3, QHeaderView.ResizeMode.Stretch)
+        self._trace_table.setMinimumHeight(120)
+        table_layout.addWidget(self._trace_table)
+        splitter.addWidget(table_container)
+
+        splitter.setSizes([700, 220])
+        outer.addWidget(splitter, stretch=1)
+
+    # ------------------------------------------------------------------
+    # Trace table helpers (PDF-tool style)
+    # ------------------------------------------------------------------
+
+    def _refresh_trace_table(self) -> None:
+        self._trace_table.setRowCount(0)
+        for row, entry in enumerate(self._entries):
+            self._trace_table.insertRow(row)
+            key = entry.entry_id
+
+            visible_box = QCheckBox()
+            visible_box.setChecked(self._trace_visibility.get(key, True))
+            visible_box.toggled.connect(
+                lambda checked, k=key: self._set_trace_visible(k, checked)
+            )
+            self._trace_table.setCellWidget(row, 0, visible_box)
+
+            color_btn = QPushButton()
+            color_btn.clicked.connect(
+                lambda _=False, k=key: self._choose_trace_color(k)
+            )
+            self._configure_color_button(
+                color_btn, self._trace_colors.get(key, "#333333")
+            )
+            self._trace_table.setCellWidget(row, 1, color_btn)
+
+            label_item = QTableWidgetItem(
+                ElectronDensityMappingMainWindow._saved_output_entry_heading(
+                    entry, index=row + 1
+                )
+            )
+            label_item.setFlags(
+                label_item.flags() & ~Qt.ItemFlag.ItemIsEditable
+            )
+            self._trace_table.setItem(row, 2, label_item)
+
+            info_item = QTableWidgetItem(
+                ElectronDensityMappingMainWindow._saved_output_entry_summary_text(
+                    entry
+                )
+            )
+            info_item.setFlags(info_item.flags() & ~Qt.ItemFlag.ItemIsEditable)
+            self._trace_table.setItem(row, 3, info_item)
+
+    def _configure_color_button(self, button: QPushButton, color: str) -> None:
+        qc = QColor(color)
+        text_color = "#000000" if qc.lightnessF() > 0.55 else "#ffffff"
+        button.setText(color)
+        button.setStyleSheet(
+            f"QPushButton {{background-color:{color};color:{text_color};"
+            "padding:3px 8px;}}"
+        )
+
+    def _choose_trace_color(self, entry_id: str) -> None:
+        current = self._trace_colors.get(entry_id, "#333333")
+        chosen = QColorDialog.getColor(
+            QColor(current), self, "Choose trace color"
+        )
+        if not chosen.isValid():
+            return
+        self._trace_colors[entry_id] = chosen.name()
+        self._refresh_trace_table()
+        self._refresh_plots()
+
+    def _set_trace_visible(self, entry_id: str, visible: bool) -> None:
+        self._trace_visibility[entry_id] = bool(visible)
+        self._refresh_plots()
+
+    # ------------------------------------------------------------------
+    # Overlay plot drawing
+    # ------------------------------------------------------------------
+
+    def _refresh_plots(self) -> None:
+        self._refresh_trace_table()
+        self._draw_raw_density()
+        self._draw_smeared_density()
+        self._draw_residual_density()
+        self._draw_fourier_preview()
+        self._draw_scattering_profile()
+
+    def _visible_entries(
+        self,
+    ) -> list[tuple[_SavedOutputEntry, str]]:
+        return [
+            (e, self._trace_colors.get(e.entry_id, "#333333"))
+            for e in self._entries
+            if self._trace_visibility.get(e.entry_id, True)
+        ]
+
+    def _draw_raw_density(self) -> None:
+        pairs = self._visible_entries()
+        fig = self._raw_plot.figure
+        fig.clear()
+        ax = fig.add_subplot(111)
+        if not pairs:
+            ax.text(
+                0.5,
+                0.5,
+                "No visible entries.",
+                ha="center",
+                va="center",
+                transform=ax.transAxes,
+            )
+            ax.set_axis_off()
+            self._raw_plot.canvas.draw_idle()
+            return
+        for entry, color in pairs:
+            result = entry.profile_result
+            radial = np.asarray(result.radial_centers, dtype=float)
+            density = np.asarray(
+                result.orientation_average_density, dtype=float
+            )
+            label = (
+                ElectronDensityMappingMainWindow._saved_output_context_label(
+                    entry
+                )
+            )
+            ax.step(
+                radial,
+                density,
+                where="mid",
+                color=color,
+                linewidth=1.8,
+                label=label,
+            )
+            if self._show_variance_shading:
+                spread = np.asarray(
+                    result.orientation_density_stddev, dtype=float
+                )
+                if np.any(spread > 0.0):
+                    ax.fill_between(
+                        radial,
+                        np.maximum(density - spread, 0.0),
+                        density + spread,
+                        step="mid",
+                        alpha=0.14,
+                        color=color,
+                    )
+        ax.set_xlabel("r (Å)")
+        ax.set_ylabel("ρ(r) (e/Å³)")
+        ax.set_title("Orientation-Averaged Radial Electron Density ρ(r)")
+        ax.grid(True, alpha=0.28)
+        ax.legend(loc="upper right", frameon=True, fontsize=8)
+        fig.tight_layout()
+        self._raw_plot.canvas.draw_idle()
+
+    def _draw_smeared_density(self) -> None:
+        pairs = self._visible_entries()
+        fig = self._smeared_plot.figure
+        fig.clear()
+        ax = fig.add_subplot(111)
+        if not pairs:
+            ax.text(
+                0.5,
+                0.5,
+                "No visible entries.",
+                ha="center",
+                va="center",
+                transform=ax.transAxes,
+            )
+            ax.set_axis_off()
+            self._smeared_plot.canvas.draw_idle()
+            return
+        for entry, color in pairs:
+            result = entry.profile_result
+            radial = np.asarray(result.radial_centers, dtype=float)
+            density = np.asarray(
+                result.smeared_orientation_average_density, dtype=float
+            )
+            label = (
+                ElectronDensityMappingMainWindow._saved_output_context_label(
+                    entry
+                )
+            )
+            ax.plot(radial, density, color=color, linewidth=2.0, label=label)
+            if self._show_variance_shading:
+                spread = np.asarray(
+                    result.smeared_orientation_density_stddev, dtype=float
+                )
+                if np.any(spread > 0.0):
+                    ax.fill_between(
+                        radial,
+                        np.maximum(density - spread, 0.0),
+                        density + spread,
+                        alpha=0.14,
+                        color=color,
+                    )
+            if result.solvent_contrast is not None:
+                contrast = result.solvent_contrast
+                ax.axhline(
+                    float(contrast.solvent_density_e_per_a3),
+                    color=color,
+                    linewidth=1.2,
+                    linestyle=":",
+                    alpha=0.65,
+                )
+        ax.set_xlabel("r (Å)")
+        ax.set_ylabel("ρ(r) (e/Å³)")
+        ax.set_title("Gaussian-Smeared Radial Electron Density ρ(r)")
+        ax.grid(True, alpha=0.28)
+        ax.legend(loc="upper right", frameon=True, fontsize=8)
+        fig.tight_layout()
+        self._smeared_plot.canvas.draw_idle()
+
+    def _draw_residual_density(self) -> None:
+        pairs = self._visible_entries()
+        fig = self._residual_plot.figure
+        fig.clear()
+        ax = fig.add_subplot(111)
+        has_residual = False
+        for entry, color in pairs:
+            result = entry.profile_result
+            if result.solvent_contrast is None:
+                continue
+            contrast = result.solvent_contrast
+            radial = np.asarray(result.radial_centers, dtype=float)
+            residual = np.asarray(
+                contrast.solvent_subtracted_smeared_density, dtype=float
+            )
+            label = (
+                ElectronDensityMappingMainWindow._saved_output_context_label(
+                    entry
+                )
+            )
+            ax.plot(
+                radial,
+                residual,
+                color=color,
+                linewidth=1.8,
+                linestyle="--",
+                label=label,
+            )
+            if self._show_variance_shading:
+                spread = np.asarray(
+                    result.smeared_orientation_density_stddev, dtype=float
+                )
+                if np.any(spread > 0.0):
+                    ax.fill_between(
+                        radial,
+                        residual - spread,
+                        residual + spread,
+                        alpha=0.12,
+                        color=color,
+                    )
+            has_residual = True
+        if not has_residual:
+            ax.text(
+                0.5,
+                0.5,
+                "No solvent contrast data available for selected entries.",
+                ha="center",
+                va="center",
+                transform=ax.transAxes,
+            )
+            ax.set_axis_off()
+            self._residual_plot.canvas.draw_idle()
+            return
+        ax.axhline(
+            0.0, color="#94a3b8", linewidth=1.4, linestyle=":", alpha=0.9
+        )
+        ax.set_xlabel("r (Å)")
+        ax.set_ylabel("Δρ(r) (e/Å³)")
+        ax.set_title("Solvent-Subtracted Residual Δρ(r)")
+        ax.grid(True, alpha=0.28)
+        ax.legend(loc="upper right", frameon=True, fontsize=8)
+        fig.tight_layout()
+        self._residual_plot.canvas.draw_idle()
+
+    def _draw_fourier_preview(self) -> None:
+        pairs = self._visible_entries()
+        fig = self._fourier_plot.figure
+        fig.clear()
+        ax = fig.add_subplot(111)
+        has_preview = False
+        for entry, color in pairs:
+            preview = ElectronDensityMappingMainWindow._preview_for_saved_output_entry(
+                entry
+            )
+            if preview is None:
+                continue
+            resampled_r = np.asarray(preview.resampled_r_values, dtype=float)
+            windowed = np.asarray(preview.windowed_density_values, dtype=float)
+            label = (
+                ElectronDensityMappingMainWindow._saved_output_context_label(
+                    entry
+                )
+            )
+            ax.plot(
+                resampled_r, windowed, color=color, linewidth=1.8, label=label
+            )
+            has_preview = True
+        if not has_preview:
+            ax.text(
+                0.5,
+                0.5,
+                "No Fourier preview data available.",
+                ha="center",
+                va="center",
+                transform=ax.transAxes,
+            )
+            ax.set_axis_off()
+            self._fourier_plot.canvas.draw_idle()
+            return
+        ax.set_xlabel("r (Å)")
+        ax.set_ylabel("ρ(r) (e/Å³)")
+        ax.set_title("Fourier-Transform Preparation (Windowed Source)")
+        ax.grid(True, alpha=0.28)
+        ax.legend(loc="upper right", frameon=True, fontsize=8)
+        fig.tight_layout()
+        self._fourier_plot.canvas.draw_idle()
+
+    def _draw_scattering_profile(self) -> None:
+        pairs = self._visible_entries()
+        fig = self._scatter_plot.figure
+        fig.clear()
+        ax = fig.add_subplot(111)
+        has_scatter = False
+        use_log_q = any(
+            bool(e.fourier_settings.log_q_axis)
+            for e, _ in pairs
+            if e.transform_result is not None
+        )
+        use_log_i = any(
+            bool(e.fourier_settings.log_intensity_axis)
+            for e, _ in pairs
+            if e.transform_result is not None
+        )
+        for entry, color in pairs:
+            if entry.transform_result is None:
+                continue
+            result = entry.transform_result
+            q = np.asarray(result.q_values, dtype=float)
+            intensity = np.asarray(result.intensity, dtype=float)
+            mask = np.ones_like(q, dtype=bool)
+            if use_log_q:
+                mask &= q > 0.0
+            if use_log_i:
+                mask &= intensity > 0.0
+            if not mask.any():
+                continue
+            label = (
+                entry.group_label
+                or ElectronDensityMappingMainWindow._saved_output_context_label(
+                    entry
+                )
+            )
+            ax.plot(
+                q[mask],
+                intensity[mask],
+                color=color,
+                linewidth=1.8,
+                label=label,
+            )
+            has_scatter = True
+        if not has_scatter:
+            ax.text(
+                0.5,
+                0.5,
+                "No Fourier transform results available for selected entries.",
+                ha="center",
+                va="center",
+                transform=ax.transAxes,
+            )
+            ax.set_axis_off()
+            self._scatter_plot.canvas.draw_idle()
+            return
+        if use_log_q:
+            ax.set_xscale("log")
+        if use_log_i:
+            ax.set_yscale("log")
+        ax.set_xlabel("q (Å⁻¹)", labelpad=10.0)
+        ax.set_ylabel("Intensity (arb. units)")
+        ax.set_title("q-Space Scattering Profile")
+        ax.grid(True, which="both", alpha=0.28)
+        ax.legend(loc="upper right", frameon=True, fontsize=8)
+        fig.tight_layout()
+        self._scatter_plot.canvas.draw_idle()
+
+    # ------------------------------------------------------------------
+    # Save / export
+    # ------------------------------------------------------------------
+
+    @Slot()
+    def _save_all_pngs(self) -> None:
+        chosen = QFileDialog.getExistingDirectory(
+            self, "Choose Directory for Saved Output PNGs", ""
+        )
+        if not chosen:
+            return
+        export_dir = Path(chosen).expanduser().resolve()
+        export_dir.mkdir(parents=True, exist_ok=True)
+        panels = [
+            ("raw_density", self._raw_plot),
+            ("smeared_density", self._smeared_plot),
+            ("residual_density", self._residual_plot),
+            ("fourier_preview", self._fourier_plot),
+            ("scattering_profile", self._scatter_plot),
+        ]
+        written_count = 0
+        original_visibility = dict(self._trace_visibility)
+        try:
+            for index, entry in enumerate(self._entries, start=1):
+                self._trace_visibility = {
+                    candidate.entry_id: candidate.entry_id == entry.entry_id
+                    for candidate in self._entries
+                }
+                self._refresh_plots()
+                stem = ElectronDensityMappingMainWindow._saved_output_entry_file_stem(
+                    entry,
+                    index=index,
+                )
+                for suffix, widget in panels:
+                    widget.figure.savefig(
+                        export_dir / f"{stem}_{suffix}.png",
+                        dpi=200,
+                        bbox_inches="tight",
+                    )
+                    written_count += 1
+        except Exception as exc:
+            QMessageBox.critical(self, "PNG Export Failed", str(exc))
+            return
+        finally:
+            self._trace_visibility = original_visibility
+            self._refresh_plots()
+        self.status_label.setText(
+            f"Saved {written_count} PNG file"
+            f"{'' if written_count == 1 else 's'} to {export_dir}."
+        )
+
+    @Slot()
+    def _export_all_csvs(self) -> None:
+        chosen = QFileDialog.getExistingDirectory(
+            self, "Choose Directory for Saved Output CSVs", ""
+        )
+        if not chosen:
+            return
+        export_dir = Path(chosen).expanduser().resolve()
+        export_dir.mkdir(parents=True, exist_ok=True)
+        written_count = 0
+        try:
+            for index, entry in enumerate(self._entries, start=1):
+                preview = ElectronDensityMappingMainWindow._preview_for_saved_output_entry(
+                    entry
+                )
+                csv_path = export_dir / (
+                    ElectronDensityMappingMainWindow._saved_output_entry_file_stem(
+                        entry, index=index
+                    )
+                    + ".csv"
+                )
+                ElectronDensityMappingMainWindow._write_plot_trace_csv(
+                    csv_path,
+                    profile_result=entry.profile_result,
+                    fourier_preview=preview,
+                    transform_result=entry.transform_result,
+                )
+                written_count += 1
+        except Exception as exc:
+            QMessageBox.critical(self, "CSV Export Failed", str(exc))
+            return
+        self.status_label.setText(
+            f"Exported {written_count} CSV file"
+            f"{'' if written_count == 1 else 's'} to {export_dir}."
+        )
+
+
+class _DebyeScatteringComparisonDialog(QDialog):
+    def __init__(
+        self,
+        entries: list[_DebyeComparisonEntry],
+        *,
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose, True)
+        self.setWindowTitle("Debye Scattering Comparison")
+        self.resize(1320, 900)
+        self._entries = tuple(entries)
+        self._trace_colors = {
+            entry.entry_id: str(entry.color) for entry in self._entries
+        }
+        self._trace_visibility = {
+            entry.entry_id: True for entry in self._entries
+        }
+        self._build_ui()
+        self._refresh_plot()
+
+    def _build_ui(self) -> None:
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(10, 10, 10, 10)
+        outer.setSpacing(8)
+
+        controls = QHBoxLayout()
+        controls.setSpacing(6)
+        summary = QLabel(
+            f"Comparing {len(self._entries)} Born/Debye trace pair"
+            f"{'' if len(self._entries) == 1 else 's'}."
+        )
+        summary.setWordWrap(True)
+        controls.addWidget(summary, stretch=1)
+
+        self.log_x_checkbox = QCheckBox("Log X")
+        self.log_x_checkbox.setChecked(True)
+        self.log_x_checkbox.toggled.connect(self._refresh_plot)
+        controls.addWidget(self.log_x_checkbox)
+
+        self.log_y_checkbox = QCheckBox("Log Y")
+        self.log_y_checkbox.setChecked(True)
+        self.log_y_checkbox.toggled.connect(self._refresh_plot)
+        controls.addWidget(self.log_y_checkbox)
+
+        self.legend_button = QPushButton("Legend")
+        self.legend_button.setCheckable(True)
+        self.legend_button.setChecked(True)
+        self.legend_button.toggled.connect(self._refresh_plot)
+        controls.addWidget(self.legend_button)
+
+        self.autoscale_button = QPushButton("Autoscale Overlay")
+        self.autoscale_button.setCheckable(True)
+        self.autoscale_button.setChecked(True)
+        self.autoscale_button.toggled.connect(self._refresh_plot)
+        controls.addWidget(self.autoscale_button)
+
+        self.close_button = QPushButton("Close")
+        self.close_button.clicked.connect(self.close)
+        controls.addWidget(self.close_button)
+        outer.addLayout(controls)
+
+        self.status_label = QLabel(
+            "Born-approximation traces use the left axis and solid lines. "
+            "Debye scattering traces use the right axis and dashed lines. "
+            "Use the table below to overlay selected trace pairs."
+        )
+        self.status_label.setWordWrap(True)
+        self.status_label.setStyleSheet("color: #475569;")
+        outer.addWidget(self.status_label)
+
+        splitter = QSplitter(Qt.Orientation.Vertical, self)
+        self._plot_widget = _OverlayFigureWidget(
+            "Born Approximation vs Debye Scattering",
+            figsize=(8.8, 4.4),
+        )
+        splitter.addWidget(self._plot_widget)
+
+        table_container = QGroupBox("Trace Pairs")
+        table_layout = QVBoxLayout(table_container)
+        self._trace_table = QTableWidget(0, 5)
+        self._trace_table.setHorizontalHeaderLabels(
+            ["Visible", "Color", "Label", "Born", "Debye"]
+        )
+        self._trace_table.verticalHeader().setVisible(False)
+        self._trace_table.setSelectionMode(
+            QTableWidget.SelectionMode.NoSelection
+        )
+        header = self._trace_table.horizontalHeader()
+        header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(1, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(2, QHeaderView.ResizeMode.Stretch)
+        header.setSectionResizeMode(3, QHeaderView.ResizeMode.Stretch)
+        header.setSectionResizeMode(4, QHeaderView.ResizeMode.Stretch)
+        self._trace_table.setMinimumHeight(160)
+        table_layout.addWidget(self._trace_table)
+        splitter.addWidget(table_container)
+        splitter.setSizes([680, 220])
+        outer.addWidget(splitter, stretch=1)
+
+    def _configure_color_button(
+        self,
+        button: QPushButton,
+        color: str,
+    ) -> None:
+        qc = QColor(color)
+        text_color = "#000000" if qc.lightnessF() > 0.55 else "#ffffff"
+        button.setText(color)
+        button.setStyleSheet(
+            f"QPushButton {{background-color:{color};color:{text_color};"
+            "padding:3px 8px;}}"
+        )
+
+    def _choose_trace_color(self, entry_id: str) -> None:
+        current = self._trace_colors.get(entry_id, "#333333")
+        chosen = QColorDialog.getColor(
+            QColor(current), self, "Choose trace color"
+        )
+        if not chosen.isValid():
+            return
+        self._trace_colors[entry_id] = chosen.name()
+        self._refresh_trace_table()
+        self._refresh_plot()
+
+    def _set_trace_visible(self, entry_id: str, visible: bool) -> None:
+        self._trace_visibility[entry_id] = bool(visible)
+        self._refresh_plot()
+
+    def _refresh_trace_table(self) -> None:
+        self._trace_table.setRowCount(0)
+        for row_index, entry in enumerate(self._entries):
+            self._trace_table.insertRow(row_index)
+            key = entry.entry_id
+
+            visible_box = QCheckBox()
+            visible_box.setChecked(self._trace_visibility.get(key, True))
+            visible_box.toggled.connect(
+                lambda checked, entry_id=key: self._set_trace_visible(
+                    entry_id,
+                    checked,
+                )
+            )
+            self._trace_table.setCellWidget(row_index, 0, visible_box)
+
+            color_button = QPushButton()
+            color_button.clicked.connect(
+                lambda _=False, entry_id=key: self._choose_trace_color(
+                    entry_id
+                )
+            )
+            self._configure_color_button(
+                color_button,
+                self._trace_colors.get(key, "#333333"),
+            )
+            self._trace_table.setCellWidget(row_index, 1, color_button)
+
+            for column_index, value in enumerate(
+                (
+                    entry.label,
+                    self._born_status_text(entry.born_result),
+                    self._debye_status_text(entry.debye_result),
+                ),
+                start=2,
+            ):
+                item = QTableWidgetItem(value)
+                item.setFlags(item.flags() & ~Qt.ItemFlag.ItemIsEditable)
+                if column_index == 2:
+                    item.setToolTip(entry.info_text)
+                self._trace_table.setItem(row_index, column_index, item)
+
+    @staticmethod
+    def _born_status_text(
+        result: ElectronDensityScatteringTransformResult,
+    ) -> str:
+        q_values = np.asarray(result.q_values, dtype=float)
+        if q_values.size == 0:
+            return "Unavailable"
+        return (
+            f"{len(q_values)} points, q={float(q_values[0]):.4f}"
+            f"–{float(q_values[-1]):.4f} Å⁻¹"
+        )
+
+    @staticmethod
+    def _debye_status_text(
+        result: ElectronDensityDebyeScatteringAverageResult,
+    ) -> str:
+        q_values = np.asarray(result.q_values, dtype=float)
+        return (
+            f"{result.source_structure_count} structure"
+            f"{'' if result.source_structure_count == 1 else 's'}, "
+            f"{len(q_values)} q points"
+        )
+
+    def _visible_entries(self) -> list[_DebyeComparisonEntry]:
+        return [
+            entry
+            for entry in self._entries
+            if self._trace_visibility.get(entry.entry_id, True)
+        ]
+
+    def _refresh_plot(self) -> None:
+        self._refresh_trace_table()
+        fig = self._plot_widget.figure
+        fig.clear()
+        visible_entries = self._visible_entries()
+        if not visible_entries:
+            axis = fig.add_subplot(111)
+            axis.text(
+                0.5,
+                0.5,
+                "No visible comparison traces.",
+                ha="center",
+                va="center",
+                transform=axis.transAxes,
+            )
+            axis.set_axis_off()
+            self._plot_widget.canvas.draw_idle()
+            self.status_label.setText(
+                "Born-approximation traces use the left axis and solid lines. "
+                "Debye scattering traces use the right axis and dashed lines. "
+                "Use the table below to overlay selected trace pairs."
+            )
+            return
+
+        base_axis = fig.add_subplot(111)
+        born_axis = base_axis
+        debye_axis = base_axis.twinx()
+        plotted_lines: list[object] = []
+
+        positive_q = True
+        born_positive_i = True
+        debye_positive_i = True
+        for entry in visible_entries:
+            color = self._trace_colors.get(entry.entry_id, entry.color)
+            born_q = np.asarray(entry.born_result.q_values, dtype=float)
+            born_i = np.asarray(entry.born_result.intensity, dtype=float)
+            debye_q = np.asarray(entry.debye_result.q_values, dtype=float)
+            debye_i = np.asarray(
+                entry.debye_result.mean_intensity, dtype=float
+            )
+            positive_q = positive_q and bool(
+                np.all(born_q > 0.0) and np.all(debye_q > 0.0)
+            )
+            born_positive_i = born_positive_i and bool(np.all(born_i > 0.0))
+            debye_positive_i = debye_positive_i and bool(np.all(debye_i > 0.0))
+            (born_line,) = born_axis.plot(
+                born_q,
+                born_i,
+                color=color,
+                linewidth=1.8,
+                label=f"{entry.label} · Born",
+            )
+            (debye_line,) = debye_axis.plot(
+                debye_q,
+                debye_i,
+                color=color,
+                linewidth=1.8,
+                linestyle="--",
+                label=f"{entry.label} · Debye",
+            )
+            plotted_lines.extend([born_line, debye_line])
+
+        if self.log_x_checkbox.isChecked() and positive_q:
+            born_axis.set_xscale("log")
+            debye_axis.set_xscale("log")
+        born_axis.set_yscale(
+            "log"
+            if self.log_y_checkbox.isChecked() and born_positive_i
+            else "linear"
+        )
+        debye_axis.set_yscale(
+            "log"
+            if self.log_y_checkbox.isChecked() and debye_positive_i
+            else "linear"
+        )
+        born_axis.set_xlabel("q (Å⁻¹)")
+        born_axis.set_ylabel("Born Approximation Intensity (arb. units)")
+        debye_axis.set_ylabel("Debye Scattering Intensity (arb. units)")
+        born_axis.set_title("Born Approximation vs Debye Scattering")
+        born_axis.grid(True, which="both", alpha=0.28)
+
+        if self.autoscale_button.isChecked():
+            self._autoscale_to_born_range(born_axis, debye_axis)
+
+        if plotted_lines and self.legend_button.isChecked():
+            born_axis.legend(
+                plotted_lines,
+                [line.get_label() for line in plotted_lines],
+                loc="best",
+                fontsize=8,
+            )
+        fig.tight_layout()
+        self._plot_widget.canvas.draw_idle()
+        self.status_label.setText(
+            f"Overlaying {len(visible_entries)} visible trace pair"
+            f"{'' if len(visible_entries) == 1 else 's'}."
+        )
+
+    def _autoscale_to_born_range(self, born_axis, debye_axis) -> None:
+        born_lines = [
+            line for line in born_axis.get_lines() if line.get_visible()
+        ]
+        if not born_lines:
+            return
+        born_q_values = np.concatenate(
+            [
+                np.asarray(line.get_xdata(orig=False), dtype=float)
+                for line in born_lines
+            ]
+        )
+        born_q_values = born_q_values[np.isfinite(born_q_values)]
+        if born_q_values.size == 0:
+            return
+        q_min = float(np.nanmin(born_q_values))
+        q_max = float(np.nanmax(born_q_values))
+        born_axis.set_xlim(q_min, q_max)
+        debye_axis.set_xlim(q_min, q_max)
+        self._autoscale_axis_y(born_axis, q_min, q_max)
+        self._normalize_debye_axis(born_axis, debye_axis)
+
+    def _normalize_debye_axis(self, born_axis, debye_axis) -> None:
+        born_lines = [
+            line for line in born_axis.get_lines() if line.get_visible()
+        ]
+        debye_lines = [
+            line for line in debye_axis.get_lines() if line.get_visible()
+        ]
+        if not born_lines or not debye_lines:
+            return
+        born_q = np.concatenate(
+            [
+                np.asarray(line.get_xdata(orig=False), dtype=float)
+                for line in born_lines
+            ]
+        )
+        born_i = np.concatenate(
+            [
+                np.asarray(line.get_ydata(orig=False), dtype=float)
+                for line in born_lines
+            ]
+        )
+        debye_q = np.concatenate(
+            [
+                np.asarray(line.get_xdata(orig=False), dtype=float)
+                for line in debye_lines
+            ]
+        )
+        debye_i = np.concatenate(
+            [
+                np.asarray(line.get_ydata(orig=False), dtype=float)
+                for line in debye_lines
+            ]
+        )
+        overlap_mask = (born_q >= float(np.nanmin(debye_q))) & (
+            born_q <= float(np.nanmax(debye_q))
+        )
+        if np.any(overlap_mask):
+            born_i = born_i[overlap_mask]
+        born_i = born_i[np.isfinite(born_i)]
+        debye_i = debye_i[np.isfinite(debye_i)]
+        if self.log_y_checkbox.isChecked():
+            born_i = born_i[born_i > 0.0]
+            debye_i = debye_i[debye_i > 0.0]
+        if born_i.size == 0 or debye_i.size == 0:
+            return
+        debye_axis.set_ylim(
+            self._aligned_y_limits(
+                born_axis.get_ylim(),
+                float(np.nanmin(born_i)),
+                float(np.nanmax(born_i)),
+                float(np.nanmin(debye_i)),
+                float(np.nanmax(debye_i)),
+                log_scale=self.log_y_checkbox.isChecked(),
+            )
+        )
+
+    def _autoscale_axis_y(
+        self,
+        axis,
+        q_min: float,
+        q_max: float,
+    ) -> None:
+        y_segments: list[np.ndarray] = []
+        log_scale = self.log_y_checkbox.isChecked()
+        for line in axis.get_lines():
+            if not line.get_visible():
+                continue
+            x_data = np.asarray(line.get_xdata(orig=False), dtype=float)
+            y_data = np.asarray(line.get_ydata(orig=False), dtype=float)
+            mask = (
+                np.isfinite(x_data)
+                & np.isfinite(y_data)
+                & (x_data >= q_min)
+                & (x_data <= q_max)
+            )
+            if log_scale:
+                mask &= y_data > 0.0
+            if np.any(mask):
+                y_segments.append(y_data[mask])
+        if not y_segments:
+            return
+        y_values = np.concatenate(y_segments)
+        y_min = float(np.nanmin(y_values))
+        y_max = float(np.nanmax(y_values))
+        if np.isclose(y_min, y_max):
+            padding = max(abs(y_min) * 0.05, 1e-12)
+            axis.set_ylim(y_min - padding, y_max + padding)
+            return
+        if log_scale:
+            axis.set_ylim(y_min / 1.15, y_max * 1.15)
+        else:
+            padding = 0.05 * (y_max - y_min)
+            axis.set_ylim(y_min - padding, y_max + padding)
+
+    @staticmethod
+    def _aligned_y_limits(
+        left_limits: tuple[float, float],
+        born_min: float,
+        born_max: float,
+        debye_min: float,
+        debye_max: float,
+        *,
+        log_scale: bool,
+    ) -> tuple[float, float]:
+        if log_scale:
+            if (
+                min(
+                    left_limits[0],
+                    left_limits[1],
+                    born_min,
+                    born_max,
+                    debye_min,
+                    debye_max,
+                )
+                <= 0.0
+            ):
+                log_scale = False
+        if not log_scale:
+            left_low, left_high = left_limits
+            born_low, born_high = sorted((born_min, born_max))
+            debye_low, debye_high = sorted((debye_min, debye_max))
+            if np.isclose(left_high, left_low) or np.isclose(
+                born_high,
+                born_low,
+            ):
+                padding = max(abs(debye_low) * 0.1, 1e-12)
+                return debye_low - padding, debye_high + padding
+            p0 = (born_low - left_low) / (left_high - left_low)
+            p1 = (born_high - left_low) / (left_high - left_low)
+            if np.isclose(p1, p0):
+                padding = max(abs(debye_low) * 0.1, 1e-12)
+                return debye_low - padding, debye_high + padding
+            delta = (debye_high - debye_low) / (p1 - p0)
+            right_low = debye_low - p0 * delta
+            right_high = right_low + delta
+            return right_low, right_high
+
+        left_logs = np.log10(np.asarray(left_limits, dtype=float))
+        born_logs = np.log10(
+            np.asarray(sorted((born_min, born_max)), dtype=float)
+        )
+        debye_logs = np.log10(
+            np.asarray(sorted((debye_min, debye_max)), dtype=float)
+        )
+        if np.isclose(left_logs[1], left_logs[0]) or np.isclose(
+            born_logs[1],
+            born_logs[0],
+        ):
+            return debye_min / 1.2, debye_max * 1.2
+        p0 = (born_logs[0] - left_logs[0]) / (left_logs[1] - left_logs[0])
+        p1 = (born_logs[1] - left_logs[0]) / (left_logs[1] - left_logs[0])
+        if np.isclose(p1, p0):
+            return debye_min / 1.2, debye_max * 1.2
+        delta = (debye_logs[1] - debye_logs[0]) / (p1 - p0)
+        right_low_log = debye_logs[0] - p0 * delta
+        right_high_log = right_low_log + delta
+        return 10**right_low_log, 10**right_high_log
+
+
+class ElectronDensityWorkspaceLoadWorker(QObject):
+    progress = Signal(int, int, str)
+    finished = Signal(object)
+    failed = Signal(str)
+
+    def __init__(self, path: Path) -> None:
+        super().__init__()
+        self._path = Path(path).expanduser().resolve()
+
+    @Slot()
+    def run(self) -> None:
+        try:
+            payload = _build_workspace_load_payload(
+                self._path,
+                progress_callback=self.progress.emit,
+            )
+        except Exception as exc:
+            self.failed.emit(str(exc))
+            return
+        self.finished.emit(payload)
 
 
 class ElectronDensityCalculationWorker(QObject):
     progress = Signal(int, int, str)
+    overall_progress = Signal(int, int, str)
     finished = Signal(object)
+    canceled = Signal(object)
     failed = Signal(str)
 
     def __init__(
         self,
         *,
-        inspection: ElectronDensityInputInspection,
+        inspection: ElectronDensityInputInspection | None,
+        reference_structure: ElectronDensityStructure | None,
         mesh_settings: ElectronDensityMeshSettings,
         smearing_settings: ElectronDensitySmearingSettings,
         center_mode: str,
         reference_element: str | None,
         output_dir: str,
         output_basename: str,
+        use_contiguous_frame_mode: bool,
+        grouped_inspections: tuple[
+            tuple[str, ElectronDensityInputInspection],
+            ...,
+        ] = (),
+        grouped_reference_structures: tuple[
+            tuple[str, ElectronDensityStructure],
+            ...,
+        ] = (),
+        single_atom_group_keys: tuple[str, ...] = (),
+        debye_scattering_settings: (
+            ElectronDensityFourierTransformSettings | None
+        ) = None,
     ) -> None:
         super().__init__()
         self._inspection = inspection
+        self._reference_structure = reference_structure
+        self._grouped_inspections = tuple(grouped_inspections)
+        self._grouped_reference_structures = {
+            str(group_key): structure
+            for group_key, structure in grouped_reference_structures
+        }
+        self._single_atom_group_keys = {
+            str(group_key) for group_key in single_atom_group_keys
+        }
         self._mesh_settings = mesh_settings
         self._smearing_settings = smearing_settings
         self._center_mode = str(center_mode)
@@ -175,20 +1632,167 @@ class ElectronDensityCalculationWorker(QObject):
             if reference_element is None
             else str(reference_element).strip() or None
         )
+        self._use_contiguous_frame_mode = bool(use_contiguous_frame_mode)
         self._output_dir = str(output_dir)
         self._output_basename = str(output_basename)
+        self._debye_scattering_settings = (
+            ElectronDensityFourierTransformSettings()
+            if debye_scattering_settings is None
+            else debye_scattering_settings.normalized()
+        )
+        self._cancel_requested = False
+
+    @Slot()
+    def cancel(self) -> None:
+        self._cancel_requested = True
+
+    @staticmethod
+    def _safe_group_basename(label: str) -> str:
+        normalized = "".join(
+            character if character.isalnum() or character in "._-" else "_"
+            for character in str(label).strip()
+        )
+        return normalized.strip("._") or "cluster_group"
+
+    @staticmethod
+    def _group_progress_prefix(
+        group_index: int,
+        group_count: int,
+        group_label: str,
+    ) -> str:
+        return (
+            f"Cluster {group_index}/{group_count} "
+            f"[{str(group_label).strip() or 'cluster_group'}]"
+        )
 
     @Slot()
     def run(self) -> None:
+        group_results: dict[str, ElectronDensityProfileResult] = {}
+        group_transform_results: dict[
+            str, ElectronDensityScatteringTransformResult
+        ] = {}
+        group_artifacts: dict[str, ElectronDensityOutputArtifacts] = {}
         try:
+            if self._grouped_inspections:
+                group_count = len(self._grouped_inspections)
+                self.overall_progress.emit(
+                    0,
+                    max(group_count, 1),
+                    "Overall cluster progress: "
+                    f"0/{group_count} groups complete.",
+                )
+                for group_index, (group_key, inspection) in enumerate(
+                    self._grouped_inspections,
+                    start=1,
+                ):
+                    group_label = str(group_key).strip() or "cluster_group"
+                    progress_prefix = self._group_progress_prefix(
+                        group_index,
+                        group_count,
+                        group_label,
+                    )
+                    self.overall_progress.emit(
+                        group_index - 1,
+                        max(group_count, 1),
+                        "Overall cluster progress: "
+                        f"{group_index - 1}/{group_count} groups complete. "
+                        f"Running {group_label}.",
+                    )
+
+                    def emit_group_progress(
+                        current: int,
+                        total: int,
+                        message: str,
+                        *,
+                        _prefix: str = progress_prefix,
+                    ) -> None:
+                        self.progress.emit(
+                            int(current),
+                            int(total),
+                            f"{_prefix}: {str(message).strip()}",
+                        )
+
+                    if group_key in self._single_atom_group_keys:
+                        transform_result = compute_single_atom_debye_scattering_profile_for_input(
+                            inspection,
+                            self._debye_scattering_settings,
+                            progress_callback=emit_group_progress,
+                            cancel_callback=lambda: self._cancel_requested,
+                        )
+                        if self._cancel_requested:
+                            raise ElectronDensityCalculationCanceled(
+                                "Electron-density calculation was stopped by the user."
+                            )
+                        group_transform_results[group_key] = transform_result
+                    else:
+                        result = compute_electron_density_profile_for_input(
+                            inspection,
+                            self._mesh_settings,
+                            smearing_settings=self._smearing_settings,
+                            reference_structure=self._grouped_reference_structures.get(
+                                group_key
+                            ),
+                            center_mode=self._center_mode,
+                            reference_element=None,
+                            use_contiguous_frame_mode=self._use_contiguous_frame_mode,
+                            progress_callback=emit_group_progress,
+                            cancel_callback=lambda: self._cancel_requested,
+                        )
+                        if self._cancel_requested:
+                            raise ElectronDensityCalculationCanceled(
+                                "Electron-density calculation was stopped by the user."
+                            )
+                        group_results[group_key] = result
+                        if self._output_dir.strip():
+                            artifact = write_electron_density_profile_outputs(
+                                result,
+                                self._output_dir,
+                                (
+                                    f"{self._output_basename}_"
+                                    f"{self._safe_group_basename(group_key)}"
+                                ),
+                            )
+                            if self._cancel_requested:
+                                raise ElectronDensityCalculationCanceled(
+                                    "Electron-density calculation was stopped by the user."
+                                )
+                            group_artifacts[group_key] = artifact
+                    self.overall_progress.emit(
+                        group_index,
+                        max(group_count, 1),
+                        "Overall cluster progress: "
+                        f"{group_index}/{group_count} groups complete. "
+                        f"Finished {group_label}.",
+                    )
+                    if self._cancel_requested and group_index < group_count:
+                        raise ElectronDensityCalculationCanceled(
+                            "Electron-density calculation was stopped by the user."
+                        )
+                self.finished.emit(
+                    {
+                        "group_results": group_results,
+                        "group_transform_results": group_transform_results,
+                        "group_artifacts": group_artifacts,
+                    }
+                )
+                return
+            if self._inspection is None:
+                raise ValueError("No input inspection was provided.")
             result = compute_electron_density_profile_for_input(
                 self._inspection,
                 self._mesh_settings,
                 smearing_settings=self._smearing_settings,
+                reference_structure=self._reference_structure,
                 center_mode=self._center_mode,
                 reference_element=self._reference_element,
+                use_contiguous_frame_mode=self._use_contiguous_frame_mode,
                 progress_callback=self.progress.emit,
+                cancel_callback=lambda: self._cancel_requested,
             )
+            if self._cancel_requested:
+                raise ElectronDensityCalculationCanceled(
+                    "Electron-density calculation was stopped by the user."
+                )
             artifacts = None
             if self._output_dir.strip():
                 structure_count = len(self._inspection.structure_files)
@@ -198,15 +1802,31 @@ class ElectronDensityCalculationWorker(QObject):
                     progress_total,
                     "Writing electron-density outputs.",
                 )
+                if self._cancel_requested:
+                    raise ElectronDensityCalculationCanceled(
+                        "Electron-density calculation was stopped by the user."
+                    )
                 artifacts = write_electron_density_profile_outputs(
                     result,
                     self._output_dir,
                     self._output_basename,
                 )
+                if self._cancel_requested:
+                    raise ElectronDensityCalculationCanceled(
+                        "Electron-density calculation was stopped by the user."
+                    )
             self.finished.emit(
                 {
                     "result": result,
                     "artifacts": artifacts,
+                }
+            )
+        except ElectronDensityCalculationCanceled:
+            self.canceled.emit(
+                {
+                    "group_results": group_results,
+                    "group_transform_results": group_transform_results,
+                    "group_artifacts": group_artifacts,
                 }
             )
         except Exception as exc:
@@ -217,26 +1837,85 @@ class ElectronDensityMappingMainWindow(QMainWindow):
     """Interactive supporting tool for radial electron-density
     inspection."""
 
+    born_components_built = Signal(object)
+    cancel_calculation_requested = Signal()
+
+    @staticmethod
+    def _default_fourier_settings() -> ElectronDensityFourierTransformSettings:
+        return ElectronDensityFourierTransformSettings(
+            r_min=-1.0,
+            r_max=1.0,
+            domain_mode="mirrored",
+            window_function="hanning",
+            q_min=0.02,
+            q_max=1.2,
+            q_step=0.01,
+            resampling_points=2048,
+        )
+
     def __init__(
         self,
         *,
         initial_project_dir: Path | None = None,
         initial_input_path: Path | None = None,
+        initial_output_dir: Path | None = None,
+        initial_project_q_min: float | None = None,
+        initial_project_q_max: float | None = None,
+        initial_distribution_id: str | None = None,
+        initial_distribution_root_dir: Path | None = None,
+        initial_use_predicted_structure_weights: bool = False,
+        preview_mode: bool = True,
+        restore_saved_distribution_state_on_init: bool = True,
     ) -> None:
         super().__init__()
+        self._preview_mode = bool(preview_mode)
         self._project_dir = (
             None
             if initial_project_dir is None
             else Path(initial_project_dir).expanduser().resolve()
         )
+        self._initial_output_dir = (
+            None
+            if initial_output_dir is None
+            else Path(initial_output_dir).expanduser().resolve()
+        )
+        self._project_q_min = (
+            None
+            if initial_project_q_min is None
+            else float(initial_project_q_min)
+        )
+        self._project_q_max = (
+            None
+            if initial_project_q_max is None
+            else float(initial_project_q_max)
+        )
+        self._distribution_id = (
+            str(initial_distribution_id or "").strip() or None
+        )
+        self._distribution_root_dir = (
+            None
+            if initial_distribution_root_dir is None
+            else Path(initial_distribution_root_dir).expanduser().resolve()
+        )
+        self._use_predicted_structure_weights = bool(
+            initial_use_predicted_structure_weights
+        )
         self._inspection: ElectronDensityInputInspection | None = None
         self._structure: ElectronDensityStructure | None = None
+        self._cluster_group_states: list[_ClusterDensityGroupState] = []
+        self._selected_cluster_group_key: str | None = None
+        self._restoring_saved_distribution_state = False
+        self._restoring_saved_output_history = False
+        self._mesh_settings_confirmed_for_run = False
+        self._manual_mesh_lock_settings: ElectronDensityMeshSettings | None = (
+            None
+        )
+        self._current_group_run_manual = False
+        self._auto_snap_panes_enabled = self._load_auto_snap_panes_setting()
         self._active_mesh_settings = ElectronDensityMeshSettings()
         self._active_mesh_geometry: ElectronDensityMeshGeometry | None = None
         self._active_smearing_settings = ElectronDensitySmearingSettings()
-        self._active_fourier_settings = (
-            ElectronDensityFourierTransformSettings()
-        )
+        self._active_fourier_settings = self._default_fourier_settings()
         self._solvent_presets: dict[str, ContrastSolventPreset] = {}
         self._active_contrast_settings: (
             ContrastSolventDensitySettings | None
@@ -249,30 +1928,67 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         self._fourier_result: (
             ElectronDensityScatteringTransformResult | None
         ) = None
+        self._debye_scattering_result: (
+            ElectronDensityDebyeScatteringAverageResult | None
+        ) = None
+        self._calculation_ui_running = False
+        self._calculation_cancel_requested = False
         self._calculation_thread: QThread | None = None
         self._calculation_worker: ElectronDensityCalculationWorker | None = (
             None
         )
-        self._last_progress_message = ""
+        self._workspace_load_thread: QThread | None = None
+        self._workspace_load_worker: (
+            ElectronDensityWorkspaceLoadWorker | None
+        ) = None
+        self._workspace_load_progress_dialog: SAXSProgressDialog | None = None
+        self._batch_operation_progress_dialog: SAXSProgressDialog | None = None
+        self._restore_distribution_state_after_workspace_load = False
+        self._saved_output_entries: list[_SavedOutputEntry] = []
+        self._output_history_compare_dialog: QDialog | None = None
+        self._debye_scattering_compare_dialog: QDialog | None = None
+        self._updating_fourier_settings_table = False
+        self._syncing_cluster_selection = False
+        self._deferred_initial_input_path: Path | None = None
+        self._deferred_restore_saved_distribution_state = False
+        self._last_workspace_load_message = ""
+        self._cluster_view_cache_prewarm_queue: list[str] = []
+        self._cluster_view_cache_prewarm_timer = QTimer(self)
+        self._cluster_view_cache_prewarm_timer.setSingleShot(True)
+        self._cluster_view_cache_prewarm_timer.timeout.connect(
+            self._prime_next_cluster_view_cache_entry
+        )
+        self._initial_workspace_load_timer = QTimer(self)
+        self._initial_workspace_load_timer.setSingleShot(True)
+        self._initial_workspace_load_timer.timeout.connect(
+            self._run_deferred_initial_workspace_load
+        )
+        self._project_debye_waller_source_path: Path | None = None
 
-        self.setWindowTitle("Electron Density Mapping")
+        self._apply_preview_mode_title()
         self.setWindowIcon(load_saxshell_icon())
         self.resize(1520, 960)
         self._build_ui()
+        self._load_project_debye_waller_terms()
         self._set_initial_defaults()
         if initial_input_path is not None:
             self.input_path_edit.setText(
                 str(Path(initial_input_path).expanduser().resolve())
             )
-            self._load_input_from_edit()
+            self._load_input_path(Path(initial_input_path))
+        if restore_saved_distribution_state_on_init:
+            self._restore_saved_distribution_state_if_available()
+        else:
+            self._update_push_to_model_state()
 
     def _build_ui(self) -> None:
+        self._build_menu_bar()
         central = QWidget(self)
         root_layout = QVBoxLayout(central)
         root_layout.setContentsMargins(8, 8, 8, 8)
         root_layout.setSpacing(8)
-        splitter = QSplitter(Qt.Orientation.Horizontal, central)
-        root_layout.addWidget(splitter, stretch=1)
+        self._pane_splitter = QSplitter(Qt.Orientation.Horizontal, central)
+        root_layout.addWidget(self._pane_splitter, stretch=1)
         self.setCentralWidget(central)
 
         self._left_scroll_area = QScrollArea(self)
@@ -288,16 +2004,15 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         left_layout.setContentsMargins(10, 10, 10, 10)
         left_layout.setSpacing(10)
         self._left_scroll_area.setWidget(left_container)
-        splitter.addWidget(self._left_scroll_area)
+        self._pane_splitter.addWidget(self._left_scroll_area)
 
-        intro = QLabel(
-            "This supporting application previews a single XYZ or PDB "
-            "structure, centers it at a mass-weighted origin or a nearby "
-            "atom, and computes both raw and Gaussian-smeared spherical "
-            "electron-density profiles."
+        self.preview_mode_banner = QLabel()
+        self.preview_mode_banner.setWordWrap(True)
+        self.preview_mode_banner.setStyleSheet(
+            "QLabel { padding: 8px; border: 1px solid #cbd5e1; "
+            "background: #f8fafc; }"
         )
-        intro.setWordWrap(True)
-        left_layout.addWidget(intro)
+        left_layout.addWidget(self.preview_mode_banner)
 
         left_layout.addWidget(self._build_input_group())
         left_layout.addWidget(self._build_output_group())
@@ -306,7 +2021,12 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         )
         left_layout.addWidget(self.mesh_section)
         left_layout.addWidget(self._build_actions_group())
-        left_layout.addWidget(self._build_smearing_group())
+        self.smearing_section = _CollapsibleSection(
+            "Smearing",
+            self._build_smearing_group(),
+            left_container,
+        )
+        left_layout.addWidget(self.smearing_section)
         self.contrast_section = _CollapsibleSection(
             "Electron Density Contrast",
             self._build_contrast_group(),
@@ -319,6 +2039,17 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             left_container,
         )
         left_layout.addWidget(self.fourier_section)
+        self.push_to_model_group = self._build_push_to_model_group()
+        left_layout.addWidget(self.push_to_model_group)
+        self.debye_scattering_group = self._build_debye_scattering_group()
+        left_layout.addWidget(self.debye_scattering_group)
+        self.output_history_section = _CollapsibleSection(
+            "Saved Outputs",
+            self._build_output_history_group(),
+            left_container,
+        )
+        self.output_history_section.collapse()
+        left_layout.addWidget(self.output_history_section)
         left_layout.addWidget(self._build_status_group(), stretch=1)
         left_layout.addStretch(1)
 
@@ -352,7 +2083,23 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             "Automatically expand a plot panel when its data is updated."
         )
         plot_options_row.addWidget(self.auto_expand_checkbox)
+        self.show_all_cluster_transforms_checkbox = QCheckBox(
+            "Show All Cluster Transforms"
+        )
+        self.show_all_cluster_transforms_checkbox.setChecked(False)
+        self.show_all_cluster_transforms_checkbox.toggled.connect(
+            self._refresh_scattering_plot
+        )
+        plot_options_row.addWidget(self.show_all_cluster_transforms_checkbox)
         plot_options_row.addStretch(1)
+        self.collapse_expand_button = QPushButton("Expand All")
+        self.collapse_expand_button.setToolTip(
+            "Expand or collapse all plot panels at once"
+        )
+        self.collapse_expand_button.clicked.connect(
+            self._toggle_all_plot_sections
+        )
+        plot_options_row.addWidget(self.collapse_expand_button)
         self.export_plot_traces_button = QPushButton("Export Plot Traces")
         self.export_plot_traces_button.setToolTip(
             "Export all active plot traces (raw density, smeared density, "
@@ -417,6 +2164,13 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             self._right_panel,
         )
         right_layout.addWidget(self.fourier_preview_section)
+        self.fourier_preview_info_label = QLabel()
+        self.fourier_preview_info_label.setStyleSheet(
+            "color: #334155; font-size: 11px;"
+        )
+        self.fourier_preview_section.add_header_widget(
+            self.fourier_preview_info_label
+        )
 
         self.scattering_plot = ElectronDensityScatteringPlot(self._right_panel)
         self.scattering_section = _CollapsibleSection(
@@ -425,6 +2179,11 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             self._right_panel,
         )
         right_layout.addWidget(self.scattering_section)
+        self.scattering_info_label = QLabel()
+        self.scattering_info_label.setStyleSheet(
+            "color: #7c2d12; font-size: 11px;"
+        )
+        self.scattering_section.add_header_widget(self.scattering_info_label)
 
         self.structure_viewer = ElectronDensityStructureViewer(
             self._right_panel
@@ -438,16 +2197,370 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             self.scattering_section,
         ):
             section.toggled.connect(self._refresh_right_panel_layout)
+            section.toggled.connect(self._sync_collapse_expand_button)
         self.profile_plot.set_variance_visible(True)
         self.smeared_profile_plot.set_variance_visible(True)
         self.residual_profile_plot.set_variance_visible(True)
 
         self._right_scroll_area.setWidget(self._right_panel)
         self._refresh_right_panel_layout()
-        splitter.addWidget(self._right_scroll_area)
-        splitter.setStretchFactor(0, 0)
-        splitter.setStretchFactor(1, 1)
-        splitter.setSizes([430, 1090])
+        self._pane_splitter.addWidget(self._right_scroll_area)
+        self._pane_splitter.setStretchFactor(0, 0)
+        self._pane_splitter.setStretchFactor(1, 1)
+        self._pane_splitter.setSizes([430, 1090])
+        self._auto_snap_filter = PaneSnapFilter(
+            self._pane_splitter,
+            self._left_scroll_area,
+            self._right_scroll_area,
+            self,
+        )
+        self._set_auto_snap_panes_enabled(
+            self._auto_snap_panes_enabled,
+            persist=False,
+        )
+        self._refresh_preview_mode_banner()
+
+    def _build_menu_bar(self) -> None:
+        settings_menu = self.menuBar().addMenu("Settings")
+        self.auto_snap_panes_action = QAction("Auto-Snap Panes", self)
+        self.auto_snap_panes_action.setCheckable(True)
+        self.auto_snap_panes_action.setChecked(
+            bool(self._auto_snap_panes_enabled)
+        )
+        self.auto_snap_panes_action.triggered.connect(
+            self._toggle_auto_snap_panes
+        )
+        settings_menu.addAction(self.auto_snap_panes_action)
+
+    def _apply_preview_mode_title(self) -> None:
+        title = "Electron Density Mapping"
+        if self._preview_mode:
+            title += " (Preview)"
+        self.setWindowTitle(title)
+
+    def _refresh_preview_mode_banner(self) -> None:
+        if self._preview_mode:
+            self.preview_mode_banner.setText(
+                "Preview Mode: this tool can inspect standalone structures, "
+                "folders, or cluster folders without saving model components "
+                "into a computed distribution. Use Build SAXS Components from "
+                "the main UI to launch the linked workflow."
+            )
+            self.preview_mode_banner.setToolTip(
+                "Preview mode does not push component traces into the active "
+                "SAXS model."
+            )
+            return
+        distribution_text = (
+            self._distribution_id
+            if self._distribution_id is not None
+            else "active computed distribution"
+        )
+        self.preview_mode_banner.setText(
+            "Computed Distribution Mode: this run is linked to "
+            f"{distribution_text}. Output defaults and q-range context are "
+            "inherited from the active SAXS project."
+        )
+        self.preview_mode_banner.setToolTip(
+            "This workflow was launched from Build SAXS Components for the "
+            "active computed distribution."
+        )
+
+    def set_preview_mode(self, preview_mode: bool) -> None:
+        self._preview_mode = bool(preview_mode)
+        self._apply_preview_mode_title()
+        self._refresh_preview_mode_banner()
+
+    def schedule_initial_workspace_load(
+        self,
+        *,
+        initial_input_path: Path | None = None,
+        restore_saved_distribution_state: bool | None = None,
+    ) -> None:
+        self._deferred_initial_input_path = (
+            None
+            if initial_input_path is None
+            else Path(initial_input_path).expanduser().resolve()
+        )
+        self._deferred_restore_saved_distribution_state = bool(
+            (not self._preview_mode)
+            if restore_saved_distribution_state is None
+            else restore_saved_distribution_state
+        )
+        if self._deferred_initial_input_path is not None:
+            self.input_path_edit.setText(
+                str(self._deferred_initial_input_path)
+            )
+        if (
+            self._deferred_initial_input_path is None
+            and not self._deferred_restore_saved_distribution_state
+        ):
+            return
+        self._reset_progress_display("Loading inherited workspace...")
+        self.statusBar().showMessage(
+            "Loading inherited electron-density workspace"
+        )
+        self._initial_workspace_load_timer.start(0)
+
+    @Slot()
+    def _run_deferred_initial_workspace_load(self) -> None:
+        input_path = self._deferred_initial_input_path
+        restore_saved_distribution_state = (
+            self._deferred_restore_saved_distribution_state
+        )
+        self._deferred_initial_input_path = None
+        self._deferred_restore_saved_distribution_state = False
+        if input_path is not None:
+            self._start_workspace_load(
+                input_path,
+                restore_saved_distribution_state=restore_saved_distribution_state,
+                progress_message=(
+                    "Loading inherited electron-density workspace..."
+                ),
+            )
+            return
+        if restore_saved_distribution_state:
+            restore_message = (
+                "Restoring saved electron-density mapping state..."
+            )
+            self.calculation_progress_bar.setRange(0, 0)
+            self.calculation_progress_bar.setFormat("")
+            self.calculation_progress_message.setText(
+                "Restoring saved computed-distribution state..."
+            )
+            self.statusBar().showMessage(restore_message)
+            self._set_workspace_load_progress_busy_message(restore_message)
+            QApplication.processEvents()
+            if self._restore_saved_distribution_state_if_available():
+                return
+            self._close_workspace_load_progress_dialog()
+            self._reset_progress_display("Idle")
+        elif input_path is None:
+            self._reset_progress_display("Idle")
+
+    def _start_workspace_load(
+        self,
+        input_path: Path,
+        *,
+        restore_saved_distribution_state: bool,
+        progress_message: str = "Loading electron-density workspace...",
+    ) -> None:
+        if (
+            self._workspace_load_thread is not None
+            and self._workspace_load_thread.isRunning()
+        ):
+            return
+        progress_text = (
+            str(progress_message).strip()
+            or "Loading electron-density workspace..."
+        )
+        self._restore_distribution_state_after_workspace_load = bool(
+            restore_saved_distribution_state
+        )
+        self._set_calculation_running(True)
+        self.stop_calculation_button.setEnabled(False)
+        self.calculation_progress_bar.setRange(0, 0)
+        self.calculation_progress_bar.setFormat("")
+        self.calculation_progress_message.setText(progress_text)
+        self.statusBar().showMessage(progress_text)
+        self._begin_workspace_load_progress(progress_text)
+
+        self._workspace_load_thread = QThread()
+        self._workspace_load_worker = ElectronDensityWorkspaceLoadWorker(
+            input_path
+        )
+        self._workspace_load_worker.moveToThread(self._workspace_load_thread)
+        self._workspace_load_thread.started.connect(
+            self._workspace_load_worker.run
+        )
+        self._workspace_load_worker.progress.connect(
+            self._on_workspace_load_progress
+        )
+        self._workspace_load_worker.finished.connect(
+            self._on_workspace_load_finished
+        )
+        self._workspace_load_worker.failed.connect(
+            self._on_workspace_load_failed
+        )
+        self._workspace_load_worker.finished.connect(
+            self._workspace_load_thread.quit
+        )
+        self._workspace_load_worker.failed.connect(
+            self._workspace_load_thread.quit
+        )
+        self._workspace_load_thread.finished.connect(
+            self._workspace_load_worker.deleteLater
+        )
+        self._workspace_load_thread.finished.connect(
+            self._workspace_load_thread.deleteLater
+        )
+        self._workspace_load_thread.finished.connect(
+            self._clear_workspace_load_handles
+        )
+        self._workspace_load_thread.start(QThread.Priority.LowPriority)
+
+    @Slot()
+    def _clear_workspace_load_handles(self) -> None:
+        self._workspace_load_worker = None
+        self._workspace_load_thread = None
+
+    def _ensure_workspace_load_progress_dialog(self) -> SAXSProgressDialog:
+        if self._workspace_load_progress_dialog is None:
+            self._workspace_load_progress_dialog = SAXSProgressDialog(self)
+        return self._workspace_load_progress_dialog
+
+    def _begin_workspace_load_progress(self, message: str) -> None:
+        dialog = self._ensure_workspace_load_progress_dialog()
+        self._last_workspace_load_message = ""
+        dialog.begin_busy(
+            str(message).strip() or "Loading electron-density workspace...",
+            title="Loading Electron Density Mapping",
+        )
+        QApplication.processEvents()
+
+    def _set_workspace_load_progress_busy_message(self, message: str) -> None:
+        dialog = self._ensure_workspace_load_progress_dialog()
+        stripped = (
+            str(message).strip() or "Loading electron-density workspace..."
+        )
+        dialog.setWindowTitle("Loading Electron Density Mapping")
+        dialog.progress_bar.setRange(0, 0)
+        dialog.progress_bar.setValue(0)
+        dialog.progress_bar.setFormat("")
+        dialog.message_label.setText(stripped)
+        dialog.show()
+        dialog.raise_()
+        QApplication.processEvents()
+
+    def _append_workspace_load_output(self, message: str) -> None:
+        stripped = str(message).strip()
+        if (
+            not stripped
+            or stripped == self._last_workspace_load_message
+            or self._workspace_load_progress_dialog is None
+        ):
+            return
+        self._last_workspace_load_message = stripped
+        self._workspace_load_progress_dialog.append_output(stripped)
+
+    def _close_workspace_load_progress_dialog(self) -> None:
+        self._last_workspace_load_message = ""
+        if self._workspace_load_progress_dialog is not None:
+            self._workspace_load_progress_dialog.close()
+
+    def _ensure_batch_operation_progress_dialog(self) -> SAXSProgressDialog:
+        if self._batch_operation_progress_dialog is None:
+            dialog = SAXSProgressDialog(self)
+            dialog.setModal(True)
+            dialog.setWindowModality(Qt.WindowModality.WindowModal)
+            self._batch_operation_progress_dialog = dialog
+        return self._batch_operation_progress_dialog
+
+    def _begin_batch_operation_progress(
+        self,
+        *,
+        total: int,
+        message: str,
+        title: str,
+    ) -> None:
+        bounded_total = max(int(total), 1)
+        stripped = str(message).strip() or "Preparing batch update..."
+        dialog = self._ensure_batch_operation_progress_dialog()
+        dialog.begin(
+            bounded_total,
+            stripped,
+            unit_label="stoichiometries",
+            title=title,
+        )
+        self._on_calculation_progress(0, bounded_total, stripped)
+        self.statusBar().showMessage(stripped)
+        QApplication.processEvents()
+
+    def _update_batch_operation_progress(
+        self,
+        current: int,
+        total: int,
+        message: str,
+    ) -> None:
+        bounded_total = max(int(total), 1)
+        stripped = str(message).strip() or "Processing stoichiometry..."
+        self._on_calculation_progress(current, bounded_total, stripped)
+        if self._batch_operation_progress_dialog is not None:
+            self._batch_operation_progress_dialog.update_progress(
+                current,
+                bounded_total,
+                stripped,
+                unit_label="stoichiometries",
+            )
+        self.statusBar().showMessage(stripped)
+        QApplication.processEvents()
+
+    def _close_batch_operation_progress_dialog(self) -> None:
+        if self._batch_operation_progress_dialog is not None:
+            self._batch_operation_progress_dialog.close()
+
+    @Slot(int, int, str)
+    def _on_workspace_load_progress(
+        self,
+        current: int,
+        total: int,
+        message: str,
+    ) -> None:
+        self._on_calculation_progress(current, total, message)
+        stripped = str(message).strip()
+        if self._workspace_load_progress_dialog is not None:
+            self._workspace_load_progress_dialog.update_progress(
+                current,
+                total,
+                stripped or "Loading inherited electron-density workspace...",
+                unit_label="steps",
+            )
+        self._append_workspace_load_output(stripped)
+        if stripped:
+            self.statusBar().showMessage(stripped)
+        QApplication.processEvents()
+
+    @Slot(object)
+    def _on_workspace_load_finished(self, payload: object) -> None:
+        try:
+            if not isinstance(payload, _ElectronDensityWorkspaceLoadPayload):
+                raise RuntimeError(
+                    "Workspace loader returned an unexpected payload type."
+                )
+            self._apply_workspace_load_payload(payload)
+            if self._restore_distribution_state_after_workspace_load:
+                restore_message = (
+                    "Restoring saved electron-density mapping state..."
+                )
+                self.calculation_progress_bar.setRange(0, 0)
+                self.calculation_progress_bar.setFormat("")
+                self.calculation_progress_message.setText(
+                    "Restoring saved computed-distribution state..."
+                )
+                self.statusBar().showMessage(restore_message)
+                self._set_workspace_load_progress_busy_message(restore_message)
+                QApplication.processEvents()
+                self._restore_saved_distribution_state_if_available()
+            self._reset_progress_display("Idle")
+        except Exception as exc:
+            self._handle_workspace_load_failure(str(exc))
+            return
+        finally:
+            self._restore_distribution_state_after_workspace_load = False
+            self._set_calculation_running(False)
+            self._close_workspace_load_progress_dialog()
+
+    @Slot(str)
+    def _on_workspace_load_failed(self, message: str) -> None:
+        self._handle_workspace_load_failure(message)
+
+    def _handle_workspace_load_failure(self, message: str) -> None:
+        self._restore_distribution_state_after_workspace_load = False
+        self._set_calculation_running(False)
+        self._reset_progress_display("Workspace load failed.")
+        self._append_status(f"Workspace load failed: {message}")
+        self._close_workspace_load_progress_dialog()
+        self._show_error("Input Error", message)
 
     @Slot()
     def _refresh_right_panel_layout(self, *_args: object) -> None:
@@ -460,6 +2573,29 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             self._right_panel.setMinimumHeight(minimum_height)
         self._right_panel.updateGeometry()
         self._right_panel.adjustSize()
+
+    def _plot_sections(self) -> tuple[_CollapsibleSection, ...]:
+        return (
+            self.profile_section,
+            self.smeared_section,
+            self.residual_section,
+            self.fourier_preview_section,
+            self.scattering_section,
+        )
+
+    @Slot()
+    def _sync_collapse_expand_button(self, *_args: object) -> None:
+        any_expanded = any(s.is_expanded for s in self._plot_sections())
+        self.collapse_expand_button.setText(
+            "Collapse All" if any_expanded else "Expand All"
+        )
+
+    @Slot()
+    def _toggle_all_plot_sections(self) -> None:
+        sections = self._plot_sections()
+        any_expanded = any(s.is_expanded for s in sections)
+        for section in sections:
+            section.set_expanded(not any_expanded)
 
     def _build_input_group(self) -> QWidget:
         group = QGroupBox("Input")
@@ -487,20 +2623,23 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         layout.addWidget(self.load_input_button)
 
         form = QFormLayout()
+        form.addRow(QLabel("Input mode:"))
         self.input_mode_value = QLabel("No structure loaded")
         self.input_mode_value.setWordWrap(True)
-        form.addRow("Input mode", self.input_mode_value)
+        form.addRow(self.input_mode_value)
 
+        form.addRow(QLabel("Reference file:"))
         self.reference_file_value = QLabel("Unavailable")
         self.reference_file_value.setWordWrap(True)
-        form.addRow("Reference file", self.reference_file_value)
+        form.addRow(self.reference_file_value)
 
+        form.addRow(QLabel("Structure summary:"))
         self.structure_summary_value = QLabel(
             "Load a structure to populate atoms, element counts, center of "
             "mass, active center, and rmax."
         )
         self.structure_summary_value.setWordWrap(True)
-        form.addRow("Structure summary", self.structure_summary_value)
+        form.addRow(self.structure_summary_value)
         layout.addLayout(form)
         return group
 
@@ -568,11 +2707,11 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         layout.addRow("rmax (Å)", self.rmax_spin)
 
         layout.addRow(QLabel("Center mode:"))
-        self.center_mode_value = QLabel("Calculated center of mass")
+        self.center_mode_value = QLabel("Geometric Mass Center")
         self.center_mode_value.setWordWrap(True)
         layout.addRow(self.center_mode_value)
 
-        layout.addRow(QLabel("Calculated center:"))
+        layout.addRow(QLabel("Geometric mass center:"))
         self.calculated_center_value = QLabel("Unavailable")
         self.calculated_center_value.setWordWrap(True)
         layout.addRow(self.calculated_center_value)
@@ -609,28 +2748,99 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         self.reference_element_offset_value.setWordWrap(True)
         layout.addRow(self.reference_element_offset_value)
 
+        layout.addRow(QLabel("Snap center:"))
         center_button_row = QWidget(group)
-        center_button_layout = QHBoxLayout(center_button_row)
-        center_button_layout.setContentsMargins(0, 0, 0, 0)
-        center_button_layout.setSpacing(6)
-        self.snap_center_button = QPushButton("Snap Center to Nearest Atom")
-        self.snap_center_button.clicked.connect(
-            lambda _checked=False: self._apply_center_mode("nearest_atom")
+        center_button_grid = QGridLayout(center_button_row)
+        center_button_grid.setContentsMargins(0, 0, 0, 0)
+        center_button_grid.setSpacing(4)
+
+        self.reset_center_button = QPushButton("Geometric Mass Center")
+        self.reset_center_button.setCheckable(True)
+        self.reset_center_button.setToolTip(
+            "Reset active center to the geometric mass center"
         )
-        center_button_layout.addWidget(self.snap_center_button)
-        self.reset_center_button = QPushButton("Reset to Calculated Center")
         self.reset_center_button.clicked.connect(
             lambda _checked=False: self._apply_center_mode("center_of_mass")
         )
-        center_button_layout.addWidget(self.reset_center_button)
-        self.snap_reference_center_button = QPushButton(
-            "Snap Center to Reference Element"
+        center_button_grid.addWidget(self.reset_center_button, 0, 0)
+
+        self.snap_center_button = QPushButton("Nearest Atom")
+        self.snap_center_button.setCheckable(True)
+        self.snap_center_button.setToolTip(
+            "Snap active center to the atom nearest to the geometric mass center"
+        )
+        self.snap_center_button.clicked.connect(
+            lambda _checked=False: self._apply_center_mode("nearest_atom")
+        )
+        center_button_grid.addWidget(self.snap_center_button, 0, 1)
+
+        self.snap_reference_center_button = QPushButton("Reference Element")
+        self.snap_reference_center_button.setCheckable(True)
+        self.snap_reference_center_button.setToolTip(
+            "Snap active center to the geometric center of the reference element"
         )
         self.snap_reference_center_button.clicked.connect(
             lambda _checked=False: self._apply_center_mode("reference_element")
         )
-        center_button_layout.addWidget(self.snap_reference_center_button)
+        center_button_grid.addWidget(self.snap_reference_center_button, 1, 0)
+
+        self._center_snap_button_group = QButtonGroup(group)
+        self._center_snap_button_group.setExclusive(True)
+        self._center_snap_button_group.addButton(self.reset_center_button)
+        self._center_snap_button_group.addButton(self.snap_center_button)
+        self._center_snap_button_group.addButton(
+            self.snap_reference_center_button
+        )
+        self.reset_center_button.setChecked(True)
+
         layout.addRow(center_button_row)
+
+        self.pinned_geometric_tracking_checkbox = QCheckBox(
+            "Pin Geometric Tracking Across Contiguous PDB Frames"
+        )
+        self.pinned_geometric_tracking_checkbox.setToolTip(
+            "For folder and stoichiometry-folder runs with contiguous PDB "
+            "frame_<NNNN> names, reuse the first frame's geometric mass "
+            "center coordinates across each contiguous set instead of "
+            "recomputing the center for every frame."
+        )
+        self.pinned_geometric_tracking_checkbox.setChecked(
+            bool(self._active_mesh_settings.pin_contiguous_geometric_tracking)
+        )
+        self.pinned_geometric_tracking_checkbox.toggled.connect(
+            self._handle_pinned_geometric_tracking_toggled
+        )
+        layout.addRow(self.pinned_geometric_tracking_checkbox)
+
+        self.pinned_geometric_tracking_notice = QLabel()
+        self.pinned_geometric_tracking_notice.setWordWrap(True)
+        self.pinned_geometric_tracking_notice.setStyleSheet("color: #475569;")
+        layout.addRow(self.pinned_geometric_tracking_notice)
+
+        self.contiguous_frame_mode_checkbox = QCheckBox(
+            "Use Contiguous Frame Evaluation"
+        )
+        self.contiguous_frame_mode_checkbox.setChecked(True)
+        self.contiguous_frame_mode_checkbox.setToolTip(
+            "When averaging multiple structures, group files by frame_<NNNN> "
+            "sequences and lock each contiguous set to a shared center offset "
+            "relative to the heaviest-element geometric center. Files without "
+            "frame_<NNNN> identifiers fall back to complete averaging."
+        )
+        self.contiguous_frame_mode_checkbox.toggled.connect(
+            self._handle_contiguous_frame_mode_toggled
+        )
+        layout.addRow(self.contiguous_frame_mode_checkbox)
+
+        self.contiguous_frame_mode_notice = QLabel(
+            "Default: on. Folder and cluster-folder runs will try contiguous "
+            "frame grouping from frame_<NNNN> file names, then fall back to "
+            "complete averaging with a status notice when that naming scheme "
+            "is unavailable."
+        )
+        self.contiguous_frame_mode_notice.setWordWrap(True)
+        self.contiguous_frame_mode_notice.setStyleSheet("color: #475569;")
+        layout.addRow(self.contiguous_frame_mode_notice)
 
         self.update_mesh_button = QPushButton("Update Mesh Settings")
         self.update_mesh_button.clicked.connect(self._apply_mesh_from_controls)
@@ -645,14 +2855,155 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         self.pending_mesh_value = QLabel()
         self.pending_mesh_value.setWordWrap(True)
         layout.addRow(self.pending_mesh_value)
+        self._refresh_pinned_geometric_tracking_controls()
         return group
 
     def _build_actions_group(self) -> QWidget:
         group = QGroupBox("Actions")
         layout = QVBoxLayout(group)
+        self.cluster_group_status_label = QLabel(
+            "Single-file and folder inputs run directly. Loading a folder of "
+            "stoichiometry subfolders will populate a per-cluster summary table here."
+        )
+        self.cluster_group_status_label.setWordWrap(True)
+        layout.addWidget(self.cluster_group_status_label)
+
+        cluster_group_table_body = QWidget(group)
+        cluster_group_table_layout = QVBoxLayout(cluster_group_table_body)
+        cluster_group_table_layout.setContentsMargins(0, 0, 0, 0)
+        cluster_group_table_layout.setSpacing(0)
+
+        self.cluster_group_table = QTableWidget(0, 14)
+        self.cluster_group_table.setHorizontalHeaderLabels(
+            [
+                "Stoichiometry",
+                "Files",
+                "Avg Atoms",
+                "Center Mode",
+                "Center Ref",
+                "Center Element",
+                "Density",
+                "Fourier",
+                "Trace Color",
+                "Smearing",
+                "Solvent",
+                "Cutoff",
+                "FT Settings",
+                "Reference File",
+            ]
+        )
+        self.cluster_group_table.verticalHeader().setVisible(False)
+        self.cluster_group_table.setSelectionBehavior(
+            QTableWidget.SelectionBehavior.SelectRows
+        )
+        self.cluster_group_table.setSelectionMode(
+            QTableWidget.SelectionMode.ExtendedSelection
+        )
+        self.cluster_group_table.setEditTriggers(
+            QTableWidget.EditTrigger.NoEditTriggers
+        )
+        self.cluster_group_table.horizontalHeader().setSectionResizeMode(
+            QHeaderView.ResizeMode.ResizeToContents
+        )
+        self.cluster_group_table.horizontalHeader().setStretchLastSection(True)
+        self.cluster_group_table.setMinimumHeight(180)
+        self.cluster_group_table.itemSelectionChanged.connect(
+            self._handle_cluster_group_selection_changed
+        )
+        cluster_group_table_layout.addWidget(self.cluster_group_table)
+
+        self.cluster_group_table_section = _CollapsibleSection(
+            "Stoichiometry Table",
+            cluster_group_table_body,
+            group,
+        )
+        self.cluster_group_table_section.collapse()
+        layout.addWidget(self.cluster_group_table_section)
+
+        self.cluster_batch_scope_label = QLabel()
+        self.cluster_batch_scope_label.setWordWrap(True)
+        self.cluster_batch_scope_label.setStyleSheet("color: #475569;")
+        layout.addWidget(self.cluster_batch_scope_label)
+
+        self.manual_mode_checkbox = QCheckBox(
+            "Manual Mode (selected stoichiometry only)"
+        )
+        self.manual_mode_checkbox.setToolTip(
+            "Run only the actively selected stoichiometry row. After the "
+            "first manual calculation succeeds, mesh settings stay locked "
+            "until you reset the calculated densities."
+        )
+        self.manual_mode_checkbox.toggled.connect(
+            self._refresh_manual_mode_notice
+        )
+        layout.addWidget(self.manual_mode_checkbox)
+
+        self.manual_mode_notice_label = QLabel()
+        self.manual_mode_notice_label.setWordWrap(True)
+        self.manual_mode_notice_label.setStyleSheet("color: #475569;")
+        layout.addWidget(self.manual_mode_notice_label)
+
+        self.cluster_completion_indicator = QLabel("PENDING")
+        self.cluster_completion_indicator.setAlignment(
+            Qt.AlignmentFlag.AlignCenter
+        )
+        self.cluster_completion_indicator.setMinimumWidth(92)
+        self.cluster_completion_indicator.setStyleSheet(
+            "background-color: #94a3b8; color: white; padding: 4px 8px; "
+            "border-radius: 8px; font-weight: 600;"
+        )
+        self.cluster_completion_tracker_label = QLabel(
+            "Computed stoichiometries: n/a"
+        )
+        self.cluster_completion_tracker_label.setWordWrap(True)
+        tracker_row = QWidget(group)
+        tracker_layout = QHBoxLayout(tracker_row)
+        tracker_layout.setContentsMargins(0, 0, 0, 0)
+        tracker_layout.setSpacing(8)
+        tracker_layout.addWidget(self.cluster_completion_indicator, stretch=0)
+        tracker_layout.addWidget(
+            self.cluster_completion_tracker_label,
+            stretch=1,
+        )
+        layout.addWidget(tracker_row)
+
         self.run_button = QPushButton("Run Electron Density Calculation")
         self.run_button.clicked.connect(self._run_calculation)
-        layout.addWidget(self.run_button)
+        self.stop_calculation_button = QPushButton("Stop Active Calculation")
+        self.stop_calculation_button.clicked.connect(
+            self._request_calculation_stop
+        )
+        run_row = QWidget(group)
+        run_layout = QHBoxLayout(run_row)
+        run_layout.setContentsMargins(0, 0, 0, 0)
+        run_layout.setSpacing(6)
+        run_layout.addWidget(self.run_button, stretch=1)
+        run_layout.addWidget(self.stop_calculation_button, stretch=0)
+        layout.addWidget(run_row)
+
+        self.reset_calculations_button = QPushButton(
+            "Reset Calculated Densities"
+        )
+        self.reset_calculations_button.clicked.connect(
+            self._reset_calculated_densities
+        )
+        layout.addWidget(self.reset_calculations_button)
+
+        self.calculation_overall_progress_message = QLabel(
+            "Overall progress: idle"
+        )
+        self.calculation_overall_progress_message.setWordWrap(True)
+        self.calculation_overall_progress_message.setHidden(True)
+        layout.addWidget(self.calculation_overall_progress_message)
+
+        self.calculation_overall_progress_bar = QProgressBar()
+        self.calculation_overall_progress_bar.setRange(0, 1)
+        self.calculation_overall_progress_bar.setValue(0)
+        self.calculation_overall_progress_bar.setFormat(
+            "%v / %m cluster groups"
+        )
+        self.calculation_overall_progress_bar.setHidden(True)
+        layout.addWidget(self.calculation_overall_progress_bar)
 
         self.calculation_progress_message = QLabel("Idle")
         self.calculation_progress_message.setWordWrap(True)
@@ -661,8 +3012,2202 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         self.calculation_progress_bar = QProgressBar()
         self.calculation_progress_bar.setRange(0, 1)
         self.calculation_progress_bar.setValue(0)
+        self.calculation_progress_bar.setFormat("%v / %m steps")
         layout.addWidget(self.calculation_progress_bar)
         return group
+
+    def _build_push_to_model_group(self) -> QWidget:
+        group = QGroupBox("Push to Model")
+        layout = QVBoxLayout(group)
+        self.push_to_model_status_label = QLabel()
+        self.push_to_model_status_label.setWordWrap(True)
+        layout.addWidget(self.push_to_model_status_label)
+
+        self.push_to_model_button = QPushButton("Push to Model")
+        self.push_to_model_button.setToolTip(
+            "Write the active Born-approximation component traces into the "
+            "linked computed distribution so the main SAXS UI can load them."
+        )
+        self.push_to_model_button.clicked.connect(
+            self._push_components_to_model
+        )
+        layout.addWidget(self.push_to_model_button)
+        self._update_push_to_model_state()
+        return group
+
+    def _build_debye_scattering_group(self) -> QWidget:
+        group = QGroupBox("Debye Scattering Calculation")
+        layout = QVBoxLayout(group)
+        self.debye_scattering_summary_label = QLabel(
+            "Compute averaged Debye scattering traces on the same q-grid as "
+            "the current Born-approximation I(Q) results, then open a "
+            "deployable comparison plot with paired overlays."
+        )
+        self.debye_scattering_summary_label.setWordWrap(True)
+        layout.addWidget(self.debye_scattering_summary_label)
+
+        self.debye_scattering_status_label = QLabel()
+        self.debye_scattering_status_label.setWordWrap(True)
+        layout.addWidget(self.debye_scattering_status_label)
+
+        self.debye_scattering_progress_bar = QProgressBar()
+        self.debye_scattering_progress_bar.setRange(0, 1)
+        self.debye_scattering_progress_bar.setValue(0)
+        self.debye_scattering_progress_bar.setFormat("%v / %m steps")
+        self.debye_scattering_progress_bar.setHidden(True)
+        layout.addWidget(self.debye_scattering_progress_bar)
+
+        controls = QHBoxLayout()
+        controls.setContentsMargins(0, 0, 0, 0)
+        controls.setSpacing(6)
+
+        self.calculate_debye_scattering_button = QPushButton(
+            "Calculate Debye Scattering"
+        )
+        self.calculate_debye_scattering_button.clicked.connect(
+            self._calculate_debye_scattering_action
+        )
+        controls.addWidget(self.calculate_debye_scattering_button)
+
+        self.apply_debye_to_all_button = QCheckBox("Apply to All Rows")
+        self.apply_debye_to_all_button.toggled.connect(
+            self._refresh_debye_scattering_group
+        )
+        controls.addWidget(self.apply_debye_to_all_button)
+
+        self.open_debye_scattering_compare_button = QPushButton(
+            "Open Comparison Plot"
+        )
+        self.open_debye_scattering_compare_button.clicked.connect(
+            self._open_debye_scattering_comparison_plot
+        )
+        controls.addWidget(self.open_debye_scattering_compare_button)
+        controls.addStretch(1)
+        layout.addLayout(controls)
+
+        self._refresh_debye_scattering_group()
+        return group
+
+    @staticmethod
+    def _debye_scattering_progress_total_for_inspection(
+        inspection: ElectronDensityInputInspection,
+    ) -> int:
+        return max(len(tuple(inspection.structure_files)) * 2 + 2, 1)
+
+    def _reset_debye_scattering_progress(self) -> None:
+        if not hasattr(self, "debye_scattering_progress_bar"):
+            return
+        self.debye_scattering_progress_bar.setRange(0, 1)
+        self.debye_scattering_progress_bar.setValue(0)
+        self.debye_scattering_progress_bar.setFormat("%v / %m steps")
+        self.debye_scattering_progress_bar.setHidden(True)
+
+    def _begin_debye_scattering_progress(
+        self,
+        *,
+        total: int,
+        message: str,
+    ) -> None:
+        if not hasattr(self, "debye_scattering_progress_bar"):
+            return
+        bounded_total = max(int(total), 1)
+        stripped = (
+            str(message).strip() or "Preparing Debye scattering calculation..."
+        )
+        self.debye_scattering_progress_bar.setHidden(False)
+        self.debye_scattering_progress_bar.setRange(0, bounded_total)
+        self.debye_scattering_progress_bar.setValue(0)
+        self.debye_scattering_progress_bar.setFormat("%v / %m steps")
+        self.debye_scattering_status_label.setText(stripped)
+        self.statusBar().showMessage(stripped)
+        QApplication.processEvents()
+
+    def _update_debye_scattering_progress(
+        self,
+        current: int,
+        total: int,
+        message: str,
+    ) -> None:
+        if not hasattr(self, "debye_scattering_progress_bar"):
+            return
+        bounded_total = max(int(total), 1)
+        bounded_current = min(max(int(current), 0), bounded_total)
+        stripped = str(message).strip()
+        self.debye_scattering_progress_bar.setHidden(False)
+        self.debye_scattering_progress_bar.setRange(0, bounded_total)
+        self.debye_scattering_progress_bar.setValue(bounded_current)
+        self.debye_scattering_progress_bar.setFormat("%v / %m steps")
+        if stripped:
+            self.debye_scattering_status_label.setText(stripped)
+            self.statusBar().showMessage(stripped)
+        QApplication.processEvents()
+
+    @staticmethod
+    def _cluster_trace_color(index: int) -> str:
+        return _cluster_trace_color_for_index(index)
+
+    def _active_cluster_group_state(self) -> _ClusterDensityGroupState | None:
+        return self._cluster_group_state_by_key(
+            str(self._selected_cluster_group_key or "")
+        )
+
+    def _cluster_group_state_by_key(
+        self,
+        group_key: str,
+    ) -> _ClusterDensityGroupState | None:
+        for state in self._cluster_group_states:
+            if state.key == group_key:
+                return state
+        return None
+
+    def _cluster_group_render_complexity(
+        self,
+        state: _ClusterDensityGroupState,
+    ) -> float:
+        structure = state.reference_structure
+        bond_count = len(structure.bonds)
+        atom_count = float(max(structure.atom_count, state.average_atom_count))
+        return atom_count + bond_count * 0.35
+
+    def _schedule_cluster_view_cache_prewarm(self) -> None:
+        self._cluster_view_cache_prewarm_timer.stop()
+        self._cluster_view_cache_prewarm_queue = []
+        if len(self._cluster_group_states) <= 1:
+            return
+        active_key = self._selected_cluster_group_key
+        ranked_states = sorted(
+            self._cluster_group_states,
+            key=self._cluster_group_render_complexity,
+            reverse=True,
+        )
+        self._cluster_view_cache_prewarm_queue = [
+            state.key for state in ranked_states if state.key != active_key
+        ]
+        if self._cluster_view_cache_prewarm_queue:
+            self._cluster_view_cache_prewarm_timer.start(0)
+
+    def _prime_next_cluster_view_cache_entry(self) -> None:
+        if not self._cluster_view_cache_prewarm_queue:
+            return
+        scene_key = self._cluster_view_cache_prewarm_queue.pop(0)
+        if scene_key == self._selected_cluster_group_key:
+            if self._cluster_view_cache_prewarm_queue:
+                self._cluster_view_cache_prewarm_timer.start(0)
+            return
+        target_state = next(
+            (
+                state
+                for state in self._cluster_group_states
+                if state.key == scene_key
+            ),
+            None,
+        )
+        if target_state is None:
+            if self._cluster_view_cache_prewarm_queue:
+                self._cluster_view_cache_prewarm_timer.start(0)
+            return
+        mesh_geometry = (
+            None
+            if target_state.profile_result is None
+            else target_state.profile_result.mesh_geometry
+        )
+        self.structure_viewer.prewarm_scene(
+            target_state.key,
+            structure=target_state.reference_structure,
+            mesh_geometry=mesh_geometry,
+            complexity_score=self._cluster_group_render_complexity(
+                target_state
+            ),
+        )
+        if self._cluster_view_cache_prewarm_queue:
+            self._cluster_view_cache_prewarm_timer.start(0)
+
+    def _selected_cluster_group_rows(self) -> list[int]:
+        selection_model = self.cluster_group_table.selectionModel()
+        if selection_model is None:
+            return []
+        return sorted(
+            {
+                index.row()
+                for index in selection_model.selectedRows()
+                if 0 <= index.row() < len(self._cluster_group_states)
+            }
+        )
+
+    def _batch_target_cluster_group_states(
+        self,
+        *,
+        apply_to_all: bool,
+    ) -> tuple[list[_ClusterDensityGroupState], str, list[str]]:
+        if apply_to_all:
+            return (
+                list(self._cluster_group_states),
+                f"all {len(self._cluster_group_states)} stoichiometr"
+                f"{'y' if len(self._cluster_group_states) == 1 else 'ies'}",
+                [],
+            )
+        selected_rows = self._selected_cluster_group_rows()
+        if not selected_rows:
+            active_state = self._active_cluster_group_state()
+            if active_state is None:
+                return [], "0 selected stoichiometries", []
+            return (
+                [active_state],
+                "1 selected stoichiometry",
+                [active_state.key],
+            )
+        selected_states = [
+            self._cluster_group_states[row_index]
+            for row_index in selected_rows
+        ]
+        return (
+            selected_states,
+            f"{len(selected_states)} selected stoichiometr"
+            f"{'y' if len(selected_states) == 1 else 'ies'}",
+            [state.key for state in selected_states],
+        )
+
+    def _restore_cluster_group_selection(
+        self,
+        group_keys: list[str],
+        *,
+        preferred_current_key: str | None = None,
+    ) -> None:
+        if not self._cluster_group_states:
+            return
+        selection_model = self.cluster_group_table.selectionModel()
+        if selection_model is None:
+            return
+        key_set = {str(key) for key in group_keys if str(key).strip()}
+        if not key_set:
+            return
+        self.cluster_group_table.blockSignals(True)
+        try:
+            selection_model.clearSelection()
+            current_row = -1
+            fallback_row = -1
+            for row_index, state in enumerate(self._cluster_group_states):
+                if state.key in key_set:
+                    index = self.cluster_group_table.model().index(
+                        row_index,
+                        0,
+                    )
+                    selection_model.select(
+                        index,
+                        QItemSelectionModel.SelectionFlag.Select
+                        | QItemSelectionModel.SelectionFlag.Rows,
+                    )
+                    if fallback_row < 0:
+                        fallback_row = row_index
+                if state.key == preferred_current_key:
+                    current_row = row_index
+            if current_row < 0:
+                current_row = fallback_row
+            if current_row >= 0:
+                self.cluster_group_table.setCurrentCell(current_row, 0)
+        finally:
+            self.cluster_group_table.blockSignals(False)
+
+    def _set_current_cluster_group_row(
+        self,
+        group_key: str,
+        *,
+        preserve_selection: bool,
+    ) -> None:
+        if not self._cluster_group_states:
+            return
+        selection_model = self.cluster_group_table.selectionModel()
+        if selection_model is None:
+            return
+        target_row = -1
+        for row_index, state in enumerate(self._cluster_group_states):
+            if state.key == group_key:
+                target_row = row_index
+                break
+        if target_row < 0:
+            return
+        index = self.cluster_group_table.model().index(target_row, 0)
+        self.cluster_group_table.blockSignals(True)
+        try:
+            if preserve_selection:
+                selection_model.select(
+                    index,
+                    QItemSelectionModel.SelectionFlag.Select
+                    | QItemSelectionModel.SelectionFlag.Rows,
+                )
+            else:
+                selection_model.clearSelection()
+                selection_model.select(
+                    index,
+                    QItemSelectionModel.SelectionFlag.Select
+                    | QItemSelectionModel.SelectionFlag.Rows,
+                )
+            self.cluster_group_table.setCurrentCell(target_row, 0)
+        finally:
+            self.cluster_group_table.blockSignals(False)
+
+    @staticmethod
+    def _solvent_metadata_for_result(
+        result: ElectronDensityProfileResult | None,
+    ) -> tuple[float | None, float | None]:
+        contrast = None if result is None else result.solvent_contrast
+        density = (
+            None
+            if contrast is None
+            else float(contrast.solvent_density_e_per_a3)
+        )
+        cutoff = (
+            None
+            if contrast is None or contrast.cutoff_radius_a is None
+            else float(contrast.cutoff_radius_a)
+        )
+        return density, cutoff
+
+    def _sync_cluster_state_solvent_metadata(
+        self,
+        state: _ClusterDensityGroupState,
+    ) -> None:
+        density, cutoff = self._solvent_metadata_for_result(
+            state.profile_result
+        )
+        state.solvent_density_e_per_a3 = density
+        state.solvent_cutoff_radius_a = cutoff
+
+    def _cluster_state_fourier_settings(
+        self,
+        state: _ClusterDensityGroupState,
+    ) -> ElectronDensityFourierTransformSettings:
+        if state.fourier_settings is not None:
+            return state.fourier_settings.normalized()
+        if state.transform_result is not None:
+            return state.transform_result.preview.settings
+        try:
+            base_settings = self._fourier_settings_from_controls()
+        except Exception:
+            base_settings = self._active_fourier_settings
+        if state.profile_result is not None and not state.single_atom_only:
+            return self._constrain_fourier_settings_for_result(
+                state.profile_result,
+                base_settings,
+                prefer_solvent_cutoff=bool(state.solvent_cutoff_radius_a),
+            )
+        return base_settings.normalized()
+
+    def _set_cluster_state_fourier_settings(
+        self,
+        state: _ClusterDensityGroupState,
+        settings: ElectronDensityFourierTransformSettings,
+        *,
+        prefer_solvent_cutoff: bool,
+    ) -> ElectronDensityFourierTransformSettings:
+        current_settings = self._cluster_state_fourier_settings(state)
+        next_settings = settings.normalized()
+        if state.profile_result is not None and not state.single_atom_only:
+            next_settings = self._constrain_fourier_settings_for_result(
+                state.profile_result,
+                next_settings,
+                prefer_solvent_cutoff=prefer_solvent_cutoff,
+            )
+        if current_settings != next_settings:
+            state.transform_result = None
+            state.debye_scattering_result = None
+            self._close_debye_scattering_compare_dialog()
+        state.fourier_settings = next_settings
+        return next_settings
+
+    @staticmethod
+    def _fourier_profile_label_for_settings(
+        settings: ElectronDensityFourierTransformSettings,
+        *,
+        single_atom_only: bool,
+    ) -> str:
+        if single_atom_only:
+            return "Debye"
+        return (
+            "solvent" if settings.use_solvent_subtracted_profile else "smeared"
+        )
+
+    def _shared_fourier_settings_for_state(
+        self,
+        state: _ClusterDensityGroupState,
+        reference_settings: ElectronDensityFourierTransformSettings,
+    ) -> ElectronDensityFourierTransformSettings:
+        row_settings = self._cluster_state_fourier_settings(state)
+        return ElectronDensityFourierTransformSettings(
+            r_min=row_settings.r_min,
+            r_max=row_settings.r_max,
+            domain_mode=reference_settings.domain_mode,
+            window_function=reference_settings.window_function,
+            resampling_points=reference_settings.resampling_points,
+            q_min=reference_settings.q_min,
+            q_max=reference_settings.q_max,
+            q_step=reference_settings.q_step,
+            use_solvent_subtracted_profile=(
+                reference_settings.use_solvent_subtracted_profile
+            ),
+            log_q_axis=row_settings.log_q_axis,
+            log_intensity_axis=row_settings.log_intensity_axis,
+        ).normalized()
+
+    def _fourier_domain_mode_from_controls(self) -> str:
+        if (
+            hasattr(self, "fourier_legacy_mode_checkbox")
+            and self.fourier_legacy_mode_checkbox.isChecked()
+        ):
+            return "legacy"
+        return "mirrored"
+
+    def _refresh_fourier_domain_mode_controls(self) -> None:
+        if not hasattr(self, "fourier_rmin_label"):
+            return
+        mirrored_mode = self._fourier_domain_mode_from_controls() == "mirrored"
+        self.fourier_rmin_label.setText("-r max" if mirrored_mode else "r min")
+        if hasattr(self, "fourier_settings_table"):
+            header_item = self.fourier_settings_table.horizontalHeaderItem(
+                _FT_COLUMN_RMIN
+            )
+            if header_item is not None:
+                header_item.setText("-r max" if mirrored_mode else "r min")
+        self._sync_mirrored_fourier_rmin_to_rmax()
+
+    def _sync_mirrored_fourier_rmin_to_rmax(self, *_args: object) -> None:
+        if (
+            not hasattr(self, "fourier_rmin_spin")
+            or self._fourier_domain_mode_from_controls() != "mirrored"
+        ):
+            return
+        target_rmin = -float(self.fourier_rmax_spin.value())
+        self.fourier_rmin_spin.blockSignals(True)
+        try:
+            self.fourier_rmin_spin.setValue(target_rmin)
+        finally:
+            self.fourier_rmin_spin.blockSignals(False)
+
+    @Slot(bool)
+    def _handle_fourier_domain_mode_toggled(self, checked: bool) -> None:
+        self._refresh_fourier_domain_mode_controls()
+        if checked:
+            self.fourier_rmin_spin.blockSignals(True)
+            try:
+                self.fourier_rmin_spin.setValue(
+                    max(float(self.fourier_rmin_spin.value()), 0.0)
+                )
+            finally:
+                self.fourier_rmin_spin.blockSignals(False)
+        else:
+            self._sync_mirrored_fourier_rmin_to_rmax()
+        self._sync_fourier_controls_to_domain(reset_bounds=False)
+        self._refresh_fourier_table_interaction_state()
+        self._refresh_fourier_preview_from_controls()
+
+    def _refresh_cluster_views_after_batch_update(
+        self,
+        target_states: list[_ClusterDensityGroupState],
+        *,
+        selected_keys: list[str] | None = None,
+    ) -> None:
+        active_key = self._selected_cluster_group_key or (
+            None if not target_states else target_states[0].key
+        )
+        keys_to_restore = (
+            list(selected_keys)
+            if selected_keys
+            else ([] if active_key is None else [active_key])
+        )
+        self._populate_cluster_group_table()
+        self._restore_cluster_group_selection(
+            keys_to_restore,
+            preferred_current_key=active_key,
+        )
+        if active_key is not None:
+            self._set_active_cluster_group(active_key)
+        self._schedule_cluster_view_cache_prewarm()
+        self._refresh_debye_scattering_group()
+
+    def _clear_cluster_group_states(self) -> None:
+        self._cluster_view_cache_prewarm_timer.stop()
+        self._cluster_view_cache_prewarm_queue = []
+        self.structure_viewer.clear_scene_cache()
+        self._cluster_group_states = []
+        self._selected_cluster_group_key = None
+        self._manual_mesh_lock_settings = None
+        self.cluster_group_table.setRowCount(0)
+        if hasattr(self, "fourier_settings_table"):
+            self.fourier_settings_table.setRowCount(0)
+        self.cluster_group_table_section.collapse()
+        self.cluster_group_status_label.setText(
+            "Single-file and folder inputs run directly. Loading a folder of "
+            "stoichiometry subfolders will populate a per-cluster summary table here."
+        )
+        if hasattr(self, "cluster_batch_scope_label"):
+            self.cluster_batch_scope_label.setText(
+                "Batch solvent, smearing, and Fourier actions become "
+                "available after loading cluster folders."
+            )
+        for button, checked in (
+            (getattr(self, "apply_smearing_to_all_button", None), True),
+            (getattr(self, "apply_contrast_to_all_button", None), True),
+            (getattr(self, "apply_fourier_to_all_button", None), True),
+            (getattr(self, "apply_debye_to_all_button", None), False),
+        ):
+            if button is None:
+                continue
+            button.blockSignals(True)
+            button.setChecked(checked)
+            button.blockSignals(False)
+        self.show_all_cluster_transforms_checkbox.setChecked(False)
+        self.show_all_cluster_transforms_checkbox.setEnabled(False)
+        self._debye_scattering_result = None
+        self._close_debye_scattering_compare_dialog()
+        self._refresh_smearing_scope_status(False)
+        self._refresh_contrast_scope_status(False)
+        self._refresh_fourier_scope_status(False)
+        self._refresh_run_action_state()
+        self._refresh_mesh_notice()
+        self._refresh_debye_scattering_group()
+
+    def _clear_cluster_group_outputs(
+        self,
+        *,
+        clear_manual_mesh_lock: bool,
+    ) -> int:
+        cleared_count = 0
+        for state in self._cluster_group_states:
+            if (
+                state.profile_result is not None
+                or state.transform_result is not None
+                or state.debye_scattering_result is not None
+                or state.solvent_density_e_per_a3 is not None
+                or state.solvent_cutoff_radius_a is not None
+            ):
+                cleared_count += 1
+            state.profile_result = None
+            state.transform_result = None
+            state.debye_scattering_result = None
+            state.solvent_density_e_per_a3 = None
+            state.solvent_cutoff_radius_a = None
+        if clear_manual_mesh_lock:
+            self._manual_mesh_lock_settings = None
+        self._debye_scattering_result = None
+        self._close_debye_scattering_compare_dialog()
+        if self._cluster_group_states:
+            self._populate_cluster_group_table()
+        else:
+            self._refresh_run_action_state()
+        self._refresh_mesh_notice()
+        self._update_push_to_model_state()
+        self._refresh_debye_scattering_group()
+        return cleared_count
+
+    def _clear_cluster_group_outputs_for_keys(
+        self,
+        group_keys: set[str],
+    ) -> int:
+        resolved_keys = {
+            str(key).strip() for key in group_keys if str(key).strip()
+        }
+        if not resolved_keys:
+            return 0
+        cleared_count = 0
+        active_key = str(self._selected_cluster_group_key or "").strip()
+        for state in self._cluster_group_states:
+            if state.key not in resolved_keys:
+                continue
+            if (
+                state.profile_result is not None
+                or state.transform_result is not None
+                or state.debye_scattering_result is not None
+                or state.solvent_density_e_per_a3 is not None
+                or state.solvent_cutoff_radius_a is not None
+            ):
+                cleared_count += 1
+            state.profile_result = None
+            state.transform_result = None
+            state.debye_scattering_result = None
+            state.solvent_density_e_per_a3 = None
+            state.solvent_cutoff_radius_a = None
+        if self._manual_mesh_lock_settings is not None and not any(
+            self._cluster_group_is_complete(state)
+            for state in self._cluster_group_states
+        ):
+            self._manual_mesh_lock_settings = None
+        if active_key in resolved_keys or not self._cluster_group_states:
+            self._debye_scattering_result = None
+        self._close_debye_scattering_compare_dialog()
+        self._populate_cluster_group_table()
+        if active_key in resolved_keys:
+            self._set_active_cluster_group(active_key)
+        else:
+            self._refresh_run_action_state()
+            self._refresh_mesh_notice()
+            self._update_push_to_model_state()
+            self._refresh_debye_scattering_group()
+        return cleared_count
+
+    @staticmethod
+    def _distribution_prefit_snapshot_count(
+        distribution_root_dir: Path,
+    ) -> int:
+        prefit_dir = distribution_root_dir / "prefit"
+        if not prefit_dir.is_dir():
+            return 0
+        return len(
+            [
+                path
+                for path in prefit_dir.iterdir()
+                if path.is_dir() and (path / "prefit_state.json").is_file()
+            ]
+        )
+
+    @staticmethod
+    def _distribution_dream_run_count(distribution_root_dir: Path) -> int:
+        runtime_dir = distribution_root_dir / "dream" / "runtime_scripts"
+        if not runtime_dir.is_dir():
+            return 0
+        return len([path for path in runtime_dir.iterdir() if path.is_dir()])
+
+    def _distribution_push_lock_reason(self) -> str | None:
+        if self._preview_mode:
+            return (
+                "Preview mode does not save component traces into a computed "
+                "distribution."
+            )
+        if self._distribution_root_dir is None:
+            return "This window is not linked to a computed distribution."
+        prefit_count = self._distribution_prefit_snapshot_count(
+            self._distribution_root_dir
+        )
+        if prefit_count > 0:
+            return (
+                "Push is locked because this computed distribution already has "
+                f"{prefit_count} saved prefit snapshot"
+                f"{'' if prefit_count == 1 else 's'}."
+            )
+        dream_count = self._distribution_dream_run_count(
+            self._distribution_root_dir
+        )
+        if dream_count > 0:
+            return (
+                "Push is locked because this computed distribution already has "
+                f"{dream_count} saved DREAM run"
+                f"{'' if dream_count == 1 else 's'}."
+            )
+        return None
+
+    def _project_q_range_mismatch_text(self) -> str | None:
+        settings = None
+        active_state = self._active_cluster_group_state()
+        if (
+            active_state is not None
+            and active_state.transform_result is not None
+        ):
+            settings = active_state.transform_result.preview.settings
+        elif self._fourier_result is not None:
+            settings = self._fourier_result.preview.settings
+        else:
+            try:
+                settings = self._fourier_settings_from_controls()
+            except Exception:
+                settings = None
+        if settings is None:
+            return None
+        mismatches: list[str] = []
+        if (
+            self._project_q_min is not None
+            and abs(float(settings.q_min) - float(self._project_q_min))
+            > 1.0e-9
+        ):
+            mismatches.append(
+                f"q min {settings.q_min:.6g} vs project {self._project_q_min:.6g}"
+            )
+        if (
+            self._project_q_max is not None
+            and abs(float(settings.q_max) - float(self._project_q_max))
+            > 1.0e-9
+        ):
+            mismatches.append(
+                f"q max {settings.q_max:.6g} vs project {self._project_q_max:.6g}"
+            )
+        if not mismatches:
+            return None
+        return (
+            "Fourier q-range differs from the inherited project q-range: "
+            + "; ".join(mismatches)
+            + ". The pushed model will use the transform q-grid as written."
+        )
+
+    def _update_push_to_model_state(self) -> None:
+        if not hasattr(self, "push_to_model_button"):
+            return
+        lock_reason = self._distribution_push_lock_reason()
+        pending_count = sum(
+            1
+            for state in self._cluster_group_states
+            if state.transform_result is None
+        )
+        if lock_reason is not None:
+            enabled = False
+            status_text = lock_reason
+        elif not self._cluster_group_states:
+            enabled = False
+            status_text = (
+                "Load a folder of cluster bins, calculate each density, and "
+                "evaluate each Born-approximation transform before pushing."
+            )
+        elif pending_count > 0:
+            enabled = False
+            status_text = (
+                f"{pending_count} cluster transform"
+                f"{'' if pending_count == 1 else 's'} still need to be evaluated."
+            )
+        else:
+            enabled = True
+            status_text = (
+                "All cluster transforms are ready to be written into the "
+                "linked computed distribution."
+            )
+            mismatch_text = self._project_q_range_mismatch_text()
+            if mismatch_text:
+                status_text += " " + mismatch_text
+        self.push_to_model_button.setEnabled(enabled)
+        self.push_to_model_status_label.setText(status_text)
+
+    def _is_calculation_running(self) -> bool:
+        return bool(self._calculation_ui_running)
+
+    def _cluster_group_is_complete(
+        self,
+        state: _ClusterDensityGroupState,
+    ) -> bool:
+        if state.single_atom_only:
+            return state.transform_result is not None
+        return state.profile_result is not None
+
+    def _completed_cluster_group_count(self) -> int:
+        return sum(
+            1
+            for state in self._cluster_group_states
+            if self._cluster_group_is_complete(state)
+        )
+
+    def _has_calculated_density_outputs(self) -> bool:
+        if any(
+            self._cluster_group_is_complete(state)
+            for state in self._cluster_group_states
+        ):
+            return True
+        return (
+            self._profile_result is not None
+            or self._fourier_result is not None
+        )
+
+    def _manual_mode_enabled_for_run(self) -> bool:
+        return bool(
+            self._cluster_group_states
+            and self.manual_mode_checkbox.isChecked()
+        )
+
+    def _refresh_manual_mode_notice(self) -> None:
+        if not hasattr(self, "manual_mode_notice_label"):
+            return
+        if not self._cluster_group_states:
+            self.manual_mode_notice_label.setText(
+                "Manual mode becomes available after loading a cluster-folder input."
+            )
+            return
+        if self._manual_mesh_lock_settings is not None:
+            self.manual_mode_notice_label.setText(
+                "Manual-mode calculations have locked the mesh at "
+                f"{self._format_mesh_settings_summary(self._manual_mesh_lock_settings)}. "
+                "Reset the calculated densities to edit the mesh again."
+            )
+            return
+        if self.manual_mode_checkbox.isChecked():
+            self.manual_mode_notice_label.setText(
+                "Manual mode will run only the selected stoichiometry row. "
+                "The first successful manual calculation locks the mesh "
+                "settings until reset."
+            )
+            return
+        self.manual_mode_notice_label.setText(
+            "Automatic mode preserves the current behavior and runs every "
+            "stoichiometry row in one pass."
+        )
+
+    def _refresh_cluster_completion_tracker(self) -> None:
+        if not hasattr(self, "cluster_completion_indicator"):
+            return
+        total = len(self._cluster_group_states)
+        if total <= 0:
+            self.cluster_completion_indicator.setText("PENDING")
+            self.cluster_completion_indicator.setStyleSheet(
+                "background-color: #94a3b8; color: white; padding: 4px 8px; "
+                "border-radius: 8px; font-weight: 600;"
+            )
+            self.cluster_completion_tracker_label.setText(
+                "Computed stoichiometries: n/a"
+            )
+            return
+        completed = self._completed_cluster_group_count()
+        all_complete = completed >= total
+        if all_complete:
+            label = "COMPLETE"
+            style = (
+                "background-color: #15803d; color: white; padding: 4px 8px; "
+                "border-radius: 8px; font-weight: 600;"
+            )
+        elif completed > 0:
+            label = "ACTIVE"
+            style = (
+                "background-color: #b45309; color: white; padding: 4px 8px; "
+                "border-radius: 8px; font-weight: 600;"
+            )
+        else:
+            label = "PENDING"
+            style = (
+                "background-color: #475569; color: white; padding: 4px 8px; "
+                "border-radius: 8px; font-weight: 600;"
+            )
+        self.cluster_completion_indicator.setText(label)
+        self.cluster_completion_indicator.setStyleSheet(style)
+        self.cluster_completion_tracker_label.setText(
+            "Computed stoichiometries: "
+            f"{completed}/{total}"
+            + (" (all complete)" if all_complete else "")
+        )
+
+    def _refresh_mesh_control_lock(self) -> None:
+        if not hasattr(self, "rstep_spin"):
+            return
+        enabled = not self._is_calculation_running() and (
+            self._manual_mesh_lock_settings is None
+        )
+        for widget in (
+            self.rstep_spin,
+            self.theta_divisions_spin,
+            self.phi_divisions_spin,
+            self.rmax_spin,
+            self.update_mesh_button,
+        ):
+            widget.setEnabled(enabled)
+
+    def _refresh_run_action_state(self) -> None:
+        if not hasattr(self, "run_button"):
+            return
+        running = self._is_calculation_running()
+        pending_thread_teardown = (
+            (not running)
+            and self._calculation_worker is not None
+            and self._calculation_thread is not None
+            and not getattr(
+                self._calculation_worker, "_cancel_requested", False
+            )
+        )
+        has_cluster_groups = bool(self._cluster_group_states)
+        if not has_cluster_groups and self.manual_mode_checkbox.isChecked():
+            self.manual_mode_checkbox.blockSignals(True)
+            self.manual_mode_checkbox.setChecked(False)
+            self.manual_mode_checkbox.blockSignals(False)
+        self.manual_mode_checkbox.setEnabled(
+            has_cluster_groups and not running
+        )
+        for widget in (
+            getattr(self, "apply_smearing_to_all_button", None),
+            getattr(self, "apply_contrast_to_all_button", None),
+            getattr(self, "apply_fourier_to_all_button", None),
+            getattr(self, "apply_debye_to_all_button", None),
+        ):
+            if widget is None:
+                continue
+            widget.setEnabled(has_cluster_groups and not running)
+        self.stop_calculation_button.setEnabled(
+            running or pending_thread_teardown
+        )
+        self.reset_calculations_button.setEnabled(
+            (not running) and self._has_calculated_density_outputs()
+        )
+        self._refresh_manual_mode_notice()
+        self._refresh_cluster_completion_tracker()
+        self._refresh_mesh_control_lock()
+        self._refresh_fourier_table_interaction_state()
+        self._refresh_debye_scattering_group()
+
+    def _update_cluster_group_status(self) -> None:
+        if not self._cluster_group_states:
+            self.cluster_group_status_label.setText(
+                "Single-file and folder inputs run directly. Loading a folder of "
+                "stoichiometry subfolders will populate a per-cluster summary table here."
+            )
+            if hasattr(self, "cluster_batch_scope_label"):
+                self.cluster_batch_scope_label.setText(
+                    "Batch solvent, smearing, and Fourier actions become "
+                    "available after loading cluster folders."
+                )
+            self._refresh_run_action_state()
+            return
+        density_ready = sum(
+            1
+            for state in self._cluster_group_states
+            if not state.single_atom_only and state.profile_result is not None
+        )
+        debye_only = sum(
+            1 for state in self._cluster_group_states if state.single_atom_only
+        )
+        scattering_ready = sum(
+            1
+            for state in self._cluster_group_states
+            if state.transform_result is not None
+        )
+        self.cluster_group_status_label.setText(
+            f"Cluster-folder mode: {len(self._cluster_group_states)} stoichiometries, "
+            f"{density_ready} density profiles ready, "
+            f"{debye_only} Debye-only groups, "
+            f"{scattering_ready} scattering profiles ready."
+        )
+        if hasattr(self, "cluster_batch_scope_label"):
+            selected_rows = self._selected_cluster_group_rows()
+            if selected_rows:
+                scope_text = (
+                    f"Current selected stoichiometry rows: "
+                    f"{len(selected_rows)}."
+                )
+            else:
+                scope_text = "Current selected stoichiometry rows: none."
+            self.cluster_batch_scope_label.setText(
+                "Select stoichiometry rows to target apply-to-selected "
+                "actions. Turn on Apply to All within Smearing, Electron "
+                "Density Contrast, or Fourier Transform to update every "
+                "stoichiometry instead. " + scope_text
+            )
+        self._refresh_run_action_state()
+
+    @staticmethod
+    def _apply_scope_status_text(apply_to_all: bool) -> str:
+        if apply_to_all:
+            return "Selection will be applied to all."
+        return "Selection will be applied to selected."
+
+    @Slot(bool)
+    def _refresh_smearing_scope_status(
+        self, _checked: bool | None = None
+    ) -> None:
+        if hasattr(self, "smearing_scope_status_label"):
+            self.smearing_scope_status_label.setText(
+                self._apply_scope_status_text(
+                    bool(self.apply_smearing_to_all_button.isChecked())
+                )
+            )
+
+    def _auto_save_smearing_outputs_enabled(self) -> bool:
+        if not hasattr(self, "auto_save_smearing_outputs_checkbox"):
+            return False
+        return bool(self.auto_save_smearing_outputs_checkbox.isChecked())
+
+    @Slot(bool)
+    def _on_auto_save_smearing_outputs_toggled(
+        self,
+        _checked: bool | None = None,
+    ) -> None:
+        self._sync_workspace_state()
+
+    def _capture_smearing_saved_output_if_enabled(
+        self,
+        *,
+        group_state: _ClusterDensityGroupState | None = None,
+        profile_result: ElectronDensityProfileResult | None = None,
+    ) -> bool:
+        if not self._auto_save_smearing_outputs_enabled():
+            return False
+        self._capture_saved_output_entry(
+            "smearing",
+            group_state=group_state,
+            profile_result=profile_result,
+        )
+        return True
+
+    @Slot(bool)
+    def _refresh_contrast_scope_status(
+        self, _checked: bool | None = None
+    ) -> None:
+        if hasattr(self, "contrast_scope_status_label"):
+            self.contrast_scope_status_label.setText(
+                self._apply_scope_status_text(
+                    bool(self.apply_contrast_to_all_button.isChecked())
+                )
+            )
+
+    @Slot(bool)
+    def _refresh_fourier_scope_status(
+        self, _checked: bool | None = None
+    ) -> None:
+        if hasattr(self, "fourier_scope_status_label"):
+            if not self._cluster_group_states:
+                self.fourier_scope_status_label.setText(
+                    "Batch Fourier editing becomes available in "
+                    "cluster-folder mode."
+                )
+                return
+            self.fourier_scope_status_label.setText(
+                self._apply_scope_status_text(
+                    bool(self.apply_fourier_to_all_button.isChecked())
+                )
+            )
+
+    def _refresh_fourier_table_interaction_state(self) -> None:
+        if not hasattr(self, "fourier_settings_table"):
+            return
+        has_cluster_groups = bool(self._cluster_group_states)
+        apply_to_all = bool(
+            has_cluster_groups and self.apply_fourier_to_all_button.isChecked()
+        )
+        running = self._is_calculation_running()
+        for widget in (
+            self.fourier_rmax_spin,
+            self.fourier_qmin_spin,
+            self.fourier_qmax_spin,
+            self.fourier_qstep_spin,
+            self.fourier_window_combo,
+            self.fourier_resampling_points_spin,
+            self.fourier_use_solvent_subtracted_checkbox,
+            self.fourier_legacy_mode_checkbox,
+        ):
+            widget.setEnabled(not apply_to_all and not running)
+        self.fourier_rmin_spin.setEnabled(
+            (
+                not apply_to_all
+                and not running
+                and self._fourier_domain_mode_from_controls() == "legacy"
+            )
+        )
+        self._refresh_fourier_domain_mode_controls()
+        self.fourier_settings_table.setEnabled(
+            has_cluster_groups and not running
+        )
+        self.fourier_settings_table.setEditTriggers(
+            (
+                QTableWidget.EditTrigger.DoubleClicked
+                | QTableWidget.EditTrigger.EditKeyPressed
+                | QTableWidget.EditTrigger.SelectedClicked
+            )
+            if apply_to_all and not running
+            else QTableWidget.EditTrigger.NoEditTriggers
+        )
+        self._populate_fourier_settings_table()
+
+    def _populate_fourier_settings_table(self) -> None:
+        if not hasattr(self, "fourier_settings_table"):
+            return
+        active_key = self._selected_cluster_group_key
+        self._updating_fourier_settings_table = True
+        self.fourier_settings_table.blockSignals(True)
+        try:
+            self.fourier_settings_table.setRowCount(
+                len(self._cluster_group_states)
+            )
+            for row_index, state in enumerate(self._cluster_group_states):
+                settings = self._cluster_state_fourier_settings(state)
+                status_text = (
+                    "Ready (Debye)"
+                    if state.single_atom_only
+                    and state.transform_result is not None
+                    else (
+                        "Pending (Debye)"
+                        if state.single_atom_only
+                        else (
+                            "Ready"
+                            if state.transform_result is not None
+                            else "Pending"
+                        )
+                    )
+                )
+                values = [
+                    state.display_name,
+                    status_text,
+                    self._fourier_profile_label_for_settings(
+                        settings,
+                        single_atom_only=state.single_atom_only,
+                    ),
+                    f"{settings.r_min:.6g}",
+                    f"{settings.r_max:.6g}",
+                    f"{settings.q_min:.6g}",
+                    f"{settings.q_max:.6g}",
+                    f"{settings.q_step:.6g}",
+                    str(int(settings.resampling_points)),
+                    str(settings.window_function),
+                ]
+                editable_columns = {
+                    _FT_COLUMN_PROFILE,
+                    _FT_COLUMN_RMAX,
+                    _FT_COLUMN_QMIN,
+                    _FT_COLUMN_QMAX,
+                    _FT_COLUMN_QSTEP,
+                    _FT_COLUMN_RESAMPLE,
+                    _FT_COLUMN_WINDOW,
+                }
+                if settings.domain_mode == "legacy":
+                    editable_columns.add(_FT_COLUMN_RMIN)
+                for column_index, value in enumerate(values):
+                    item = QTableWidgetItem(value)
+                    flags = (
+                        Qt.ItemFlag.ItemIsEnabled
+                        | Qt.ItemFlag.ItemIsSelectable
+                    )
+                    if (
+                        self.apply_fourier_to_all_button.isChecked()
+                        and column_index in editable_columns
+                        and not state.single_atom_only
+                    ) or (
+                        self.apply_fourier_to_all_button.isChecked()
+                        and state.single_atom_only
+                        and column_index
+                        in {
+                            _FT_COLUMN_QMIN,
+                            _FT_COLUMN_QMAX,
+                            _FT_COLUMN_QSTEP,
+                            _FT_COLUMN_RESAMPLE,
+                            _FT_COLUMN_WINDOW,
+                        }
+                    ):
+                        flags |= Qt.ItemFlag.ItemIsEditable
+                    item.setFlags(flags)
+                    self.fourier_settings_table.setItem(
+                        row_index,
+                        column_index,
+                        item,
+                    )
+            if active_key is not None:
+                self._sync_fourier_settings_table_selection(active_key)
+        finally:
+            self.fourier_settings_table.blockSignals(False)
+            self._updating_fourier_settings_table = False
+
+    def _sync_fourier_settings_table_selection(self, group_key: str) -> None:
+        if (
+            not hasattr(self, "fourier_settings_table")
+            or not self._cluster_group_states
+        ):
+            return
+        self._syncing_cluster_selection = True
+        self.fourier_settings_table.blockSignals(True)
+        try:
+            target_row = -1
+            for row_index, state in enumerate(self._cluster_group_states):
+                if state.key == group_key:
+                    target_row = row_index
+                    break
+            if target_row >= 0:
+                self.fourier_settings_table.setCurrentCell(target_row, 0)
+                self.fourier_settings_table.selectRow(target_row)
+        finally:
+            self.fourier_settings_table.blockSignals(False)
+            self._syncing_cluster_selection = False
+
+    def _resolve_fourier_window_value(self, raw_value: str) -> str:
+        candidate = (
+            str(raw_value).strip().lower().replace(" ", "_").replace("-", "_")
+        )
+        for index in range(self.fourier_window_combo.count()):
+            data = str(self.fourier_window_combo.itemData(index) or "")
+            text = (
+                str(self.fourier_window_combo.itemText(index))
+                .strip()
+                .lower()
+                .replace(" ", "_")
+                .replace("-", "_")
+            )
+            if candidate == data or candidate == text:
+                return data
+        raise ValueError("Choose a supported Fourier window name.")
+
+    @Slot()
+    def _handle_fourier_settings_table_selection_changed(self) -> None:
+        if self._syncing_cluster_selection:
+            return
+        selected_ranges = self.fourier_settings_table.selectedRanges()
+        if not selected_ranges:
+            return
+        row_index = int(selected_ranges[0].topRow())
+        if row_index < 0 or row_index >= len(self._cluster_group_states):
+            return
+        group_key = self._cluster_group_states[row_index].key
+        self._syncing_cluster_selection = True
+        try:
+            self._set_current_cluster_group_row(
+                group_key,
+                preserve_selection=True,
+            )
+        finally:
+            self._syncing_cluster_selection = False
+        self._set_active_cluster_group(group_key)
+
+    @Slot(QTableWidgetItem)
+    def _handle_fourier_settings_table_item_changed(
+        self,
+        item: QTableWidgetItem,
+    ) -> None:
+        if (
+            self._updating_fourier_settings_table
+            or not self.apply_fourier_to_all_button.isChecked()
+        ):
+            return
+        row_index = int(item.row())
+        column_index = int(item.column())
+        if row_index < 0 or row_index >= len(self._cluster_group_states):
+            return
+        state = self._cluster_group_states[row_index]
+        current_settings = self._cluster_state_fourier_settings(state)
+        try:
+            new_settings = ElectronDensityFourierTransformSettings(
+                r_min=(
+                    float(item.text())
+                    if column_index == _FT_COLUMN_RMIN
+                    else current_settings.r_min
+                ),
+                r_max=(
+                    float(item.text())
+                    if column_index == _FT_COLUMN_RMAX
+                    else current_settings.r_max
+                ),
+                domain_mode=current_settings.domain_mode,
+                window_function=(
+                    self._resolve_fourier_window_value(item.text())
+                    if column_index == _FT_COLUMN_WINDOW
+                    else current_settings.window_function
+                ),
+                resampling_points=(
+                    int(float(item.text()))
+                    if column_index == _FT_COLUMN_RESAMPLE
+                    else current_settings.resampling_points
+                ),
+                q_min=(
+                    float(item.text())
+                    if column_index == _FT_COLUMN_QMIN
+                    else current_settings.q_min
+                ),
+                q_max=(
+                    float(item.text())
+                    if column_index == _FT_COLUMN_QMAX
+                    else current_settings.q_max
+                ),
+                q_step=(
+                    float(item.text())
+                    if column_index == _FT_COLUMN_QSTEP
+                    else current_settings.q_step
+                ),
+                use_solvent_subtracted_profile=(
+                    ("solvent" in str(item.text()).strip().lower())
+                    if column_index == _FT_COLUMN_PROFILE
+                    else current_settings.use_solvent_subtracted_profile
+                ),
+                log_q_axis=current_settings.log_q_axis,
+                log_intensity_axis=current_settings.log_intensity_axis,
+            ).normalized()
+        except Exception:
+            self._populate_fourier_settings_table()
+            return
+        if column_index in {
+            _FT_COLUMN_PROFILE,
+            _FT_COLUMN_QMIN,
+            _FT_COLUMN_QMAX,
+            _FT_COLUMN_QSTEP,
+            _FT_COLUMN_RESAMPLE,
+            _FT_COLUMN_WINDOW,
+        }:
+            for target_state in self._cluster_group_states:
+                self._set_cluster_state_fourier_settings(
+                    target_state,
+                    self._shared_fourier_settings_for_state(
+                        target_state,
+                        new_settings,
+                    ),
+                    prefer_solvent_cutoff=False,
+                )
+        else:
+            self._set_cluster_state_fourier_settings(
+                state,
+                new_settings,
+                prefer_solvent_cutoff=False,
+            )
+        active_key = self._selected_cluster_group_key
+        self._populate_cluster_group_table()
+        self._populate_fourier_settings_table()
+        if active_key is not None:
+            self._set_active_cluster_group(active_key)
+        self._sync_workspace_state()
+
+    @Slot(bool)
+    def _handle_fourier_apply_to_all_toggled(self, checked: bool) -> None:
+        self._refresh_fourier_scope_status(checked)
+        if checked and self._cluster_group_states:
+            reference_state = (
+                self._active_cluster_group_state()
+                or self._cluster_group_states[0]
+            )
+            reference_settings = self._cluster_state_fourier_settings(
+                reference_state
+            )
+            for state in self._cluster_group_states:
+                self._set_cluster_state_fourier_settings(
+                    state,
+                    self._shared_fourier_settings_for_state(
+                        state,
+                        reference_settings,
+                    ),
+                    prefer_solvent_cutoff=False,
+                )
+            active_key = self._selected_cluster_group_key
+            self._populate_cluster_group_table()
+            self._populate_fourier_settings_table()
+            if active_key is not None:
+                self._set_active_cluster_group(active_key)
+        elif self._selected_cluster_group_key is not None:
+            self._set_active_cluster_group(self._selected_cluster_group_key)
+        self._refresh_fourier_table_interaction_state()
+        self._sync_workspace_state()
+
+    def _use_contiguous_frame_mode(self) -> bool:
+        if not hasattr(self, "contiguous_frame_mode_checkbox"):
+            return True
+        return bool(self.contiguous_frame_mode_checkbox.isChecked())
+
+    def _use_pinned_geometric_tracking(self) -> bool:
+        return bool(self.pinned_geometric_tracking_checkbox.isChecked())
+
+    def _current_input_supports_pinned_geometric_tracking(self) -> bool:
+        if self._cluster_group_states:
+            return bool(self._cluster_group_states) and all(
+                state.inspection.input_mode == "folder"
+                and state.inspection.total_files > 1
+                and set(state.inspection.format_counts).issubset({"pdb"})
+                for state in self._cluster_group_states
+            )
+        return bool(
+            self._inspection is not None
+            and self._inspection.input_mode == "folder"
+            and self._inspection.total_files > 1
+            and set(self._inspection.format_counts).issubset({"pdb"})
+        )
+
+    @Slot(bool)
+    def _handle_contiguous_frame_mode_toggled(self, _checked: bool) -> None:
+        self._refresh_contiguous_frame_mode_notice()
+        self._refresh_pinned_geometric_tracking_controls()
+        self._refresh_mesh_notice()
+        self._sync_workspace_state()
+
+    @Slot(bool)
+    def _handle_pinned_geometric_tracking_toggled(
+        self, _checked: bool
+    ) -> None:
+        self._refresh_pinned_geometric_tracking_controls()
+        self._refresh_contiguous_frame_mode_notice()
+        self._refresh_mesh_notice()
+        self._sync_workspace_state()
+
+    def _refresh_pinned_geometric_tracking_controls(self) -> None:
+        center_mode = (
+            "center_of_mass"
+            if self._structure is None
+            else str(self._structure.center_mode)
+        )
+        supports_tracking = (
+            self._current_input_supports_pinned_geometric_tracking()
+        )
+        enabled = bool(
+            center_mode == "center_of_mass"
+            and self._use_contiguous_frame_mode()
+            and supports_tracking
+        )
+        if not enabled and self.pinned_geometric_tracking_checkbox.isChecked():
+            self.pinned_geometric_tracking_checkbox.blockSignals(True)
+            try:
+                self.pinned_geometric_tracking_checkbox.setChecked(False)
+            finally:
+                self.pinned_geometric_tracking_checkbox.blockSignals(False)
+        self.pinned_geometric_tracking_checkbox.setEnabled(enabled)
+        if center_mode != "center_of_mass":
+            notice = (
+                "Pinned geometric tracking is available only while "
+                "Geometric Mass Center mode is selected."
+            )
+        elif not self._use_contiguous_frame_mode():
+            notice = (
+                "Pinned geometric tracking also requires contiguous-frame "
+                "evaluation to be enabled."
+            )
+        elif not supports_tracking:
+            notice = (
+                "Pinned geometric tracking applies to folder or cluster-folder "
+                "runs with contiguous PDB frame_<NNNN> files."
+            )
+        elif self._use_pinned_geometric_tracking():
+            notice = (
+                "Pinned geometric tracking is on. Each contiguous PDB frame set "
+                "will reuse the first frame's geometric mass center coordinates."
+            )
+        else:
+            notice = (
+                "Optional: pin each contiguous PDB frame set to the first "
+                "frame's geometric mass center coordinates to capture "
+                "displacements without recentering every frame."
+            )
+        self.pinned_geometric_tracking_notice.setText(notice)
+
+    @staticmethod
+    def _center_mode_label_for_structure(
+        structure: ElectronDensityStructure | None,
+    ) -> str:
+        if structure is None:
+            return "Unavailable"
+        if structure.center_mode == "center_of_mass":
+            return "Geometric Mass Center"
+        if structure.center_mode == "nearest_atom":
+            return "Nearest atom to geometric mass center"
+        return (
+            f"{structure.reference_element} reference-element "
+            "geometric center"
+        )
+
+    @staticmethod
+    def _center_mode_table_text_for_structure(
+        structure: ElectronDensityStructure | None,
+    ) -> str:
+        if structure is None:
+            return "Unavailable"
+        if structure.center_mode == "center_of_mass":
+            return "Geom Mass"
+        if structure.center_mode == "nearest_atom":
+            return "Nearest Atom"
+        return "Ref Element"
+
+    @staticmethod
+    def _center_reference_table_text_for_structure(
+        structure: ElectronDensityStructure | None,
+    ) -> str:
+        if structure is None:
+            return "Unavailable"
+        if structure.center_mode == "center_of_mass":
+            return "Geom Mass"
+        if structure.center_mode == "nearest_atom":
+            return (
+                f"{structure.nearest_atom_element} atom "
+                f"#{structure.nearest_atom_index + 1}"
+            )
+        return f"{structure.reference_element} geom center"
+
+    def _center_reference_tooltip_for_structure(
+        self,
+        structure: ElectronDensityStructure | None,
+    ) -> str:
+        if structure is None:
+            return "Unavailable"
+        if structure.center_mode == "center_of_mass":
+            return (
+                "Geometric mass center at "
+                f"{self._format_point(structure.active_center)}. "
+                "Nearest atom to that point: "
+                f"{structure.nearest_atom_element} atom "
+                f"#{structure.nearest_atom_index + 1}, "
+                f"{structure.nearest_atom_distance:.3f} Å away."
+            )
+        if structure.center_mode == "nearest_atom":
+            return (
+                "Nearest atom to the geometric mass center: "
+                f"{structure.nearest_atom_element} atom "
+                f"#{structure.nearest_atom_index + 1}, "
+                f"{structure.nearest_atom_distance:.3f} Å away. "
+                f"Active center = {self._format_point(structure.active_center)}."
+            )
+        return (
+            "Reference-element center uses "
+            f"{structure.reference_element}; "
+            "reference-element geometric center = "
+            f"{self._format_point(structure.reference_element_geometric_center)}. "
+            "Offset from the total-atom geometric center = "
+            f"{structure.reference_element_offset_from_geometric_center:.3f} Å."
+        )
+
+    @staticmethod
+    def _format_mesh_settings_summary(
+        settings: ElectronDensityMeshSettings,
+    ) -> str:
+        normalized = settings.normalized()
+        summary = (
+            f"rstep={normalized.rstep:.3f} Å, "
+            f"theta={normalized.theta_divisions}, "
+            f"phi={normalized.phi_divisions}, "
+            f"rmax={normalized.rmax:.3f} Å"
+        )
+        if normalized.pin_contiguous_geometric_tracking:
+            summary += ", pinned tracking=on"
+        return summary
+
+    def _set_mesh_settings_confirmed_for_run(
+        self,
+        confirmed: bool,
+    ) -> None:
+        self._mesh_settings_confirmed_for_run = bool(confirmed)
+        if hasattr(self, "pending_mesh_value"):
+            self._refresh_mesh_notice()
+
+    def _mesh_confirmation_carries_forward_on_auto_apply(self) -> bool:
+        return bool(
+            self._mesh_settings_confirmed_for_run
+            and self._mesh_settings_from_controls()
+            == self._active_mesh_settings
+        )
+
+    def _refresh_contiguous_frame_mode_notice(self) -> None:
+        base_notice = (
+            "Default: on. Folder and cluster-folder runs will try contiguous "
+            "frame grouping from frame_<NNNN> file names and preserve the "
+            "active center mode from the mesh settings as a shared offset "
+            "relative to the heaviest-element geometric center."
+        )
+        tooltip = (
+            "When averaging multiple structures, group files by frame_<NNNN> "
+            "sequences and lock each contiguous set to a shared active-center "
+            "offset relative to the heaviest-element geometric center."
+        )
+        if self._structure is None:
+            center_notice = (
+                " Load a structure to show which active center contiguous-frame "
+                "evaluation will use."
+            )
+        else:
+            center_label = self._center_mode_label_for_structure(
+                self._structure
+            )
+            center_notice = (
+                " Current active center mode: "
+                f"{center_label}; active center="
+                f"{self._format_point(self._structure.active_center)}."
+            )
+            tooltip += (
+                " Current active center mode: "
+                f"{center_label}; active center="
+                f"{self._format_point(self._structure.active_center)}."
+            )
+        self.contiguous_frame_mode_notice.setText(
+            base_notice
+            + center_notice
+            + (
+                " Pinned geometric tracking is ready for contiguous PDB sets."
+                if self._use_pinned_geometric_tracking()
+                else ""
+            )
+            + " Files without frame_<NNNN> identifiers fall back to complete "
+            "averaging with a status notice."
+        )
+        self.contiguous_frame_mode_checkbox.setToolTip(tooltip)
+
+    @staticmethod
+    def _format_contiguous_frame_set(
+        frame_set: ElectronDensityContiguousFrameSetSummary,
+    ) -> str:
+        series_text = (
+            f"{frame_set.series_label}: "
+            if str(frame_set.series_label).strip()
+            and str(frame_set.series_label).strip().lower() != "default"
+            else ""
+        )
+        if frame_set.frame_count <= 1:
+            return (
+                f"{series_text}frame {frame_set.frame_range_label} "
+                f"({frame_set.frame_count} file)"
+            )
+        return (
+            f"{series_text}frames {frame_set.frame_range_label} "
+            f"({frame_set.frame_count} files)"
+        )
+
+    def _append_averaging_status(
+        self,
+        result: ElectronDensityProfileResult,
+        *,
+        prefix: str = "",
+    ) -> None:
+        label_prefix = str(prefix).strip()
+        if label_prefix:
+            label_prefix = label_prefix.rstrip() + " "
+        if result.contiguous_frame_mode_applied:
+            if result.pinned_geometric_tracking_applied:
+                self._append_status(
+                    f"{label_prefix}Contiguous-frame evaluation pinned "
+                    f"{len(result.contiguous_frame_sets)} frame set"
+                    f"{'' if len(result.contiguous_frame_sets) == 1 else 's'} "
+                    "to the first frame's geometric mass center coordinates."
+                )
+            else:
+                center_label = self._center_mode_label_for_structure(
+                    result.structure
+                )
+                self._append_status(
+                    f"{label_prefix}Contiguous-frame evaluation locked "
+                    f"{len(result.contiguous_frame_sets)} frame set"
+                    f"{'' if len(result.contiguous_frame_sets) == 1 else 's'} "
+                    "to shared centers relative to the heaviest-element anchor "
+                    "using the active center mode from the mesh settings: "
+                    f"{center_label}."
+                )
+            for note in result.averaging_notes:
+                self._append_status(f"{label_prefix}{note}")
+            for frame_set in result.contiguous_frame_sets:
+                self._append_status(
+                    f"{label_prefix}{self._format_contiguous_frame_set(frame_set)}"
+                )
+        elif result.contiguous_frame_mode_requested:
+            for note in result.averaging_notes:
+                self._append_status(f"{label_prefix}{note}")
+
+    @staticmethod
+    def _profile_overlay_for_result(
+        result: ElectronDensityProfileResult | None,
+    ) -> ElectronDensityProfileOverlay | None:
+        if result is None or result.solvent_contrast is None:
+            return None
+        contrast = result.solvent_contrast
+        return ElectronDensityProfileOverlay(
+            solvent_density_e_per_a3=float(contrast.solvent_density_e_per_a3),
+            solvent_density_label=contrast.legend_label,
+            cutoff_radius_a=contrast.cutoff_radius_a,
+            cutoff_label=contrast.cutoff_label,
+            solvent_subtracted_density=np.asarray(
+                contrast.solvent_subtracted_smeared_density,
+                dtype=float,
+            ),
+            solvent_subtracted_label="Solvent-subtracted ρ(r)",
+        )
+
+    @staticmethod
+    def _format_saved_output_timestamp(timestamp: str) -> str:
+        try:
+            return datetime.fromisoformat(str(timestamp)).strftime(
+                "%Y-%m-%d %H:%M:%S"
+            )
+        except Exception:
+            return str(timestamp).strip() or "Unknown time"
+
+    @staticmethod
+    def _saved_output_entry_kind_label(entry_kind: str) -> str:
+        normalized = str(entry_kind).strip().lower()
+        if normalized == "fourier_transform":
+            return "Fourier Transform"
+        if normalized == "smearing":
+            return "Smearing"
+        if normalized == "solvent_subtraction":
+            return "Solvent Subtraction"
+        return "Electron Density"
+
+    @staticmethod
+    def _saved_output_context_label(entry: _SavedOutputEntry) -> str:
+        return (
+            str(entry.group_label).strip()
+            or entry.profile_result.structure.file_path.name
+        )
+
+    @staticmethod
+    def _saved_output_entry_heading(
+        entry: _SavedOutputEntry,
+        *,
+        index: int | None = None,
+    ) -> str:
+        prefix = "" if index is None else f"{index}. "
+        return (
+            prefix
+            + ElectronDensityMappingMainWindow._saved_output_context_label(
+                entry
+            )
+            + " · "
+            + ElectronDensityMappingMainWindow._saved_output_entry_kind_label(
+                entry.entry_kind
+            )
+        )
+
+    @staticmethod
+    def _saved_output_entry_summary_text(entry: _SavedOutputEntry) -> str:
+        result = entry.profile_result
+        mesh_settings = result.mesh_geometry.settings
+        solvent_text = (
+            result.solvent_contrast.legend_label
+            if result.solvent_contrast is not None
+            else "No solvent subtraction"
+        )
+        fourier_text = (
+            "Evaluated"
+            if entry.transform_result is not None
+            else "Preview only"
+        )
+        return (
+            f"Saved {ElectronDensityMappingMainWindow._format_saved_output_timestamp(entry.created_at)} "
+            f"in {'Preview' if entry.preview_mode else 'Computed Distribution'} mode. "
+            f"Averaging: {str(result.averaging_mode).replace('_', ' ')}. "
+            f"Mesh: rstep={mesh_settings.rstep:.3f} Å, rmax={mesh_settings.rmax:.3f} Å. "
+            f"Smearing factor={result.smearing_settings.debye_waller_factor:.6g} Å². "
+            f"Solvent: {solvent_text}. "
+            f"Fourier: {fourier_text} with window={entry.fourier_settings.window_function}, "
+            f"r={entry.fourier_settings.r_min:.3f}–{entry.fourier_settings.r_max:.3f} Å."
+        )
+
+    @staticmethod
+    def _safe_saved_output_slug(value: str) -> str:
+        normalized = "".join(
+            character if character.isalnum() or character in "._-" else "_"
+            for character in str(value).strip()
+        )
+        return normalized.strip("._") or "saved_output"
+
+    @staticmethod
+    def _saved_output_entry_file_stem(
+        entry: _SavedOutputEntry,
+        *,
+        index: int,
+    ) -> str:
+        context = ElectronDensityMappingMainWindow._saved_output_context_label(
+            entry
+        )
+        return ElectronDensityMappingMainWindow._safe_saved_output_slug(
+            f"{index:02d}_{entry.entry_kind}_{context}_{entry.entry_id}"
+        )
+
+    def _update_output_history_summary(self) -> None:
+        if not hasattr(self, "output_history_summary_label"):
+            return
+        count = len(self._saved_output_entries)
+        history_path = self._saved_output_history_write_path()
+        if count == 0:
+            persistence_text = (
+                f" Persisted history will be written to {history_path}."
+                if history_path is not None
+                else " A writable output directory or computed distribution link is needed for persistence."
+            )
+            self.output_history_summary_label.setText(
+                "Density calculations, solvent-subtracted outputs, Fourier "
+                "evaluations, and optional smearing snapshots will be captured "
+                "here for reload and comparison." + persistence_text
+            )
+            return
+        self.output_history_summary_label.setText(
+            f"{count} saved output set"
+            f"{'' if count == 1 else 's'} ready. "
+            "Use Command/Ctrl-click to compare multiple entries in a separate window."
+        )
+
+    def _output_history_selected_rows(self) -> list[int]:
+        if not hasattr(self, "output_history_table"):
+            return []
+        selection_model = self.output_history_table.selectionModel()
+        if selection_model is None:
+            return []
+        return sorted(
+            {index.row() for index in selection_model.selectedRows()}
+        )
+
+    def _selected_output_history_entries(self) -> list[_SavedOutputEntry]:
+        selected_entries: list[_SavedOutputEntry] = []
+        for row_index in self._output_history_selected_rows():
+            item = self.output_history_table.item(row_index, 0)
+            entry_id = (
+                None if item is None else item.data(Qt.ItemDataRole.UserRole)
+            )
+            for entry in self._saved_output_entries:
+                if entry.entry_id == entry_id:
+                    selected_entries.append(entry)
+                    break
+        return selected_entries
+
+    def _update_output_history_actions(self) -> None:
+        if not hasattr(self, "load_output_history_button"):
+            return
+        selected_count = len(self._output_history_selected_rows())
+        self.load_output_history_button.setEnabled(selected_count == 1)
+        self.compare_output_history_button.setEnabled(selected_count >= 1)
+
+    def _populate_output_history_table(self) -> None:
+        if not hasattr(self, "output_history_table"):
+            return
+        entries = list(reversed(self._saved_output_entries))
+        self.output_history_table.blockSignals(True)
+        self.output_history_table.setRowCount(len(entries))
+        for row_index, entry in enumerate(entries):
+            result = entry.profile_result
+            mesh_settings = result.mesh_geometry.settings
+            solvent_text = (
+                result.solvent_contrast.legend_label
+                if result.solvent_contrast is not None
+                else "None"
+            )
+            averaging_text = str(result.averaging_mode).replace("_", " ")
+            if result.contiguous_frame_mode_applied:
+                averaging_text += (
+                    " · pinned geometric"
+                    if result.pinned_geometric_tracking_applied
+                    else " · contiguous"
+                )
+            elif result.contiguous_frame_mode_requested:
+                averaging_text += " · fallback"
+            values = [
+                self._format_saved_output_timestamp(entry.created_at),
+                self._saved_output_entry_kind_label(entry.entry_kind),
+                self._saved_output_context_label(entry),
+                averaging_text,
+                (
+                    f"rstep={mesh_settings.rstep:.3f} Å, "
+                    f"rmax={mesh_settings.rmax:.3f} Å"
+                ),
+                f"{result.smearing_settings.debye_waller_factor:.6g} Å²",
+                solvent_text,
+                (
+                    f"{entry.fourier_settings.window_function}, "
+                    f"r={entry.fourier_settings.r_min:.3f}–"
+                    f"{entry.fourier_settings.r_max:.3f} Å"
+                    + (
+                        ""
+                        if entry.transform_result is not None
+                        else " (preview)"
+                    )
+                ),
+            ]
+            for column_index, value in enumerate(values):
+                item = QTableWidgetItem(value)
+                item.setFlags(
+                    Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable
+                )
+                if column_index == 0:
+                    item.setData(Qt.ItemDataRole.UserRole, entry.entry_id)
+                    item.setToolTip(
+                        self._saved_output_entry_summary_text(entry)
+                    )
+                self.output_history_table.setItem(
+                    row_index, column_index, item
+                )
+        self.output_history_table.blockSignals(False)
+        self._update_output_history_summary()
+        self._update_output_history_actions()
+
+    def _clear_saved_output_history(self, *, announce: bool) -> None:
+        self._saved_output_entries = []
+        if hasattr(self, "output_history_table"):
+            self.output_history_table.setRowCount(0)
+        self._update_output_history_summary()
+        self._update_output_history_actions()
+        if announce:
+            self._append_status("Cleared the saved output history.")
+
+    @staticmethod
+    def _cluster_group_cutoff_text(
+        state: _ClusterDensityGroupState,
+    ) -> str:
+        if state.single_atom_only:
+            return "n/a"
+        if state.profile_result is None:
+            return "Pending"
+        if state.solvent_density_e_per_a3 is None:
+            return "Pending"
+        if state.solvent_cutoff_radius_a is None:
+            return "Not found"
+        return f"{state.solvent_cutoff_radius_a:.6g}"
+
+    def _cluster_group_fourier_settings_text(
+        self,
+        state: _ClusterDensityGroupState,
+    ) -> str:
+        transform = state.transform_result
+        settings = (
+            transform.preview.settings
+            if transform is not None
+            else self._cluster_state_fourier_settings(state)
+        )
+        if state.single_atom_only:
+            return (
+                f"Debye - q={settings.q_min:.3f}-{settings.q_max:.3f} "
+                f"1/A, dq={settings.q_step:.3f}"
+            )
+        preview_source = (
+            str(transform.preview.source_profile_label).lower()
+            if transform is not None
+            else self._fourier_profile_label_for_settings(
+                settings,
+                single_atom_only=False,
+            )
+        )
+        profile_source = (
+            "solvent" if "solvent-subtracted" in preview_source else "smeared"
+        )
+        return (
+            f"{profile_source} - {settings.window_function} - "
+            f"r={settings.r_min:.3f}-{settings.r_max:.3f} A - "
+            f"q={settings.q_min:.3f}-{settings.q_max:.3f} 1/A"
+        )
+
+    def _populate_cluster_group_table(self) -> None:
+        active_key = str(self._selected_cluster_group_key or "").strip()
+        self.cluster_group_table.blockSignals(True)
+        self.cluster_group_table.setRowCount(0)
+        self.cluster_group_table.setRowCount(len(self._cluster_group_states))
+        for row_index, state in enumerate(self._cluster_group_states):
+            structure = state.reference_structure
+            if state.single_atom_only:
+                profile_status = "Skipped (Debye)"
+                transform_status = (
+                    "Ready (Debye)"
+                    if state.transform_result is not None
+                    else "Auto on Run"
+                )
+            else:
+                profile_status = (
+                    "Ready" if state.profile_result is not None else "Pending"
+                )
+                transform_status = (
+                    "Ready"
+                    if state.transform_result is not None
+                    else "Pending"
+                )
+            center_element_combo = QComboBox(self.cluster_group_table)
+            for element in sorted(structure.element_counts):
+                count = int(structure.element_counts[element])
+                center_element_combo.addItem(f"{element} ({count})", element)
+            center_element_combo.setCurrentIndex(
+                max(
+                    center_element_combo.findData(structure.reference_element),
+                    0,
+                )
+            )
+            center_element_combo.setToolTip(
+                "Stored reference-element center for this stoichiometry. "
+                "This selection is used whenever reference-element centering "
+                "is active. Current center mode: "
+                f"{self._center_mode_label_for_structure(structure)}. "
+                f"{self._center_reference_tooltip_for_structure(structure)}"
+            )
+            center_element_combo.currentIndexChanged.connect(
+                lambda _index, group_key=state.key, combo=center_element_combo: (
+                    self._handle_cluster_group_reference_element_changed(
+                        group_key,
+                        combo,
+                    )
+                )
+            )
+            self.cluster_group_table.setCellWidget(
+                row_index,
+                _CLUSTER_GROUP_COLUMN_CENTER_ELEMENT,
+                center_element_combo,
+            )
+            values = [
+                (_CLUSTER_GROUP_COLUMN_STOICHIOMETRY, state.display_name),
+                (
+                    _CLUSTER_GROUP_COLUMN_FILES,
+                    str(state.inspection.total_files),
+                ),
+                (
+                    _CLUSTER_GROUP_COLUMN_AVG_ATOMS,
+                    f"{state.average_atom_count:.1f}",
+                ),
+                (
+                    _CLUSTER_GROUP_COLUMN_CENTER_MODE,
+                    self._center_mode_table_text_for_structure(structure),
+                ),
+                (
+                    _CLUSTER_GROUP_COLUMN_CENTER_REFERENCE,
+                    self._center_reference_table_text_for_structure(structure),
+                ),
+                (_CLUSTER_GROUP_COLUMN_DENSITY, profile_status),
+                (_CLUSTER_GROUP_COLUMN_FOURIER, transform_status),
+                (_CLUSTER_GROUP_COLUMN_TRACE_COLOR, state.trace_color),
+                (
+                    _CLUSTER_GROUP_COLUMN_SMEARING,
+                    (
+                        f"{state.profile_result.smearing_settings.debye_waller_factor:.6g}"
+                        if state.profile_result is not None
+                        else f"{self.smearing_factor_spin.value():.6g}"
+                    ),
+                ),
+                (
+                    _CLUSTER_GROUP_COLUMN_SOLVENT,
+                    (
+                        f"{state.solvent_density_e_per_a3:.6g}"
+                        if state.solvent_density_e_per_a3 is not None
+                        else "Pending"
+                    ),
+                ),
+                (
+                    _CLUSTER_GROUP_COLUMN_CUTOFF,
+                    self._cluster_group_cutoff_text(state),
+                ),
+                (
+                    _CLUSTER_GROUP_COLUMN_FT_SETTINGS,
+                    self._cluster_group_fourier_settings_text(state),
+                ),
+                (
+                    _CLUSTER_GROUP_COLUMN_REFERENCE_FILE,
+                    state.inspection.reference_file.name,
+                ),
+            ]
+            for column_index, value in values:
+                item = QTableWidgetItem(value)
+                item.setFlags(
+                    Qt.ItemFlag.ItemIsEnabled | Qt.ItemFlag.ItemIsSelectable
+                )
+                if column_index == _CLUSTER_GROUP_COLUMN_TRACE_COLOR:
+                    item.setToolTip(
+                        f"Transform trace color: {state.trace_color}"
+                    )
+                if column_index == _CLUSTER_GROUP_COLUMN_FT_SETTINGS:
+                    item.setToolTip(str(value))
+                if column_index == _CLUSTER_GROUP_COLUMN_CENTER_MODE:
+                    item.setToolTip(
+                        self._center_mode_label_for_structure(structure)
+                    )
+                if column_index == _CLUSTER_GROUP_COLUMN_CENTER_REFERENCE:
+                    item.setToolTip(
+                        self._center_reference_tooltip_for_structure(structure)
+                    )
+                self.cluster_group_table.setItem(row_index, column_index, item)
+        if active_key:
+            for row_index, state in enumerate(self._cluster_group_states):
+                if state.key == active_key:
+                    self.cluster_group_table.selectRow(row_index)
+                    break
+        self.cluster_group_table.blockSignals(False)
+        self.show_all_cluster_transforms_checkbox.setEnabled(
+            len(self._cluster_group_states) > 1
+        )
+        self._populate_fourier_settings_table()
+        self._update_cluster_group_status()
+        self._update_push_to_model_state()
+        self._refresh_debye_scattering_group()
+
+    def _set_active_cluster_group(
+        self,
+        group_key: str,
+        *,
+        preserve_zoom: bool = True,
+    ) -> None:
+        target_state = self._cluster_group_state_by_key(group_key)
+        if target_state is None:
+            return
+        preserved_zoom_percentage = (
+            self.structure_viewer._current_zoom_percentage()
+            if preserve_zoom
+            else None
+        )
+        preserve_mesh_confirmation = (
+            self._mesh_confirmation_carries_forward_on_auto_apply()
+        )
+        self._selected_cluster_group_key = group_key
+        self._inspection = target_state.inspection
+        self._structure = target_state.reference_structure
+        self._debye_scattering_result = target_state.debye_scattering_result
+        self.input_mode_value.setText(
+            "Cluster folders "
+            f"({len(self._cluster_group_states)} stoichiometries); "
+            f"active row = {target_state.display_name}"
+        )
+        self.reference_file_value.setText(
+            str(target_state.inspection.reference_file)
+        )
+        self._sync_controls_to_structure(sync_mesh_rmax=False)
+        active_fourier_settings = (
+            target_state.transform_result.preview.settings
+            if target_state.transform_result is not None
+            else self._cluster_state_fourier_settings(target_state)
+        )
+        if target_state.single_atom_only:
+            self._profile_result = None
+            self._fourier_preview = None
+            self._fourier_result = target_state.transform_result
+            self.profile_plot.draw_placeholder()
+            self.smeared_profile_plot.draw_placeholder()
+            self.residual_profile_plot.draw_placeholder()
+            self.fourier_preview_plot.draw_placeholder()
+            self._apply_mesh_settings(
+                self._active_mesh_settings,
+                announce=False,
+                update_viewer=False,
+            )
+            self._set_mesh_settings_confirmed_for_run(
+                preserve_mesh_confirmation
+            )
+            self._sync_fourier_controls_to_settings(active_fourier_settings)
+            self._refresh_fourier_info_labels(None)
+            self._refresh_scattering_plot()
+            self._refresh_contrast_display()
+        elif target_state.profile_result is None:
+            self._reset_density_results()
+            self._refresh_scattering_plot()
+            self._apply_mesh_settings(
+                self._active_mesh_settings,
+                announce=False,
+                update_viewer=False,
+            )
+            self._set_mesh_settings_confirmed_for_run(
+                preserve_mesh_confirmation
+            )
+            self._sync_fourier_controls_to_settings(active_fourier_settings)
+            self._refresh_fourier_info_labels(None)
+        else:
+            self._profile_result = target_state.profile_result
+            self._apply_mesh_settings(
+                self._active_mesh_settings,
+                announce=False,
+                update_viewer=False,
+            )
+            self._set_mesh_settings_confirmed_for_run(
+                preserve_mesh_confirmation
+            )
+            self._refresh_profile_plots()
+            self._sync_fourier_controls_to_domain(reset_bounds=False)
+            self._sync_fourier_controls_to_settings(active_fourier_settings)
+            if target_state.transform_result is None:
+                self._refresh_fourier_preview_from_controls(
+                    clear_transform=True
+                )
+            else:
+                self._display_fourier_preview(
+                    target_state.transform_result.preview
+                )
+                self._fourier_result = target_state.transform_result
+            self._refresh_scattering_plot()
+        self.structure_viewer.set_structure(
+            self._structure,
+            mesh_geometry=self._active_mesh_geometry,
+            reset_view=True,
+            preserve_zoom_percentage=preserved_zoom_percentage,
+            scene_key=target_state.key,
+            render_complexity=self._cluster_group_render_complexity(
+                target_state
+            ),
+        )
+        self._sync_fourier_settings_table_selection(group_key)
+        self._refresh_debye_scattering_group()
+        self._update_push_to_model_state()
+        self.statusBar().showMessage(
+            f"Selected cluster group {target_state.display_name}"
+        )
+        self._schedule_cluster_view_cache_prewarm()
+
+    @Slot()
+    def _handle_cluster_group_selection_changed(self) -> None:
+        current_row = int(self.cluster_group_table.currentRow())
+        if 0 <= current_row < len(self._cluster_group_states):
+            self._set_active_cluster_group(
+                self._cluster_group_states[current_row].key
+            )
+            self._update_cluster_group_status()
+            return
+        selected_rows = self._selected_cluster_group_rows()
+        if not selected_rows:
+            return
+        self._set_active_cluster_group(
+            self._cluster_group_states[selected_rows[0]].key
+        )
+        self._update_cluster_group_status()
+
+    def _cluster_group_states_for_path(
+        self,
+        path: Path,
+    ) -> list[_ClusterDensityGroupState]:
+        return _build_cluster_group_states_for_path(path)
 
     def _build_smearing_group(self) -> QWidget:
         group = QGroupBox("Smearing")
@@ -671,7 +5216,9 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         intro = QLabel(
             "Apply a Gaussian kernel to the raw radial density profile to "
             "soften boxy shell-to-shell transitions. A value of 0 disables "
-            "smearing."
+            "smearing. Edit the factor, then click Apply Smearing for the "
+            "selected stoichiometries or turn on Apply to All to reuse the "
+            "same factor everywhere."
         )
         intro.setWordWrap(True)
         layout.addRow(intro)
@@ -695,7 +5242,42 @@ class ElectronDensityMappingMainWindow(QMainWindow):
 
         self.smearing_summary_value = QLabel()
         self.smearing_summary_value.setWordWrap(True)
-        layout.addRow("Behavior", self.smearing_summary_value)
+        self.smearing_summary_value.setStyleSheet("color: #475569;")
+        layout.addRow(self.smearing_summary_value)
+
+        action_row = QWidget(group)
+        action_layout = QHBoxLayout(action_row)
+        action_layout.setContentsMargins(0, 0, 0, 0)
+        action_layout.setSpacing(6)
+        self.apply_smearing_button = QPushButton("Apply Smearing")
+        self.apply_smearing_button.clicked.connect(self._apply_smearing_action)
+        action_layout.addWidget(self.apply_smearing_button)
+        self.apply_smearing_to_all_button = QCheckBox("Apply to All")
+        self.apply_smearing_to_all_button.setChecked(True)
+        self.apply_smearing_to_all_button.toggled.connect(
+            self._refresh_smearing_scope_status
+        )
+        self.update_all_smearing_button = self.apply_smearing_to_all_button
+        action_layout.addWidget(self.apply_smearing_to_all_button)
+        action_layout.addSpacing(20)
+        self.smearing_scope_status_label = QLabel()
+        self.smearing_scope_status_label.setWordWrap(True)
+        self.smearing_scope_status_label.setStyleSheet("color: #475569;")
+        action_layout.addWidget(self.smearing_scope_status_label, stretch=1)
+        layout.addRow(action_row)
+        self.auto_save_smearing_outputs_checkbox = QCheckBox(
+            "Auto-save smearing snapshots to Saved Outputs"
+        )
+        self.auto_save_smearing_outputs_checkbox.setChecked(False)
+        self.auto_save_smearing_outputs_checkbox.setToolTip(
+            "When enabled, each smearing re-evaluation is saved as a reloadable "
+            "Saved Outputs entry."
+        )
+        self.auto_save_smearing_outputs_checkbox.toggled.connect(
+            self._on_auto_save_smearing_outputs_toggled
+        )
+        layout.addRow(self.auto_save_smearing_outputs_checkbox)
+        self._refresh_smearing_scope_status(False)
         return group
 
     def _build_contrast_group(self) -> QWidget:
@@ -705,7 +5287,9 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         intro = QLabel(
             "Estimate a flat solvent electron density using the contrast Debye "
             "workflow solvent options, then compare that value against the "
-            "smeared radial density profile."
+            "smeared radial density profile. Apply to All reuses the same "
+            "solvent settings across every stoichiometry while keeping each "
+            "row's own solvent-derived cutoff."
         )
         intro.setWordWrap(True)
         layout.addRow(intro)
@@ -766,7 +5350,7 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         layout.addRow("Density (g/mL)", self.solvent_density_spin)
 
         self.direct_density_spin = QDoubleSpinBox()
-        self.direct_density_spin.setDecimals(6)
+        self.direct_density_spin.setDecimals(9)
         self.direct_density_spin.setRange(0.0, 100.0)
         self.direct_density_spin.setSingleStep(0.001)
         self.direct_density_spin.setValue(0.334)
@@ -796,13 +5380,33 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         self.solvent_method_hint_label.setWordWrap(True)
         layout.addRow("", self.solvent_method_hint_label)
 
+        action_row = QWidget(group)
+        action_layout = QHBoxLayout(action_row)
+        action_layout.setContentsMargins(0, 0, 0, 0)
+        action_layout.setSpacing(6)
         self.compute_solvent_density_button = QPushButton(
-            "Compute Solvent Electron Density"
+            "Apply Electron Density Contrast"
         )
         self.compute_solvent_density_button.clicked.connect(
-            self._compute_solvent_contrast
+            self._apply_electron_density_contrast_action
         )
-        layout.addRow(self.compute_solvent_density_button)
+        action_layout.addWidget(self.compute_solvent_density_button)
+        self.apply_contrast_to_all_button = QCheckBox("Apply to All")
+        self.apply_contrast_to_all_button.setChecked(True)
+        self.apply_contrast_to_all_button.toggled.connect(
+            self._refresh_contrast_scope_status
+        )
+        self.compute_all_solvent_density_button = (
+            self.apply_contrast_to_all_button
+        )
+        action_layout.addWidget(self.apply_contrast_to_all_button)
+        action_layout.addSpacing(20)
+        self.contrast_scope_status_label = QLabel()
+        self.contrast_scope_status_label.setWordWrap(True)
+        self.contrast_scope_status_label.setStyleSheet("color: #475569;")
+        action_layout.addWidget(self.contrast_scope_status_label, stretch=1)
+        layout.addRow(action_row)
+        self._refresh_contrast_scope_status(False)
 
         layout.addRow(QLabel("Active contrast:"))
         self.active_contrast_value = QLabel(
@@ -828,8 +5432,13 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         intro = QLabel(
             "Prepare a spherical Born-approximation transform of the smeared "
             "electron-density profile into q-space. The preview panel shows "
-            "the active bounds, the selected real-space window over that interval, "
-            "and the resampled data before the transform is evaluated."
+            "the mirrored real-space source used by the transform. Mirrored "
+            "mode is the default: it reflects the profile about r = 0 and "
+            "evaluates the windowed transform over -rmax to rmax. Toggle "
+            "legacy mode to restore the historical rmin to rmax behavior. In "
+            "Apply to All mode, the table becomes the editable per-stoichiometry "
+            "Fourier settings view: q settings stay shared, while each row "
+            "keeps its own r range."
         )
         intro.setWordWrap(True)
         outer.addWidget(intro)
@@ -850,8 +5459,19 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         r_min_form = QFormLayout(r_min_cell)
         r_min_form.setContentsMargins(0, 0, 0, 0)
         r_min_form.setSpacing(2)
+        self.fourier_legacy_mode_checkbox = QCheckBox(
+            "Legacy r min to r max transform"
+        )
+        self.fourier_legacy_mode_checkbox.setChecked(
+            self._active_fourier_settings.domain_mode == "legacy"
+        )
+        self.fourier_legacy_mode_checkbox.toggled.connect(
+            self._handle_fourier_domain_mode_toggled
+        )
+        r_min_form.addRow(self.fourier_legacy_mode_checkbox)
+        self.fourier_rmin_label = QLabel("r min")
         self.fourier_rmin_spin = QDoubleSpinBox()
-        self.fourier_rmin_spin.setRange(0.0, 100000.0)
+        self.fourier_rmin_spin.setRange(-100000.0, 100000.0)
         self.fourier_rmin_spin.setDecimals(4)
         self.fourier_rmin_spin.setSingleStep(0.05)
         self.fourier_rmin_spin.setKeyboardTracking(False)
@@ -859,7 +5479,7 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         self.fourier_rmin_spin.valueChanged.connect(
             self._refresh_fourier_preview_from_controls
         )
-        r_min_form.addRow("r min", self.fourier_rmin_spin)
+        r_min_form.addRow(self.fourier_rmin_label, self.fourier_rmin_spin)
         # r max
         self.fourier_rmax_spin = QDoubleSpinBox()
         self.fourier_rmax_spin.setRange(0.01, 100000.0)
@@ -867,6 +5487,9 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         self.fourier_rmax_spin.setSingleStep(0.1)
         self.fourier_rmax_spin.setKeyboardTracking(False)
         self.fourier_rmax_spin.setValue(self._active_fourier_settings.r_max)
+        self.fourier_rmax_spin.valueChanged.connect(
+            self._sync_mirrored_fourier_rmin_to_rmax
+        )
         self.fourier_rmax_spin.valueChanged.connect(
             self._refresh_fourier_preview_from_controls
         )
@@ -993,13 +5616,73 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         log_layout.addStretch(1)
         outer.addWidget(log_row)
 
+        action_row = QWidget(group)
+        action_layout = QHBoxLayout(action_row)
+        action_layout.setContentsMargins(0, 0, 0, 0)
+        action_layout.setSpacing(6)
         self.evaluate_fourier_button = QPushButton(
             "Evaluate Fourier Transform"
         )
         self.evaluate_fourier_button.clicked.connect(
-            self._evaluate_fourier_transform
+            self._evaluate_fourier_transform_action
         )
-        outer.addWidget(self.evaluate_fourier_button)
+        action_layout.addWidget(self.evaluate_fourier_button)
+        self.apply_fourier_to_all_button = QCheckBox("Apply to All")
+        self.apply_fourier_to_all_button.setChecked(True)
+        self.apply_fourier_to_all_button.toggled.connect(
+            self._handle_fourier_apply_to_all_toggled
+        )
+        self.evaluate_all_fourier_button = self.apply_fourier_to_all_button
+        action_layout.addWidget(self.apply_fourier_to_all_button)
+        action_layout.addSpacing(20)
+        self.fourier_scope_status_label = QLabel()
+        self.fourier_scope_status_label.setWordWrap(True)
+        self.fourier_scope_status_label.setStyleSheet("color: #475569;")
+        action_layout.addWidget(self.fourier_scope_status_label, stretch=1)
+        outer.addWidget(action_row)
+
+        self.fourier_settings_table = QTableWidget(0, 10)
+        self.fourier_settings_table.setHorizontalHeaderLabels(
+            [
+                "Stoichiometry",
+                "Status",
+                "Profile",
+                "r min",
+                "r max",
+                "q min",
+                "q max",
+                "q step",
+                "Resample pts",
+                "Window",
+            ]
+        )
+        self.fourier_settings_table.verticalHeader().setVisible(False)
+        self.fourier_settings_table.setSelectionBehavior(
+            QTableWidget.SelectionBehavior.SelectRows
+        )
+        self.fourier_settings_table.setSelectionMode(
+            QTableWidget.SelectionMode.SingleSelection
+        )
+        self.fourier_settings_table.setEditTriggers(
+            QTableWidget.EditTrigger.NoEditTriggers
+        )
+        self.fourier_settings_table.horizontalHeader().setSectionResizeMode(
+            QHeaderView.ResizeMode.ResizeToContents
+        )
+        self.fourier_settings_table.horizontalHeader().setStretchLastSection(
+            True
+        )
+        self.fourier_settings_table.setMinimumHeight(180)
+        self.fourier_settings_table.itemSelectionChanged.connect(
+            self._handle_fourier_settings_table_selection_changed
+        )
+        self.fourier_settings_table.itemChanged.connect(
+            self._handle_fourier_settings_table_item_changed
+        )
+        outer.addWidget(self.fourier_settings_table)
+        self._refresh_fourier_domain_mode_controls()
+        self._refresh_fourier_scope_status(False)
+        self._refresh_fourier_table_interaction_state()
 
         info_form = QFormLayout()
         info_form.setSpacing(4)
@@ -1035,8 +5718,77 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         layout.addWidget(self.status_text)
         return group
 
+    def _build_output_history_group(self) -> QWidget:
+        group = QGroupBox("Saved Output Sets")
+        layout = QVBoxLayout(group)
+        self.output_history_summary_label = QLabel(
+            "Density calculations, solvent-subtracted outputs, and Fourier "
+            "evaluations will be captured here for reload and comparison."
+        )
+        self.output_history_summary_label.setWordWrap(True)
+        layout.addWidget(self.output_history_summary_label)
+
+        self.output_history_table = QTableWidget(0, 8)
+        self.output_history_table.setHorizontalHeaderLabels(
+            [
+                "Saved",
+                "Type",
+                "Context",
+                "Averaging",
+                "Mesh",
+                "Smearing",
+                "Solvent",
+                "Fourier",
+            ]
+        )
+        self.output_history_table.verticalHeader().setVisible(False)
+        self.output_history_table.setSelectionBehavior(
+            QTableWidget.SelectionBehavior.SelectRows
+        )
+        self.output_history_table.setSelectionMode(
+            QTableWidget.SelectionMode.ExtendedSelection
+        )
+        self.output_history_table.setEditTriggers(
+            QTableWidget.EditTrigger.NoEditTriggers
+        )
+        self.output_history_table.horizontalHeader().setSectionResizeMode(
+            QHeaderView.ResizeMode.ResizeToContents
+        )
+        self.output_history_table.horizontalHeader().setStretchLastSection(
+            True
+        )
+        self.output_history_table.setMinimumHeight(200)
+        self.output_history_table.itemSelectionChanged.connect(
+            self._update_output_history_actions
+        )
+        self.output_history_table.itemDoubleClicked.connect(
+            lambda *_args: self._load_selected_output_history_entry()
+        )
+        layout.addWidget(self.output_history_table)
+
+        controls = QHBoxLayout()
+        controls.setContentsMargins(0, 0, 0, 0)
+        controls.setSpacing(6)
+        self.load_output_history_button = QPushButton("Load Selected")
+        self.load_output_history_button.clicked.connect(
+            self._load_selected_output_history_entry
+        )
+        controls.addWidget(self.load_output_history_button)
+        self.compare_output_history_button = QPushButton("Compare Selected")
+        self.compare_output_history_button.clicked.connect(
+            self._compare_selected_output_history_entries
+        )
+        controls.addWidget(self.compare_output_history_button)
+        controls.addStretch(1)
+        layout.addLayout(controls)
+        self._update_output_history_summary()
+        self._update_output_history_actions()
+        return group
+
     def _set_initial_defaults(self) -> None:
-        if self._project_dir is not None:
+        if self._initial_output_dir is not None:
+            self.output_dir_edit.setText(str(self._initial_output_dir))
+        elif self._project_dir is not None:
             self.output_dir_edit.setText(
                 str(
                     suggest_output_dir(
@@ -1045,6 +5797,10 @@ class ElectronDensityMappingMainWindow(QMainWindow):
                     )
                 )
             )
+        if self._project_q_min is not None:
+            self.fourier_qmin_spin.setValue(float(self._project_q_min))
+        if self._project_q_max is not None:
+            self.fourier_qmax_spin.setValue(float(self._project_q_max))
         self._refresh_center_display()
         self._refresh_active_mesh_display()
         self._refresh_mesh_notice()
@@ -1053,10 +5809,129 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         self._sync_density_method_controls()
         self._refresh_contrast_display()
         self._refresh_fourier_info_labels(None)
+        self._refresh_run_action_state()
+        self._refresh_debye_scattering_group()
         self._append_status(
             "Waiting for an XYZ or PDB structure. Folder mode will preview and "
             "average across every valid structure in the folder when you run the calculation."
         )
+
+    @staticmethod
+    def _project_debye_waller_pair_term(
+        payload: object,
+    ) -> ElectronDensityDebyeWallerPairTerm:
+        return ElectronDensityDebyeWallerPairTerm(
+            scope=str(getattr(payload, "scope", "")),
+            type_definition=str(getattr(payload, "type_definition", "")),
+            pair_label_a=str(getattr(payload, "pair_label_a", "")),
+            pair_label_b=str(getattr(payload, "pair_label_b", "")),
+            pair_label=str(getattr(payload, "pair_label", "")),
+            mean_distance_a=float(getattr(payload, "mean_distance_a", 0.0)),
+            sigma_a=float(getattr(payload, "sigma_mean", 0.0)),
+            sigma_std_a=float(getattr(payload, "sigma_std", 0.0)),
+            sigma_squared_a2=float(
+                getattr(payload, "sigma_squared_mean", 0.0)
+            ),
+            sigma_squared_std_a2=float(
+                getattr(payload, "sigma_squared_std", 0.0)
+            ),
+            b_factor_a2=float(getattr(payload, "b_factor_mean", 0.0)),
+            b_factor_std_a2=float(getattr(payload, "b_factor_std", 0.0)),
+        ).normalized()
+
+    def _load_project_debye_waller_terms(self) -> None:
+        self._project_debye_waller_source_path = None
+        if self._project_dir is None:
+            return
+        try:
+            summary_path = find_saved_project_debye_waller_analysis(
+                self._project_dir
+            )
+            if summary_path is None:
+                return
+            result = load_debye_waller_analysis_result(summary_path)
+        except Exception as exc:
+            self._append_status(
+                "Could not load project Debye-Waller terms for electron-density smearing: "
+                f"{exc}"
+            )
+            return
+        imported_terms = tuple(
+            self._project_debye_waller_pair_term(entry)
+            for entry in result.aggregated_pair_summaries
+        )
+        if not imported_terms:
+            return
+        self._project_debye_waller_source_path = summary_path
+        self._active_smearing_settings = (
+            self._active_smearing_settings.with_pair_specific_terms(
+                imported_terms,
+                imported_terms=imported_terms,
+                prefer_pair_specific=True,
+            )
+        )
+        self._append_status(
+            "Imported "
+            f"{len(imported_terms)} aggregated Debye-Waller pair term"
+            f"{'' if len(imported_terms) == 1 else 's'} from "
+            f"{summary_path}."
+        )
+        if self._project_q_min is not None or self._project_q_max is not None:
+            self._append_status(
+                "Inherited project q-range context: "
+                f"{self._project_q_min if self._project_q_min is not None else 'unset'} "
+                f"to {self._project_q_max if self._project_q_max is not None else 'unset'} A^-1."
+            )
+
+    def _load_auto_snap_panes_setting(self) -> bool:
+        raw_value = self._ui_settings().value(
+            AUTO_SNAP_PANES_KEY,
+            True,
+        )
+        if isinstance(raw_value, bool):
+            return raw_value
+        return str(raw_value).strip().lower() not in {
+            "",
+            "0",
+            "false",
+            "no",
+            "off",
+        }
+
+    @Slot(bool)
+    def _toggle_auto_snap_panes(self, enabled: bool) -> None:
+        self._set_auto_snap_panes_enabled(enabled, persist=True)
+
+    def set_auto_snap_enabled(self, enabled: bool) -> None:
+        self._set_auto_snap_panes_enabled(enabled, persist=False)
+
+    def _set_auto_snap_panes_enabled(
+        self,
+        enabled: bool,
+        *,
+        persist: bool,
+    ) -> None:
+        self._auto_snap_panes_enabled = bool(enabled)
+        if hasattr(self, "auto_snap_panes_action"):
+            self.auto_snap_panes_action.blockSignals(True)
+            self.auto_snap_panes_action.setChecked(
+                self._auto_snap_panes_enabled
+            )
+            self.auto_snap_panes_action.blockSignals(False)
+        if hasattr(self, "_auto_snap_filter"):
+            self._auto_snap_filter.set_enabled(self._auto_snap_panes_enabled)
+        if persist:
+            self._ui_settings().setValue(
+                AUTO_SNAP_PANES_KEY,
+                self._auto_snap_panes_enabled,
+            )
+            self.statusBar().showMessage(
+                "Auto-snap panes "
+                + ("enabled" if self._auto_snap_panes_enabled else "disabled")
+            )
+
+    def _ui_settings(self) -> QSettings:
+        return QSettings("SAXShell", "SAXS")
 
     @Slot(bool)
     def _toggle_variance_shading(self, checked: bool) -> None:
@@ -1070,6 +5945,61 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             theta_divisions=int(self.theta_divisions_spin.value()),
             phi_divisions=int(self.phi_divisions_spin.value()),
             rmax=float(self.rmax_spin.value()),
+            pin_contiguous_geometric_tracking=self._use_pinned_geometric_tracking(),
+        ).normalized()
+
+    def _sync_pinned_geometric_tracking_control_to_settings(
+        self,
+        settings: ElectronDensityMeshSettings,
+    ) -> None:
+        normalized = settings.normalized()
+        self.pinned_geometric_tracking_checkbox.blockSignals(True)
+        try:
+            self.pinned_geometric_tracking_checkbox.setChecked(
+                bool(normalized.pin_contiguous_geometric_tracking)
+            )
+        finally:
+            self.pinned_geometric_tracking_checkbox.blockSignals(False)
+        self._refresh_pinned_geometric_tracking_controls()
+
+    def _sync_mesh_controls_to_settings(
+        self,
+        settings: ElectronDensityMeshSettings,
+    ) -> None:
+        normalized = settings.normalized()
+        for widget, value in (
+            (self.rstep_spin, float(normalized.rstep)),
+            (self.theta_divisions_spin, int(normalized.theta_divisions)),
+            (self.phi_divisions_spin, int(normalized.phi_divisions)),
+            (self.rmax_spin, float(normalized.rmax)),
+        ):
+            widget.blockSignals(True)
+            try:
+                widget.setValue(value)
+            finally:
+                widget.blockSignals(False)
+        self._sync_pinned_geometric_tracking_control_to_settings(normalized)
+
+    def _cluster_group_mesh_settings_for_states(
+        self,
+        cluster_states: list[_ClusterDensityGroupState],
+    ) -> ElectronDensityMeshSettings:
+        shared_rmax = max(
+            (
+                max(float(state.reference_structure.rmax), 0.01)
+                for state in cluster_states
+            ),
+            default=0.01,
+        )
+        current_settings = self._active_mesh_settings.normalized()
+        return ElectronDensityMeshSettings(
+            rstep=float(current_settings.rstep),
+            theta_divisions=int(current_settings.theta_divisions),
+            phi_divisions=int(current_settings.phi_divisions),
+            rmax=float(shared_rmax),
+            pin_contiguous_geometric_tracking=bool(
+                current_settings.pin_contiguous_geometric_tracking
+            ),
         ).normalized()
 
     def _smearing_settings_from_controls(
@@ -1077,6 +6007,15 @@ class ElectronDensityMappingMainWindow(QMainWindow):
     ) -> ElectronDensitySmearingSettings:
         return ElectronDensitySmearingSettings(
             debye_waller_factor=float(self.smearing_factor_spin.value()),
+            debye_waller_mode=str(
+                self._active_smearing_settings.debye_waller_mode
+            ),
+            pair_specific_terms=tuple(
+                self._active_smearing_settings.pair_specific_terms
+            ),
+            imported_pair_specific_terms=tuple(
+                self._active_smearing_settings.imported_pair_specific_terms
+            ),
         ).normalized()
 
     def _fourier_settings_from_controls(
@@ -1085,6 +6024,7 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         return ElectronDensityFourierTransformSettings(
             r_min=float(self.fourier_rmin_spin.value()),
             r_max=float(self.fourier_rmax_spin.value()),
+            domain_mode=self._fourier_domain_mode_from_controls(),
             window_function=str(
                 self.fourier_window_combo.currentData()
                 or self.fourier_window_combo.currentText()
@@ -1137,11 +6077,17 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         self._profile_result = None
         self._fourier_preview = None
         self._fourier_result = None
+        self._debye_scattering_result = None
+        self._close_debye_scattering_compare_dialog()
         self.profile_plot.draw_placeholder()
         self.smeared_profile_plot.draw_placeholder()
         self.residual_profile_plot.draw_placeholder()
         self.fourier_preview_plot.draw_placeholder()
-        self.scattering_plot.draw_placeholder()
+        self.fourier_preview_info_label.setText("")
+        self._refresh_scattering_plot()
+        if hasattr(self, "reset_calculations_button"):
+            self._refresh_run_action_state()
+        self._refresh_debye_scattering_group()
 
     def _refresh_structure_summary(self) -> None:
         if self._structure is None:
@@ -1157,7 +6103,7 @@ class ElectronDensityMappingMainWindow(QMainWindow):
                 f"{element} x{count}"
                 for element, count in structure.element_counts.items()
             )
-            + "; calculated center="
+            + "; geometric mass center="
             + self._format_point(structure.center_of_mass)
             + f"; {structure.reference_element} geometric center="
             + self._format_point(structure.reference_element_geometric_center)
@@ -1168,7 +6114,7 @@ class ElectronDensityMappingMainWindow(QMainWindow):
 
     def _refresh_center_display(self) -> None:
         if self._structure is None:
-            self.center_mode_value.setText("Calculated center of mass")
+            self.center_mode_value.setText("Geometric Mass Center")
             self.calculated_center_value.setText("Unavailable")
             self.active_center_value.setText("Unavailable")
             self.nearest_atom_value.setText("Unavailable")
@@ -1176,18 +6122,24 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             self.reference_element_center_value.setText("Unavailable")
             self.reference_element_offset_value.setText("Unavailable")
             self.reference_element_combo.setEnabled(False)
+            self.reset_center_button.setChecked(True)
+            self.snap_center_button.setChecked(False)
+            self.snap_reference_center_button.setChecked(False)
+            self._refresh_pinned_geometric_tracking_controls()
+            self._refresh_contiguous_frame_mode_notice()
             return
         structure = self._structure
-        if structure.center_mode == "center_of_mass":
-            mode_label = "Mass-weighted center of mass"
-        elif structure.center_mode == "nearest_atom":
-            mode_label = "Nearest atom to calculated center"
-        else:
-            mode_label = (
-                f"{structure.reference_element} reference-element "
-                "geometric center"
-            )
+        mode_label = self._center_mode_label_for_structure(structure)
         self.center_mode_value.setText(mode_label)
+        self.reset_center_button.setChecked(
+            structure.center_mode == "center_of_mass"
+        )
+        self.snap_center_button.setChecked(
+            structure.center_mode == "nearest_atom"
+        )
+        self.snap_reference_center_button.setChecked(
+            structure.center_mode == "reference_element"
+        )
         self.calculated_center_value.setText(
             self._format_point(structure.center_of_mass)
         )
@@ -1209,13 +6161,19 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             f"#{structure.nearest_atom_index + 1} "
             f"{structure.nearest_atom_element} at "
             f"{self._format_point(structure.nearest_atom_coordinates)}; "
-            f"{structure.nearest_atom_distance:.3f} Å from the calculated center"
+            f"{structure.nearest_atom_distance:.3f} Å from the geometric mass center"
         )
+        self._refresh_pinned_geometric_tracking_controls()
+        self._refresh_contiguous_frame_mode_notice()
 
     @Slot()
     def _handle_reference_element_changed(self) -> None:
         if self._structure is None:
             return
+        preserve_mesh_confirmation = (
+            self._mesh_confirmation_carries_forward_on_auto_apply()
+        )
+        active_cluster_state = self._active_cluster_group_state()
         reference_element = self._selected_reference_element()
         if (
             reference_element is None
@@ -1234,18 +6192,52 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             self._sync_reference_element_controls()
             return
         self._structure = updated_structure
+        if active_cluster_state is not None:
+            active_cluster_state.reference_structure = updated_structure
         active_center_changed = not np.allclose(
             previous_structure.active_center,
             updated_structure.active_center,
         ) or not np.isclose(previous_structure.rmax, updated_structure.rmax)
-        self._sync_controls_to_structure()
-        self._refresh_active_mesh_display()
+        self._sync_controls_to_structure(
+            sync_mesh_rmax=(active_cluster_state is None)
+        )
         if active_center_changed:
-            self._reset_density_results()
-            self._apply_mesh_settings(
-                self._mesh_settings_from_controls(),
-                announce=False,
-                preserve_viewer_display=True,
+            if active_cluster_state is None:
+                self._reset_density_results()
+                self._apply_mesh_settings(
+                    self._mesh_settings_from_controls(),
+                    announce=False,
+                    preserve_viewer_display=True,
+                )
+            else:
+                cleared_count = self._clear_cluster_group_outputs_for_keys(
+                    {active_cluster_state.key}
+                )
+                self._set_mesh_settings_confirmed_for_run(
+                    preserve_mesh_confirmation
+                )
+                self._sync_fourier_controls_to_domain(reset_bounds=True)
+                self._refresh_fourier_info_labels(None)
+                self._refresh_contrast_display()
+                self._append_status(
+                    "Updated "
+                    f"{active_cluster_state.display_name} to the "
+                    f"{updated_structure.reference_element} reference-element "
+                    "center."
+                    + (
+                        " Cleared that stoichiometry's saved outputs so the "
+                        "plots stay aligned with the new center."
+                        if cleared_count > 0
+                        else ""
+                    )
+                )
+                self.statusBar().showMessage(
+                    "Updated stoichiometry reference-element center"
+                )
+                self._sync_workspace_state()
+                return
+            self._set_mesh_settings_confirmed_for_run(
+                preserve_mesh_confirmation
             )
             self._sync_fourier_controls_to_domain(reset_bounds=True)
             self._refresh_fourier_info_labels(None)
@@ -1257,6 +6249,16 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             )
             self.statusBar().showMessage("Updated reference-element center")
         else:
+            if active_cluster_state is not None:
+                self._populate_cluster_group_table()
+            self._apply_mesh_settings(
+                self._active_mesh_settings,
+                announce=False,
+                preserve_viewer_display=True,
+            )
+            self._set_mesh_settings_confirmed_for_run(
+                preserve_mesh_confirmation
+            )
             self._append_status(
                 "Updated the reference element to "
                 f"{updated_structure.reference_element}; offset from the "
@@ -1264,12 +6266,114 @@ class ElectronDensityMappingMainWindow(QMainWindow):
                 f"{updated_structure.reference_element_offset_from_geometric_center:.3f} Å."
             )
             self.statusBar().showMessage("Updated reference element")
+        self._sync_workspace_state()
+
+    def _handle_cluster_group_reference_element_changed(
+        self,
+        group_key: str,
+        combo: QComboBox,
+    ) -> None:
+        state = self._cluster_group_state_by_key(group_key)
+        if state is None:
+            return
+        selected = combo.currentData() or combo.currentText()
+        reference_element = str(selected or "").strip() or None
+        if (
+            reference_element is None
+            or reference_element == state.reference_structure.reference_element
+        ):
+            return
+        is_active_group = group_key == self._selected_cluster_group_key
+        preserve_mesh_confirmation = (
+            self._mesh_confirmation_carries_forward_on_auto_apply()
+            if is_active_group
+            else False
+        )
+        previous_structure = state.reference_structure
+        try:
+            updated_structure = recenter_electron_density_structure(
+                previous_structure,
+                center_mode=previous_structure.center_mode,
+                reference_element=reference_element,
+            )
+        except Exception as exc:
+            self._show_error("Reference Element Error", str(exc))
+            self._populate_cluster_group_table()
+            return
+        state.reference_structure = updated_structure
+        active_center_changed = not np.allclose(
+            previous_structure.active_center,
+            updated_structure.active_center,
+        ) or not np.isclose(previous_structure.rmax, updated_structure.rmax)
+        if is_active_group:
+            self._structure = updated_structure
+            self._sync_controls_to_structure(sync_mesh_rmax=False)
+        if active_center_changed:
+            cleared_count = self._clear_cluster_group_outputs_for_keys(
+                {group_key}
+            )
+            if is_active_group:
+                self._set_mesh_settings_confirmed_for_run(
+                    preserve_mesh_confirmation
+                )
+                self._sync_fourier_controls_to_domain(reset_bounds=True)
+                self._refresh_fourier_info_labels(None)
+                self._refresh_contrast_display()
+            self._append_status(
+                "Updated "
+                f"{state.display_name} to the "
+                f"{updated_structure.reference_element} reference-element "
+                "center."
+                + (
+                    " Cleared that stoichiometry's saved outputs so the plots "
+                    "stay aligned with the new center."
+                    if cleared_count > 0
+                    else ""
+                )
+            )
+        else:
+            self._populate_cluster_group_table()
+            if is_active_group:
+                self._apply_mesh_settings(
+                    self._active_mesh_settings,
+                    announce=False,
+                    preserve_viewer_display=True,
+                )
+                self._set_mesh_settings_confirmed_for_run(
+                    preserve_mesh_confirmation
+                )
+            self._append_status(
+                "Updated "
+                f"{state.display_name} to use "
+                f"{updated_structure.reference_element} as its stored "
+                "reference element."
+            )
+        if is_active_group:
+            self.statusBar().showMessage(
+                "Updated stoichiometry reference element"
+            )
+        self._sync_workspace_state()
 
     def _refresh_smearing_display(self) -> None:
         settings = self._smearing_settings_from_controls()
         self._active_smearing_settings = settings
         self.smearing_sigma_value.setText(f"{settings.gaussian_sigma_a:.4f} Å")
-        if settings.debye_waller_factor <= 0.0:
+        if settings.uses_pair_specific_terms:
+            source_text = (
+                ""
+                if self._project_debye_waller_source_path is None
+                else f" from {self._project_debye_waller_source_path.name}"
+            )
+            self.smearing_summary_value.setText(
+                "Pair-specific Debye-Waller terms are selected by default: "
+                f"{len(settings.pair_specific_terms)} imported pair type"
+                f"{'' if len(settings.pair_specific_terms) == 1 else 's'}"
+                + source_text
+                + ". TODO: the electron-density smearing preview still uses "
+                "the universal Gaussian factor until pair-aware smearing is "
+                "implemented in a future update."
+            )
+        elif settings.debye_waller_factor <= 0.0:
             self.smearing_summary_value.setText(
                 "Smearing is disabled. The lower plot will match the raw profile."
             )
@@ -1282,23 +6386,7 @@ class ElectronDensityMappingMainWindow(QMainWindow):
     def _current_smeared_profile_overlay(
         self,
     ) -> ElectronDensityProfileOverlay | None:
-        if (
-            self._profile_result is None
-            or self._profile_result.solvent_contrast is None
-        ):
-            return None
-        contrast = self._profile_result.solvent_contrast
-        return ElectronDensityProfileOverlay(
-            solvent_density_e_per_a3=float(contrast.solvent_density_e_per_a3),
-            solvent_density_label=contrast.legend_label,
-            cutoff_radius_a=contrast.cutoff_radius_a,
-            cutoff_label=contrast.cutoff_label,
-            solvent_subtracted_density=np.asarray(
-                contrast.solvent_subtracted_smeared_density,
-                dtype=float,
-            ),
-            solvent_subtracted_label="Solvent-subtracted ρ(r)",
-        )
+        return self._profile_overlay_for_result(self._profile_result)
 
     def _refresh_profile_plots(self) -> None:
         if self._profile_result is None:
@@ -1552,6 +6640,21 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         return self.solvent_formula_edit.text().strip() or "Solvent"
 
     def _refresh_contrast_display(self) -> None:
+        active_cluster_state = self._active_cluster_group_state()
+        if (
+            active_cluster_state is not None
+            and active_cluster_state.single_atom_only
+        ):
+            self.active_contrast_value.setText(
+                "Single-atom Debye mode does not use solvent electron density."
+            )
+            self.active_contrast_value.setStyleSheet("color: #475569;")
+            self.contrast_notice_value.setText(
+                "This cluster bin skips electron-density and solvent-contrast "
+                "evaluation and uses direct Debye scattering for I(Q)."
+            )
+            self.contrast_notice_value.setStyleSheet("color: #475569;")
+            return
         if self._active_contrast_settings is None:
             self.active_contrast_value.setText(
                 "No active solvent electron density yet."
@@ -1575,8 +6678,8 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             )
             self.active_contrast_value.setStyleSheet("color: #92400e;")
             self.contrast_notice_value.setText(
-                "Run the density calculation or click Compute Solvent Electron Density "
-                "to populate the comparison overlays."
+                "Run the density calculation, then click Apply Electron "
+                "Density Contrast to populate the comparison overlays."
             )
             self.contrast_notice_value.setStyleSheet("color: #92400e;")
             return
@@ -1601,7 +6704,28 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         show_error: bool,
         announce: bool,
     ) -> bool:
+        active_cluster_state = self._active_cluster_group_state()
+        preserved_fourier_settings = (
+            None
+            if active_cluster_state is None
+            else self._cluster_state_fourier_settings(active_cluster_state)
+        )
         if self._profile_result is None:
+            if (
+                active_cluster_state is not None
+                and active_cluster_state.single_atom_only
+            ):
+                message = (
+                    "Single-atom cluster groups use direct Debye scattering "
+                    "and do not support solvent-contrast overlays."
+                )
+                self._refresh_contrast_display()
+                if show_error:
+                    self._show_error(
+                        "Solvent Contrast Unavailable",
+                        message,
+                    )
+                return False
             if show_error:
                 self._show_error(
                     "No Density Profile",
@@ -1629,16 +6753,51 @@ class ElectronDensityMappingMainWindow(QMainWindow):
                     5000,
                 )
             return False
+        if active_cluster_state is not None:
+            active_cluster_state.transform_result = None
+            active_cluster_state.debye_scattering_result = None
+        else:
+            self._debye_scattering_result = None
+        self._close_debye_scattering_compare_dialog()
+        self._sync_fourier_controls_to_domain(reset_bounds=False)
         self._refresh_profile_plots()
         self._refresh_contrast_display()
-        self._refresh_fourier_preview_from_controls(clear_transform=True)
         contrast = self._profile_result.solvent_contrast
+        cutoff_rmax = None
+        if active_cluster_state is not None:
+            active_cluster_state.profile_result = self._profile_result
+            self._sync_cluster_state_solvent_metadata(active_cluster_state)
+            updated_settings = self._set_cluster_state_fourier_settings(
+                active_cluster_state,
+                preserved_fourier_settings
+                or self._cluster_state_fourier_settings(active_cluster_state),
+                prefer_solvent_cutoff=True,
+            )
+            cutoff_rmax = (
+                float(updated_settings.r_max)
+                if contrast is not None
+                and contrast.cutoff_radius_a is not None
+                else None
+            )
+            self._sync_fourier_controls_to_settings(updated_settings)
+            self._populate_cluster_group_table()
+        else:
+            cutoff_rmax = self._sync_fourier_rmax_to_solvent_cutoff()
+        self._refresh_fourier_preview_from_controls(clear_transform=True)
+        if contrast is not None:
+            self._capture_saved_output_entry(
+                "solvent_subtraction",
+                group_state=active_cluster_state,
+                profile_result=self._profile_result,
+            )
         if announce and contrast is not None:
             cutoff_text = (
                 f"Highest-r cutoff={contrast.cutoff_radius_a:.3f} Å."
                 if contrast.cutoff_radius_a is not None
                 else "No highest-r solvent crossing was found."
             )
+            if cutoff_rmax is not None:
+                cutoff_text += f" Set transform r max to {cutoff_rmax:.3f} Å."
             self._append_status(
                 f"Applied solvent electron density {contrast.legend_label}. {cutoff_text}"
             )
@@ -1663,10 +6822,211 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             return
         self.statusBar().showMessage("Updated solvent electron density")
 
+    @Slot()
+    def _apply_electron_density_contrast_action(self) -> None:
+        if self._cluster_group_states:
+            self._apply_solvent_contrast_to_target_clusters(
+                apply_to_all=bool(
+                    self.apply_contrast_to_all_button.isChecked()
+                )
+            )
+            return
+        self._compute_solvent_contrast()
+
+    def _apply_solvent_contrast_to_target_clusters(
+        self,
+        *,
+        apply_to_all: bool,
+    ) -> None:
+        if not self._cluster_group_states:
+            self._show_error(
+                "No Stoichiometry Table",
+                "Load a cluster-folder input before applying solvent "
+                "subtraction across stoichiometries.",
+            )
+            return
+        try:
+            self._active_contrast_settings = (
+                self._contrast_settings_from_controls()
+            )
+            self._active_contrast_name = (
+                self._contrast_display_name_from_controls()
+            )
+        except Exception as exc:
+            self._show_error("Solvent Contrast Error", str(exc))
+            return
+        (
+            target_states,
+            scope_label,
+            selected_keys,
+        ) = self._batch_target_cluster_group_states(apply_to_all=apply_to_all)
+        if not target_states:
+            self._show_error(
+                "No Stoichiometries Selected",
+                "Select at least one stoichiometry row before applying "
+                "solvent subtraction.",
+            )
+            return
+        updated_count = 0
+        skipped_pending = 0
+        skipped_debye = 0
+        failures: list[str] = []
+        total_targets = len(target_states)
+        error_payload: tuple[str, str] | None = None
+        self._begin_batch_operation_progress(
+            total=total_targets,
+            message=(
+                "Preparing batch solvent subtraction across "
+                f"{scope_label}..."
+            ),
+            title="Applying Electron Density Contrast",
+        )
+        try:
+            for index, state in enumerate(target_states, start=1):
+                self._update_batch_operation_progress(
+                    index - 1,
+                    total_targets,
+                    "Applying solvent subtraction to "
+                    f"{state.display_name} ({index}/{total_targets}).",
+                )
+                if state.single_atom_only:
+                    skipped_debye += 1
+                    self._update_batch_operation_progress(
+                        index,
+                        total_targets,
+                        "Skipped Debye-only stoichiometry "
+                        f"{state.display_name} ({index}/{total_targets}).",
+                    )
+                    continue
+                if state.profile_result is None:
+                    skipped_pending += 1
+                    self._update_batch_operation_progress(
+                        index,
+                        total_targets,
+                        "Skipped pending stoichiometry "
+                        f"{state.display_name} ({index}/{total_targets}).",
+                    )
+                    continue
+                preserved_fourier_settings = (
+                    self._cluster_state_fourier_settings(state)
+                )
+                try:
+                    state.profile_result = (
+                        apply_solvent_contrast_to_profile_result(
+                            state.profile_result,
+                            self._active_contrast_settings,
+                            solvent_name=self._active_contrast_name,
+                        )
+                    )
+                except Exception as exc:
+                    failures.append(f"{state.display_name}: {exc}")
+                    self._update_batch_operation_progress(
+                        index,
+                        total_targets,
+                        "Solvent subtraction failed for "
+                        f"{state.display_name} ({index}/{total_targets}).",
+                    )
+                    continue
+                state.transform_result = None
+                state.debye_scattering_result = None
+                self._sync_cluster_state_solvent_metadata(state)
+                self._set_cluster_state_fourier_settings(
+                    state,
+                    preserved_fourier_settings,
+                    prefer_solvent_cutoff=True,
+                )
+                self._capture_saved_output_entry(
+                    "solvent_subtraction",
+                    group_state=state,
+                    profile_result=state.profile_result,
+                )
+                updated_count += 1
+                self._update_batch_operation_progress(
+                    index,
+                    total_targets,
+                    "Applied solvent subtraction to "
+                    f"{state.display_name} ({index}/{total_targets}).",
+                )
+            if updated_count <= 0:
+                self._update_batch_operation_progress(
+                    total_targets,
+                    total_targets,
+                    "Batch solvent subtraction finished without updates.",
+                )
+                if failures:
+                    error_payload = (
+                        "Batch Solvent Contrast Error",
+                        "\n".join(failures[:6]),
+                    )
+                else:
+                    error_payload = (
+                        "No Solvent Targets Updated",
+                        "Only stoichiometries with computed density "
+                        "profiles can receive solvent subtraction. "
+                        "Single-atom Debye rows are skipped.",
+                    )
+            else:
+                self._update_batch_operation_progress(
+                    total_targets,
+                    total_targets,
+                    "Refreshing solvent-subtracted stoichiometry views...",
+                )
+                self._close_debye_scattering_compare_dialog()
+                self._refresh_cluster_views_after_batch_update(
+                    target_states,
+                    selected_keys=selected_keys,
+                )
+                self._update_batch_operation_progress(
+                    total_targets,
+                    total_targets,
+                    "Batch solvent subtraction complete.",
+                )
+        finally:
+            self._close_batch_operation_progress_dialog()
+        if error_payload is not None:
+            self._show_error(*error_payload)
+            return
+        summary_parts = [
+            f"Applied solvent subtraction to {updated_count} stoichiometr"
+            f"{'y' if updated_count == 1 else 'ies'}"
+        ]
+        if skipped_pending > 0:
+            summary_parts.append(
+                f"skipped {skipped_pending} pending density row"
+                f"{'' if skipped_pending == 1 else 's'}"
+            )
+        if skipped_debye > 0:
+            summary_parts.append(
+                f"skipped {skipped_debye} Debye-only row"
+                f"{'' if skipped_debye == 1 else 's'}"
+            )
+        if failures:
+            summary_parts.append(
+                f"{len(failures)} row"
+                f"{'' if len(failures) == 1 else 's'} failed"
+            )
+        self._append_status(
+            "Batch solvent update: "
+            + "; ".join(summary_parts)
+            + f" across {scope_label}. Each updated stoichiometry kept its "
+            "own solvent cutoff for later Fourier evaluation."
+        )
+        for failure in failures:
+            self._append_status(f"Batch solvent warning: {failure}")
+        self.statusBar().showMessage(
+            "Updated solvent subtraction across batch"
+        )
+
     def _apply_smearing_from_controls(self, *_args: object) -> None:
         self._refresh_smearing_display()
         if self._profile_result is None:
             return
+        active_cluster_state = self._active_cluster_group_state()
+        preserved_fourier_settings = (
+            None
+            if active_cluster_state is None
+            else self._cluster_state_fourier_settings(active_cluster_state)
+        )
         current_factor = float(
             self._profile_result.smearing_settings.debye_waller_factor
         )
@@ -1679,7 +7039,23 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             self._profile_result,
             self._active_smearing_settings,
         )
+        if active_cluster_state is not None:
+            active_cluster_state.profile_result = self._profile_result
+            active_cluster_state.transform_result = None
+            active_cluster_state.debye_scattering_result = None
+            self._sync_cluster_state_solvent_metadata(active_cluster_state)
+            updated_settings = self._set_cluster_state_fourier_settings(
+                active_cluster_state,
+                preserved_fourier_settings
+                or self._cluster_state_fourier_settings(active_cluster_state),
+                prefer_solvent_cutoff=True,
+            )
+            self._sync_fourier_controls_to_settings(updated_settings)
+        else:
+            self._sync_fourier_rmax_to_solvent_cutoff()
+        self._sync_fourier_controls_to_domain(reset_bounds=False)
         self._refresh_profile_plots()
+        self._populate_cluster_group_table()
         self._refresh_contrast_display()
         self.statusBar().showMessage("Updated Gaussian smearing preview")
         self._append_status(
@@ -1688,25 +7064,212 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             f"(sigma={self._profile_result.smearing_settings.gaussian_sigma_a:.4f} Å)."
         )
         self._refresh_fourier_preview_from_controls(clear_transform=True)
+        if not self._capture_smearing_saved_output_if_enabled(
+            group_state=active_cluster_state,
+            profile_result=self._profile_result,
+        ):
+            self._sync_workspace_state()
+
+    @Slot()
+    def _apply_smearing_action(self) -> None:
+        if self._cluster_group_states:
+            self._apply_smearing_to_target_clusters(
+                apply_to_all=bool(
+                    self.apply_smearing_to_all_button.isChecked()
+                )
+            )
+            return
+        self._apply_smearing_from_controls()
+
+    def _apply_smearing_to_target_clusters(
+        self,
+        *,
+        apply_to_all: bool,
+    ) -> None:
+        if not self._cluster_group_states:
+            self._show_error(
+                "No Stoichiometry Table",
+                "Load a cluster-folder input before applying smearing across stoichiometries.",
+            )
+            return
+        self._refresh_smearing_display()
+        (
+            target_states,
+            scope_label,
+            selected_keys,
+        ) = self._batch_target_cluster_group_states(apply_to_all=apply_to_all)
+        if not target_states:
+            self._show_error(
+                "No Stoichiometries Selected",
+                "Select at least one stoichiometry row before applying "
+                "smearing.",
+            )
+            return
+        updated_count = 0
+        skipped_pending = 0
+        skipped_debye = 0
+        failures: list[str] = []
+        total_targets = len(target_states)
+        error_payload: tuple[str, str] | None = None
+        self._begin_batch_operation_progress(
+            total=total_targets,
+            message=(
+                "Preparing batch smearing update across " f"{scope_label}..."
+            ),
+            title="Applying Gaussian Smearing",
+        )
+        try:
+            for index, state in enumerate(target_states, start=1):
+                self._update_batch_operation_progress(
+                    index - 1,
+                    total_targets,
+                    "Applying Gaussian smearing to "
+                    f"{state.display_name} ({index}/{total_targets}).",
+                )
+                if state.single_atom_only:
+                    skipped_debye += 1
+                    self._update_batch_operation_progress(
+                        index,
+                        total_targets,
+                        "Skipped Debye-only stoichiometry "
+                        f"{state.display_name} ({index}/{total_targets}).",
+                    )
+                    continue
+                if state.profile_result is None:
+                    skipped_pending += 1
+                    self._update_batch_operation_progress(
+                        index,
+                        total_targets,
+                        "Skipped pending stoichiometry "
+                        f"{state.display_name} ({index}/{total_targets}).",
+                    )
+                    continue
+                preserved_fourier_settings = (
+                    self._cluster_state_fourier_settings(state)
+                )
+                try:
+                    state.profile_result = apply_smearing_to_profile_result(
+                        state.profile_result,
+                        self._active_smearing_settings,
+                    )
+                except Exception as exc:
+                    failures.append(f"{state.display_name}: {exc}")
+                    self._update_batch_operation_progress(
+                        index,
+                        total_targets,
+                        "Gaussian smearing failed for "
+                        f"{state.display_name} ({index}/{total_targets}).",
+                    )
+                    continue
+                state.transform_result = None
+                state.debye_scattering_result = None
+                self._sync_cluster_state_solvent_metadata(state)
+                self._set_cluster_state_fourier_settings(
+                    state,
+                    preserved_fourier_settings,
+                    prefer_solvent_cutoff=True,
+                )
+                self._capture_smearing_saved_output_if_enabled(
+                    group_state=state,
+                    profile_result=state.profile_result,
+                )
+                updated_count += 1
+                self._update_batch_operation_progress(
+                    index,
+                    total_targets,
+                    "Applied Gaussian smearing to "
+                    f"{state.display_name} ({index}/{total_targets}).",
+                )
+            if updated_count <= 0:
+                self._update_batch_operation_progress(
+                    total_targets,
+                    total_targets,
+                    "Batch smearing finished without updates.",
+                )
+                if failures:
+                    error_payload = (
+                        "Batch Smearing Error",
+                        "\n".join(failures[:6]),
+                    )
+                else:
+                    error_payload = (
+                        "No Smearing Targets Updated",
+                        "Only stoichiometries with computed density "
+                        "profiles can be updated. Single-atom Debye rows "
+                        "are skipped.",
+                    )
+            else:
+                self._update_batch_operation_progress(
+                    total_targets,
+                    total_targets,
+                    "Refreshing smeared stoichiometry views...",
+                )
+                self._close_debye_scattering_compare_dialog()
+                self._refresh_cluster_views_after_batch_update(
+                    target_states,
+                    selected_keys=selected_keys,
+                )
+                self._update_batch_operation_progress(
+                    total_targets,
+                    total_targets,
+                    "Batch smearing complete.",
+                )
+        finally:
+            self._close_batch_operation_progress_dialog()
+        if error_payload is not None:
+            self._show_error(*error_payload)
+            return
+        summary_parts = [
+            f"Applied smearing factor={self._active_smearing_settings.debye_waller_factor:.6f} A^2 "
+            f"to {updated_count} stoichiometr"
+            f"{'y' if updated_count == 1 else 'ies'}"
+        ]
+        if skipped_pending > 0:
+            summary_parts.append(
+                f"skipped {skipped_pending} pending density row"
+                f"{'' if skipped_pending == 1 else 's'}"
+            )
+        if skipped_debye > 0:
+            summary_parts.append(
+                f"skipped {skipped_debye} Debye-only row"
+                f"{'' if skipped_debye == 1 else 's'}"
+            )
+        if failures:
+            summary_parts.append(
+                f"{len(failures)} row"
+                f"{'' if len(failures) == 1 else 's'} failed"
+            )
+        self._append_status(
+            "Batch smearing update: "
+            + "; ".join(summary_parts)
+            + f" across {scope_label}."
+        )
+        for failure in failures:
+            self._append_status(f"Batch smearing warning: {failure}")
+        self.statusBar().showMessage("Updated smearing across batch")
+        self._sync_workspace_state()
 
     def _available_fourier_r_domain(self) -> tuple[float, float] | None:
+        domain_max: float | None = None
         if self._profile_result is not None:
             radial_values = np.asarray(
                 self._profile_result.radial_centers, dtype=float
             )
             if radial_values.size >= 2:
-                return 0.0, float(radial_values[-1])
-        if self._active_mesh_geometry is None:
+                domain_max = float(radial_values[-1])
+        elif self._active_mesh_geometry is not None:
+            radial_edges = np.asarray(
+                self._active_mesh_geometry.radial_edges, dtype=float
+            )
+            if radial_edges.size >= 2:
+                radial_centers = (radial_edges[:-1] + radial_edges[1:]) * 0.5
+                if radial_centers.size >= 1:
+                    domain_max = float(radial_centers[-1])
+        if domain_max is None:
             return None
-        radial_edges = np.asarray(
-            self._active_mesh_geometry.radial_edges, dtype=float
-        )
-        if radial_edges.size < 2:
-            return None
-        radial_centers = (radial_edges[:-1] + radial_edges[1:]) * 0.5
-        if radial_centers.size < 1:
-            return None
-        return 0.0, float(radial_centers[-1])
+        if self._fourier_domain_mode_from_controls() == "mirrored":
+            return -domain_max, domain_max
+        return 0.0, domain_max
 
     def _sync_fourier_controls_to_domain(
         self,
@@ -1717,39 +7280,69 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         if available_domain is None:
             return
         domain_min, domain_max = available_domain
+        mirrored_mode = self._fourier_domain_mode_from_controls() == "mirrored"
         minimum_span = max(min(domain_max - domain_min, 1.0e-3), 1.0e-6)
         self.fourier_rmin_spin.blockSignals(True)
         self.fourier_rmax_spin.blockSignals(True)
         try:
-            self.fourier_rmin_spin.setRange(
-                domain_min,
-                max(domain_max - minimum_span, domain_min),
-            )
-            self.fourier_rmax_spin.setRange(
-                min(domain_min + minimum_span, domain_max),
-                domain_max,
-            )
             current_rmin = float(self.fourier_rmin_spin.value())
             current_rmax = float(self.fourier_rmax_spin.value())
-            if (
-                reset_bounds
-                or current_rmin < domain_min
-                or current_rmin >= domain_max
-            ):
-                current_rmin = domain_min
-            if (
-                reset_bounds
-                or current_rmax > domain_max
-                or current_rmax <= current_rmin
-            ):
-                current_rmax = domain_max
-            current_rmin = min(current_rmin, domain_max - minimum_span)
-            current_rmax = max(current_rmax, current_rmin + minimum_span)
-            self.fourier_rmin_spin.setValue(current_rmin)
-            self.fourier_rmax_spin.setValue(min(current_rmax, domain_max))
+            if mirrored_mode:
+                mirrored_domain_max = abs(float(domain_max))
+                minimum_radius = max(min(mirrored_domain_max, 1.0e-3), 1.0e-6)
+                self.fourier_rmin_spin.setRange(
+                    -mirrored_domain_max,
+                    -minimum_radius,
+                )
+                self.fourier_rmax_spin.setRange(
+                    minimum_radius,
+                    mirrored_domain_max,
+                )
+                if (
+                    reset_bounds
+                    or current_rmax > mirrored_domain_max
+                    or current_rmax < minimum_radius
+                ):
+                    current_rmax = mirrored_domain_max
+                current_rmax = float(
+                    np.clip(
+                        current_rmax,
+                        minimum_radius,
+                        mirrored_domain_max,
+                    )
+                )
+                current_rmin = -current_rmax
+                self.fourier_rmin_spin.setValue(current_rmin)
+                self.fourier_rmax_spin.setValue(current_rmax)
+            else:
+                self.fourier_rmin_spin.setRange(
+                    domain_min,
+                    max(domain_max - minimum_span, domain_min),
+                )
+                self.fourier_rmax_spin.setRange(
+                    min(domain_min + minimum_span, domain_max),
+                    domain_max,
+                )
+                if (
+                    reset_bounds
+                    or current_rmin < domain_min
+                    or current_rmin >= domain_max
+                ):
+                    current_rmin = domain_min
+                if (
+                    reset_bounds
+                    or current_rmax > domain_max
+                    or current_rmax <= current_rmin
+                ):
+                    current_rmax = domain_max
+                current_rmin = min(current_rmin, domain_max - minimum_span)
+                current_rmax = max(current_rmax, current_rmin + minimum_span)
+                self.fourier_rmin_spin.setValue(current_rmin)
+                self.fourier_rmax_spin.setValue(min(current_rmax, domain_max))
         finally:
             self.fourier_rmin_spin.blockSignals(False)
             self.fourier_rmax_spin.blockSignals(False)
+        self._refresh_fourier_domain_mode_controls()
 
     def _sync_fourier_controls_to_settings(
         self,
@@ -1757,6 +7350,7 @@ class ElectronDensityMappingMainWindow(QMainWindow):
     ) -> None:
         normalized = settings.normalized()
         widgets = (
+            self.fourier_legacy_mode_checkbox,
             self.fourier_rmin_spin,
             self.fourier_rmax_spin,
             self.fourier_qmin_spin,
@@ -1771,6 +7365,9 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         for widget in widgets:
             widget.blockSignals(True)
         try:
+            self.fourier_legacy_mode_checkbox.setChecked(
+                normalized.domain_mode == "legacy"
+            )
             self.fourier_rmin_spin.setValue(float(normalized.r_min))
             self.fourier_rmax_spin.setValue(float(normalized.r_max))
             window_index = max(
@@ -1794,11 +7391,113 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         finally:
             for widget in widgets:
                 widget.blockSignals(False)
+        self._refresh_fourier_domain_mode_controls()
+
+    def _sync_fourier_rmax_to_solvent_cutoff(self) -> float | None:
+        if (
+            self._profile_result is None
+            or self._profile_result.solvent_contrast is None
+            or self._profile_result.solvent_contrast.cutoff_radius_a is None
+        ):
+            return None
+        available_domain = self._available_fourier_r_domain()
+        if available_domain is None:
+            return None
+        domain_min, domain_max = available_domain
+        mirrored_mode = self._fourier_domain_mode_from_controls() == "mirrored"
+        minimum_span = max(min(domain_max - domain_min, 1.0e-3), 1.0e-6)
+        minimum_radius = max(min(abs(float(domain_max)), 1.0e-3), 1.0e-6)
+        current_rmin = (
+            -float(self.fourier_rmax_spin.value())
+            if mirrored_mode
+            else float(self.fourier_rmin_spin.value())
+        )
+        target_rmax = float(
+            np.clip(
+                float(self._profile_result.solvent_contrast.cutoff_radius_a),
+                (
+                    minimum_radius
+                    if mirrored_mode
+                    else current_rmin + minimum_span
+                ),
+                abs(float(domain_max)) if mirrored_mode else domain_max,
+            )
+        )
+        if mirrored_mode:
+            self.fourier_rmin_spin.blockSignals(True)
+            try:
+                self.fourier_rmin_spin.setValue(-target_rmax)
+            finally:
+                self.fourier_rmin_spin.blockSignals(False)
+        self.fourier_rmax_spin.blockSignals(True)
+        try:
+            self.fourier_rmax_spin.setValue(target_rmax)
+        finally:
+            self.fourier_rmax_spin.blockSignals(False)
+        return target_rmax
 
     def _refresh_fourier_info_labels(
         self,
         preview: ElectronDensityFourierTransformPreview | None,
     ) -> None:
+        active_cluster_state = self._active_cluster_group_state()
+        active_settings = (
+            None
+            if active_cluster_state is None
+            else self._cluster_state_fourier_settings(active_cluster_state)
+        )
+        if (
+            active_cluster_state is not None
+            and active_cluster_state.single_atom_only
+        ):
+            if preview is None:
+                if active_cluster_state.transform_result is not None:
+                    settings = (
+                        active_cluster_state.transform_result.preview.settings
+                    )
+                else:
+                    settings = (
+                        active_settings
+                        if active_settings is not None
+                        else self._fourier_settings_from_controls()
+                    )
+            else:
+                settings = preview.settings
+            self._active_fourier_settings = settings
+            q_min = float(settings.q_min)
+            q_max = float(settings.q_max)
+            q_step = float(settings.q_step)
+            q_count = len(
+                np.arange(
+                    q_min,
+                    q_max + q_step * 0.5,
+                    q_step,
+                    dtype=float,
+                )
+            )
+            self.fourier_available_range_value.setText("Direct Debye mode")
+            self.fourier_nyquist_value.setText(
+                f"q={q_min:.4f} to {q_max:.4f} Å⁻¹, Δq={q_step:.4f} Å⁻¹, {q_count} points."
+            )
+            self.fourier_preview_info_label.setText(
+                "Direct Debye scattering  ·  no r-space preview"
+            )
+            if active_cluster_state.transform_result is None:
+                self.fourier_notice_value.setText(
+                    "This cluster bin contains only single-atom structures. "
+                    "Run the calculation or click Evaluate Fourier Transform "
+                    "to build a direct Debye I(Q) trace. The r-range "
+                    "and window controls are ignored."
+                )
+                self.fourier_notice_value.setStyleSheet("color: #92400e;")
+            else:
+                self.fourier_notice_value.setText(
+                    "This cluster bin uses direct Debye scattering. "
+                    "Electron-density, solvent-contrast, and Fourier-profile preparation "
+                    "are skipped; only the q-grid and axis-scale settings apply."
+                )
+                self.fourier_notice_value.setStyleSheet("color: #166534;")
+            return
         available_domain = self._available_fourier_r_domain()
         if available_domain is None:
             self.fourier_available_range_value.setText(
@@ -1809,15 +7508,19 @@ class ElectronDensityMappingMainWindow(QMainWindow):
                 f"{available_domain[0]:.4f} to {available_domain[1]:.4f} Å"
             )
         if preview is None:
-            try:
-                settings = self._fourier_settings_from_controls()
-            except Exception as exc:
-                self.fourier_nyquist_value.setText(
-                    "Adjust the Fourier-transform bounds to satisfy the requested sampling."
-                )
-                self.fourier_notice_value.setText(str(exc))
-                self.fourier_notice_value.setStyleSheet("color: #991b1b;")
-                return
+            if active_settings is not None:
+                settings = active_settings
+            else:
+                try:
+                    settings = self._fourier_settings_from_controls()
+                except Exception as exc:
+                    self.fourier_nyquist_value.setText(
+                        "Adjust the Fourier-transform bounds to satisfy the requested sampling."
+                    )
+                    self.fourier_notice_value.setText(str(exc))
+                    self.fourier_notice_value.setStyleSheet("color: #991b1b;")
+                    self.fourier_preview_info_label.setText("")
+                    return
             self._active_fourier_settings = settings
             span = max(settings.r_max - settings.r_min, 1.0e-12)
             resampling_step = span / max(settings.resampling_points - 1, 1)
@@ -1826,6 +7529,11 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             self.fourier_nyquist_value.setText(
                 f"Δr={resampling_step:.4f} Å, qmax≈{nyquist_qmax:.3f} Å⁻¹, "
                 f"independent Δq≈{independent_qstep:.3f} Å⁻¹."
+            )
+            self.fourier_preview_info_label.setText(
+                f"Δr={resampling_step:.4f} Å  ·  "
+                f"qmax≈{nyquist_qmax:.3f} Å⁻¹  ·  "
+                f"Δq≈{independent_qstep:.3f} Å⁻¹"
             )
             if self._profile_result is None:
                 self.fourier_notice_value.setText(
@@ -1844,6 +7552,11 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             f"qmax≈{preview.nyquist_q_max_a_inverse:.3f} Å⁻¹, "
             f"independent Δq≈{preview.independent_q_step_a_inverse:.3f} Å⁻¹."
         )
+        self.fourier_preview_info_label.setText(
+            f"Δr={preview.resampling_step_a:.4f} Å  ·  "
+            f"qmax≈{preview.nyquist_q_max_a_inverse:.3f} Å⁻¹  ·  "
+            f"Δq≈{preview.independent_q_step_a_inverse:.3f} Å⁻¹"
+        )
         if preview.notes:
             self.fourier_notice_value.setText(
                 f"Source: {preview.source_profile_label}. "
@@ -1858,32 +7571,88 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             )
             self.fourier_notice_value.setStyleSheet("color: #166534;")
 
+    def _display_fourier_preview(
+        self,
+        preview: ElectronDensityFourierTransformPreview | None,
+    ) -> None:
+        self._fourier_preview = preview
+        if preview is None:
+            self.fourier_preview_plot.draw_placeholder()
+            self._refresh_fourier_info_labels(None)
+            return
+        self.fourier_preview_plot.set_preview(preview)
+        if self.auto_expand_checkbox.isChecked():
+            self.fourier_preview_section.expand()
+        self._refresh_fourier_info_labels(preview)
+
     def _refresh_fourier_preview_from_controls(
         self,
         *_args: object,
         clear_transform: bool = True,
     ) -> None:
+        active_cluster_state = self._active_cluster_group_state()
+        if clear_transform and active_cluster_state is not None:
+            active_cluster_state.debye_scattering_result = None
+        if (
+            active_cluster_state is not None
+            and active_cluster_state.single_atom_only
+        ):
+            try:
+                settings = self._fourier_settings_from_controls()
+            except Exception:
+                settings = self._default_fourier_settings()
+            self._active_fourier_settings = (
+                self._set_cluster_state_fourier_settings(
+                    active_cluster_state,
+                    settings,
+                    prefer_solvent_cutoff=False,
+                )
+            )
+            self._fourier_preview = None
+            self.fourier_preview_plot.draw_placeholder()
+            if clear_transform:
+                self._fourier_result = None
+                self._debye_scattering_result = None
+                self._refresh_scattering_plot()
+                self._close_debye_scattering_compare_dialog()
+            self._populate_cluster_group_table()
+            self._refresh_fourier_info_labels(None)
+            self._sync_workspace_state()
+            return
         try:
             settings = self._fourier_settings_from_controls()
         except Exception as exc:
-            self._active_fourier_settings = (
-                ElectronDensityFourierTransformSettings()
-            )
+            self._active_fourier_settings = self._default_fourier_settings()
             self.fourier_notice_value.setText(str(exc))
             self.fourier_notice_value.setStyleSheet("color: #991b1b;")
             self.fourier_preview_plot.draw_placeholder()
             if clear_transform:
                 self._fourier_result = None
-                self.scattering_plot.draw_placeholder()
+                self._debye_scattering_result = None
+                self._refresh_scattering_plot()
+                self._close_debye_scattering_compare_dialog()
+            self._sync_workspace_state()
             return
+        if active_cluster_state is not None:
+            settings = self._set_cluster_state_fourier_settings(
+                active_cluster_state,
+                settings,
+                prefer_solvent_cutoff=bool(
+                    active_cluster_state.solvent_cutoff_radius_a
+                ),
+            )
+            self._populate_cluster_group_table()
         self._active_fourier_settings = settings
         if self._profile_result is None:
             self._fourier_preview = None
             self.fourier_preview_plot.draw_placeholder()
             if clear_transform:
                 self._fourier_result = None
-                self.scattering_plot.draw_placeholder()
+                self._debye_scattering_result = None
+                self._refresh_scattering_plot()
+                self._close_debye_scattering_compare_dialog()
             self._refresh_fourier_info_labels(None)
+            self._sync_workspace_state()
             return
         try:
             preview = prepare_electron_density_fourier_transform(
@@ -1895,32 +7664,163 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             self.fourier_preview_plot.draw_placeholder()
             if clear_transform:
                 self._fourier_result = None
-                self.scattering_plot.draw_placeholder()
+                self._debye_scattering_result = None
+                self._refresh_scattering_plot()
+                self._close_debye_scattering_compare_dialog()
             self._refresh_fourier_info_labels(None)
             self.fourier_notice_value.setText(str(exc))
             self.fourier_notice_value.setStyleSheet("color: #991b1b;")
+            self._sync_workspace_state()
             return
-        self._fourier_preview = preview
-        self.fourier_preview_plot.set_preview(preview)
-        if self.auto_expand_checkbox.isChecked():
-            self.fourier_preview_section.expand()
-        self._refresh_fourier_info_labels(preview)
+        self._display_fourier_preview(preview)
         if clear_transform:
             self._fourier_result = None
-            self.scattering_plot.draw_placeholder()
+            self._debye_scattering_result = None
+            self._refresh_scattering_plot()
+            self._close_debye_scattering_compare_dialog()
+        self._sync_workspace_state()
 
-    @Slot(bool)
-    def _apply_fourier_axis_scale_preferences(self, _checked: bool) -> None:
+    def _additional_scattering_series(self) -> list[dict[str, object]]:
+        if (
+            not self._cluster_group_states
+            or not self.show_all_cluster_transforms_checkbox.isChecked()
+        ):
+            return []
+        active_key = self._selected_cluster_group_key
+        overlays: list[dict[str, object]] = []
+        for state in self._cluster_group_states:
+            if state.transform_result is None or state.key == active_key:
+                continue
+            overlays.append(
+                {
+                    "label": state.display_name,
+                    "q_values": np.asarray(
+                        state.transform_result.q_values,
+                        dtype=float,
+                    ),
+                    "intensity": np.asarray(
+                        state.transform_result.intensity,
+                        dtype=float,
+                    ),
+                    "color": state.trace_color,
+                }
+            )
+        return overlays
+
+    def _refresh_scattering_plot(self) -> None:
         if self._fourier_result is None:
+            self.scattering_plot.draw_placeholder()
+            self.scattering_info_label.setText("")
             return
+        active_cluster_state = self._active_cluster_group_state()
+        uses_single_atom_debye = (
+            active_cluster_state is not None
+            and active_cluster_state.single_atom_only
+        )
         self.scattering_plot.set_transform_result(
             self._fourier_result,
             log_q_axis=self.fourier_log_q_checkbox.isChecked(),
             log_intensity_axis=self.fourier_log_intensity_checkbox.isChecked(),
+            additional_series=self._additional_scattering_series(),
+            primary_label=(
+                "Direct Debye intensity"
+                if uses_single_atom_debye
+                else (
+                    "Born-approximation intensity"
+                    if not self._cluster_group_states
+                    else (
+                        self._active_cluster_group_state().display_name
+                        if self._active_cluster_group_state() is not None
+                        else "Born-approximation intensity"
+                    )
+                )
+            ),
+            primary_color=(
+                "#2563eb"
+                if uses_single_atom_debye
+                else (
+                    "#b45309"
+                    if self._active_cluster_group_state() is None
+                    else self._active_cluster_group_state().trace_color
+                )
+            ),
+        )
+        settings = self._fourier_result.preview.settings
+        if uses_single_atom_debye:
+            self.scattering_info_label.setText(
+                f"Direct Debye scattering  ·  "
+                f"q: {settings.q_min:.3f}–{settings.q_max:.3f} Å⁻¹  ·  "
+                f"Δq={settings.q_step:.3f} Å⁻¹  ·  "
+                f"{len(self._fourier_result.q_values)} q points"
+            )
+            return
+        self.scattering_info_label.setText(
+            f"Window: {settings.window_function}  ·  "
+            f"r: {settings.r_min:.3f}–{settings.r_max:.3f} Å  ·  "
+            f"{len(self._fourier_result.q_values)} q points"
         )
 
     @Slot()
+    def _evaluate_fourier_transform_action(self) -> None:
+        if self._cluster_group_states:
+            self._evaluate_fourier_transform_for_target_clusters(
+                apply_to_all=bool(self.apply_fourier_to_all_button.isChecked())
+            )
+            return
+        self._evaluate_fourier_transform()
+
+    @Slot()
     def _evaluate_fourier_transform(self) -> None:
+        active_cluster_state = self._active_cluster_group_state()
+        try:
+            settings = (
+                self._cluster_state_fourier_settings(active_cluster_state)
+                if active_cluster_state is not None
+                else self._fourier_settings_from_controls()
+            )
+        except Exception as exc:
+            self._show_error("Fourier Transform Error", str(exc))
+            return
+        if (
+            active_cluster_state is not None
+            and active_cluster_state.single_atom_only
+        ):
+            try:
+                transform_result = (
+                    compute_single_atom_debye_scattering_profile_for_input(
+                        active_cluster_state.inspection,
+                        settings,
+                    )
+                )
+            except Exception as exc:
+                self._show_error("Debye Scattering Error", str(exc))
+                return
+            self._fourier_preview = None
+            self._fourier_result = transform_result
+            self._debye_scattering_result = None
+            active_cluster_state.fourier_settings = (
+                transform_result.preview.settings
+            )
+            active_cluster_state.transform_result = transform_result
+            active_cluster_state.debye_scattering_result = None
+            self._sync_fourier_controls_to_settings(
+                transform_result.preview.settings
+            )
+            self.fourier_preview_plot.draw_placeholder()
+            self._refresh_fourier_info_labels(None)
+            self._populate_cluster_group_table()
+            self._refresh_scattering_plot()
+            self._append_status(
+                "Built direct Debye I(Q) for single-atom cluster group "
+                f"{active_cluster_state.display_name}: "
+                f"{len(transform_result.q_values)} q points."
+            )
+            self._update_push_to_model_state()
+            self._refresh_debye_scattering_group()
+            self.statusBar().showMessage("Built single-atom Debye scattering")
+            self._close_debye_scattering_compare_dialog()
+            self._sync_workspace_state()
+            return
         if self._profile_result is None:
             self._show_error(
                 "No Density Profile",
@@ -1930,23 +7830,34 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         try:
             transform_result = compute_electron_density_scattering_profile(
                 self._profile_result,
-                self._fourier_settings_from_controls(),
+                settings,
             )
         except Exception as exc:
             self._show_error("Fourier Transform Error", str(exc))
             return
         self._fourier_preview = transform_result.preview
         self._fourier_result = transform_result
+        self._debye_scattering_result = None
         self._sync_fourier_controls_to_settings(
             transform_result.preview.settings
         )
         self._refresh_fourier_info_labels(transform_result.preview)
         self.fourier_preview_plot.set_preview(transform_result.preview)
-        self.scattering_plot.set_transform_result(
-            transform_result,
-            log_q_axis=self.fourier_log_q_checkbox.isChecked(),
-            log_intensity_axis=self.fourier_log_intensity_checkbox.isChecked(),
+        active_cluster_state = self._active_cluster_group_state()
+        if active_cluster_state is not None:
+            active_cluster_state.fourier_settings = (
+                transform_result.preview.settings
+            )
+            active_cluster_state.transform_result = transform_result
+            active_cluster_state.debye_scattering_result = None
+            self._populate_cluster_group_table()
+        self._capture_saved_output_entry(
+            "fourier_transform",
+            group_state=active_cluster_state,
+            profile_result=self._profile_result,
+            transform_result=transform_result,
         )
+        self._refresh_scattering_plot()
         if self.auto_expand_checkbox.isChecked():
             self.fourier_preview_section.expand()
             self.scattering_section.expand()
@@ -1959,55 +7870,361 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         )
         for note in transform_result.preview.notes:
             self._append_status(note)
+        self._update_push_to_model_state()
+        self._refresh_debye_scattering_group()
         self.statusBar().showMessage("Evaluated Fourier transform")
+        self._close_debye_scattering_compare_dialog()
+        self._sync_workspace_state()
 
-    def _sync_controls_to_structure(self) -> None:
+    def _evaluate_fourier_transform_for_target_clusters(
+        self,
+        *,
+        apply_to_all: bool,
+    ) -> None:
+        if not self._cluster_group_states:
+            self._show_error(
+                "No Stoichiometry Table",
+                "Load a cluster-folder input before evaluating Fourier "
+                "transforms across stoichiometries.",
+            )
+            return
+        (
+            target_states,
+            scope_label,
+            selected_keys,
+        ) = self._batch_target_cluster_group_states(apply_to_all=apply_to_all)
+        if not target_states:
+            self._show_error(
+                "No Stoichiometries Selected",
+                "Select at least one stoichiometry row before evaluating "
+                "the Fourier transform.",
+            )
+            return
+        density_count = 0
+        debye_count = 0
+        skipped_pending = 0
+        failures: list[str] = []
+        total_targets = len(target_states)
+        error_payload: tuple[str, str] | None = None
+        self._begin_batch_operation_progress(
+            total=total_targets,
+            message=(
+                "Preparing batch Fourier evaluation across "
+                f"{scope_label}..."
+            ),
+            title="Evaluating Fourier Transforms",
+        )
+        try:
+            for index, state in enumerate(target_states, start=1):
+                self._update_batch_operation_progress(
+                    index - 1,
+                    total_targets,
+                    "Evaluating Fourier transform for "
+                    f"{state.display_name} ({index}/{total_targets}).",
+                )
+                settings = self._cluster_state_fourier_settings(state)
+                try:
+                    if state.single_atom_only:
+                        transform_result = compute_single_atom_debye_scattering_profile_for_input(
+                            state.inspection,
+                            settings,
+                        )
+                        state.fourier_settings = (
+                            transform_result.preview.settings
+                        )
+                        state.transform_result = transform_result
+                        state.debye_scattering_result = None
+                        debye_count += 1
+                        self._update_batch_operation_progress(
+                            index,
+                            total_targets,
+                            "Built direct Debye scattering for "
+                            f"{state.display_name} ({index}/{total_targets}).",
+                        )
+                        continue
+                    if state.profile_result is None:
+                        skipped_pending += 1
+                        self._update_batch_operation_progress(
+                            index,
+                            total_targets,
+                            "Skipped pending stoichiometry "
+                            f"{state.display_name} ({index}/{total_targets}).",
+                        )
+                        continue
+                    transform_result = (
+                        compute_electron_density_scattering_profile(
+                            state.profile_result,
+                            settings,
+                        )
+                    )
+                except Exception as exc:
+                    failures.append(f"{state.display_name}: {exc}")
+                    self._update_batch_operation_progress(
+                        index,
+                        total_targets,
+                        "Fourier evaluation failed for "
+                        f"{state.display_name} ({index}/{total_targets}).",
+                    )
+                    continue
+                state.fourier_settings = transform_result.preview.settings
+                state.transform_result = transform_result
+                state.debye_scattering_result = None
+                self._capture_saved_output_entry(
+                    "fourier_transform",
+                    group_state=state,
+                    profile_result=state.profile_result,
+                    transform_result=transform_result,
+                )
+                density_count += 1
+                self._update_batch_operation_progress(
+                    index,
+                    total_targets,
+                    "Evaluated Fourier transform for "
+                    f"{state.display_name} ({index}/{total_targets}).",
+                )
+            if density_count <= 0 and debye_count <= 0:
+                self._update_batch_operation_progress(
+                    total_targets,
+                    total_targets,
+                    "Batch Fourier evaluation finished without updates.",
+                )
+                if failures:
+                    error_payload = (
+                        "Batch Fourier Transform Error",
+                        "\n".join(failures[:6]),
+                    )
+                else:
+                    error_payload = (
+                        "No Fourier Targets Updated",
+                        "Only stoichiometries with computed density "
+                        "profiles or single-atom Debye rows can be "
+                        "evaluated.",
+                    )
+            else:
+                self._update_batch_operation_progress(
+                    total_targets,
+                    total_targets,
+                    "Refreshing Fourier-transform stoichiometry views...",
+                )
+                self._close_debye_scattering_compare_dialog()
+                self._refresh_cluster_views_after_batch_update(
+                    target_states,
+                    selected_keys=selected_keys,
+                )
+                self._update_batch_operation_progress(
+                    total_targets,
+                    total_targets,
+                    "Batch Fourier evaluation complete.",
+                )
+        finally:
+            self._close_batch_operation_progress_dialog()
+        if error_payload is not None:
+            self._show_error(*error_payload)
+            return
+        summary_parts: list[str] = []
+        if density_count > 0:
+            summary_parts.append(
+                f"{density_count} Born-approximation transform"
+                f"{'' if density_count == 1 else 's'}"
+            )
+        if debye_count > 0:
+            summary_parts.append(
+                f"{debye_count} direct Debye trace"
+                f"{'' if debye_count == 1 else 's'}"
+            )
+        if skipped_pending > 0:
+            summary_parts.append(
+                f"skipped {skipped_pending} pending density row"
+                f"{'' if skipped_pending == 1 else 's'}"
+            )
+        if failures:
+            summary_parts.append(
+                f"{len(failures)} row"
+                f"{'' if len(failures) == 1 else 's'} failed"
+            )
+        self._append_status(
+            "Batch Fourier evaluation: "
+            + "; ".join(summary_parts)
+            + f" across {scope_label}. Each density-based transform used the "
+            "stored Fourier settings for that row, including its own r range."
+        )
+        for failure in failures:
+            self._append_status(f"Batch Fourier warning: {failure}")
+        self.statusBar().showMessage(
+            "Evaluated Fourier transforms across batch"
+        )
+        self._sync_workspace_state()
+
+    @Slot(bool)
+    def _apply_fourier_axis_scale_preferences(self, _checked: bool) -> None:
+        if self._fourier_result is None:
+            return
+        self._refresh_scattering_plot()
+
+    def _sync_controls_to_structure(
+        self,
+        *,
+        sync_mesh_rmax: bool = True,
+    ) -> None:
         if self._structure is None:
             return
-        self.rmax_spin.setValue(max(float(self._structure.rmax), 0.01))
+        if sync_mesh_rmax:
+            self.rmax_spin.setValue(max(float(self._structure.rmax), 0.01))
         self._sync_reference_element_controls()
         self._refresh_center_display()
         self._refresh_structure_summary()
 
     def _refresh_active_mesh_display(self) -> None:
+        center_label = self._center_mode_label_for_structure(self._structure)
+        center_text = (
+            self._format_point(self._structure.active_center)
+            if self._structure is not None
+            else "Unavailable"
+        )
         if self._active_mesh_geometry is None:
             self.active_mesh_value.setText(
-                "No active structure yet. The current defaults are "
-                f"rstep={self._active_mesh_settings.rstep:.3f} Å, "
-                f"theta={self._active_mesh_settings.theta_divisions}, "
-                f"phi={self._active_mesh_settings.phi_divisions}, "
-                f"rmax={self._active_mesh_settings.rmax:.3f} Å."
+                "No active mesh is rendered yet. The current settings are "
+                f"{self._format_mesh_settings_summary(self._active_mesh_settings)}, "
+                f"center mode={center_label}, "
+                f"center={center_text}."
             )
             return
         geometry = self._active_mesh_geometry
         self.active_mesh_value.setText(
-            f"rstep={geometry.settings.rstep:.3f} Å, "
-            f"theta={geometry.settings.theta_divisions}, "
-            f"phi={geometry.settings.phi_divisions}, "
-            f"rmax={geometry.settings.rmax:.3f} Å, "
+            f"{self._format_mesh_settings_summary(geometry.settings)}, "
             f"shells={geometry.shell_count}, "
             f"domain=0 to {geometry.domain_max_radius:.3f} Å, "
-            f"center={self._format_point(self._structure.active_center) if self._structure is not None else 'Unavailable'}"
+            f"center mode={center_label}, "
+            f"center={center_text}"
         )
 
     @Slot()
     def _refresh_mesh_notice(self) -> None:
+        if self._manual_mesh_lock_settings is not None:
+            self.pending_mesh_value.setText(
+                "Mesh settings are locked at "
+                f"{self._format_mesh_settings_summary(self._manual_mesh_lock_settings)} "
+                "while manual-mode stoichiometry calculations remain active. "
+                "Reset the calculated densities to edit the mesh."
+            )
+            self.pending_mesh_value.setStyleSheet("color: #92400e;")
+            return
         pending = self._mesh_settings_from_controls()
-        if pending == self._active_mesh_settings:
+        if pending != self._active_mesh_settings:
+            self.pending_mesh_value.setText(
+                "Pending field values differ from the rendered mesh. Press "
+                "Update Mesh Settings to redraw the spherical overlay before "
+                "running, or continue with the last updated mesh."
+            )
+            self.pending_mesh_value.setStyleSheet("color: #92400e;")
+            return
+        if self._mesh_settings_confirmed_for_run:
             self.pending_mesh_value.setText(
                 "Pending field values match the rendered mesh."
             )
             self.pending_mesh_value.setStyleSheet("color: #166534;")
             return
         self.pending_mesh_value.setText(
-            "Pending field values differ from the rendered mesh. Press "
-            "Update Mesh Settings to redraw the spherical overlay."
+            "Mesh settings still reflect the current default values shown in "
+            "the UI. Press Update Mesh Settings to confirm them before "
+            "running, or continue from the run warning."
         )
         self.pending_mesh_value.setStyleSheet("color: #92400e;")
 
-    def _load_input_path(self, path: Path) -> None:
-        inspection = inspect_structure_input(path)
-        structure = load_electron_density_structure(inspection.reference_file)
+    def _load_cluster_group_input(
+        self,
+        path: Path,
+        *,
+        cluster_states: list[_ClusterDensityGroupState] | None = None,
+    ) -> bool:
+        if cluster_states is None:
+            cluster_states = self._cluster_group_states_for_path(path)
+        if not cluster_states:
+            return False
+        single_atom_count = sum(
+            1 for state in cluster_states if state.single_atom_only
+        )
+        self._cluster_group_states = cluster_states
+        for state in self._cluster_group_states:
+            if state.fourier_settings is None:
+                state.fourier_settings = (
+                    self._active_fourier_settings.normalized()
+                )
+        self._selected_cluster_group_key = cluster_states[0].key
+        self._reset_density_results()
+        self._reset_progress_display("Idle")
+        self.input_mode_value.setText(
+            f"Cluster folders ({len(cluster_states)} stoichiometries)"
+        )
+        self.reference_file_value.setText(
+            str(cluster_states[0].inspection.reference_file)
+        )
+        self._active_mesh_settings = (
+            self._cluster_group_mesh_settings_for_states(cluster_states)
+        )
+        self._sync_mesh_controls_to_settings(self._active_mesh_settings)
+        self._set_mesh_settings_confirmed_for_run(False)
+        self.output_dir_edit.setText(
+            str(
+                self._initial_output_dir
+                or suggest_output_dir(
+                    path,
+                    project_dir=self._project_dir,
+                )
+            )
+        )
+        self.output_basename_edit.setText(
+            f"{path.name}_cluster_average_density"
+        )
+        self.smearing_factor_spin.setValue(0.001)
+        self._populate_cluster_group_table()
+        self.cluster_group_table.selectRow(0)
+        self._set_active_cluster_group(
+            cluster_states[0].key,
+            preserve_zoom=False,
+        )
+        self._sync_pinned_geometric_tracking_control_to_settings(
+            self._active_mesh_settings
+        )
+        self._schedule_cluster_view_cache_prewarm()
+        self._append_status(
+            f"Loaded cluster-folder input {path} with {len(cluster_states)} stoichiometries."
+        )
+        self._append_status(
+            "Cluster-folder mode computes an averaged electron-density profile "
+            "for each stoichiometry subfolder and lets you switch plots by row."
+        )
+        if single_atom_count > 0:
+            self._append_status(
+                f"{single_atom_count} stoichiometry folder"
+                f"{'' if single_atom_count == 1 else 's'} contain only single-atom "
+                "structures and will use direct Debye scattering instead of "
+                "electron-density and Fourier-profile evaluation."
+            )
+        self.statusBar().showMessage(
+            f"Loaded cluster folders from {path.name}"
+        )
+        return True
+
+    def _apply_workspace_load_payload(
+        self,
+        payload: _ElectronDensityWorkspaceLoadPayload,
+    ) -> None:
+        path = Path(payload.selection_path).expanduser().resolve()
+        self._clear_saved_output_history(announce=False)
+        self._clear_cluster_group_states()
+        if self._load_cluster_group_input(
+            path,
+            cluster_states=list(payload.cluster_states),
+        ):
+            self._restore_saved_output_history_if_available()
+            return
+        inspection = payload.inspection
+        structure = payload.structure
+        if inspection is None or structure is None:
+            raise RuntimeError(
+                "Workspace loader returned an incomplete structure payload."
+            )
         self._inspection = inspection
         self._structure = structure
         self._reset_density_results()
@@ -2022,6 +8239,9 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             self.input_mode_value.setText("Single structure file")
         self.reference_file_value.setText(str(inspection.reference_file))
         self._sync_controls_to_structure()
+        self._sync_pinned_geometric_tracking_control_to_settings(
+            self._active_mesh_settings
+        )
 
         self.output_dir_edit.setText(
             str(
@@ -2037,6 +8257,7 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             self._mesh_settings_from_controls(),
             announce=False,
         )
+        self._set_mesh_settings_confirmed_for_run(False)
         self._sync_fourier_controls_to_domain(reset_bounds=True)
         self._refresh_fourier_info_labels(None)
         self._refresh_contrast_display()
@@ -2053,6 +8274,2445 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         for note in inspection.notes():
             self._append_status(note)
         self.statusBar().showMessage(f"Loaded {structure.file_path.name}")
+        self._restore_saved_output_history_if_available()
+
+    def _load_input_path(
+        self,
+        path: Path,
+        *,
+        asynchronous: bool = False,
+        restore_saved_distribution_state: bool = False,
+    ) -> None:
+        resolved_path = Path(path).expanduser().resolve()
+        if asynchronous:
+            self._start_workspace_load(
+                resolved_path,
+                restore_saved_distribution_state=restore_saved_distribution_state,
+                progress_message="Loading electron-density input...",
+            )
+            return
+        self._apply_workspace_load_payload(
+            _build_workspace_load_payload(resolved_path)
+        )
+
+    def _component_summary_path(self) -> Path | None:
+        if self._distribution_root_dir is None:
+            return None
+        return (
+            self._distribution_root_dir
+            / "electron_density_mapping"
+            / "born_approximation_component_summary.json"
+        )
+
+    def _workspace_state_path(self) -> Path | None:
+        if self._distribution_root_dir is None:
+            return None
+        return (
+            self._distribution_root_dir
+            / "electron_density_mapping"
+            / "workspace_state.json"
+        )
+
+    def _component_artifact_targets(self) -> tuple[Path, Path] | None:
+        if self._distribution_root_dir is None:
+            return None
+        if self._use_predicted_structure_weights:
+            return (
+                self._distribution_root_dir
+                / "scattering_components_predicted_structures",
+                self._distribution_root_dir
+                / "md_saxs_map_predicted_structures.json",
+            )
+        return (
+            self._distribution_root_dir / "scattering_components",
+            self._distribution_root_dir / "md_saxs_map.json",
+        )
+
+    @staticmethod
+    def _component_profile_filename(structure: str, motif: str) -> str:
+        safe_name = f"{structure}_{motif}".replace("/", "_")
+        return f"{safe_name}.txt"
+
+    @staticmethod
+    def _serialize_structure(
+        structure: ElectronDensityStructure,
+    ) -> dict[str, object]:
+        return {
+            "file_path": str(structure.file_path),
+            "display_label": str(structure.display_label),
+            "structure_comment": str(structure.structure_comment),
+            "coordinates": np.asarray(
+                structure.coordinates, dtype=float
+            ).tolist(),
+            "centered_coordinates": np.asarray(
+                structure.centered_coordinates,
+                dtype=float,
+            ).tolist(),
+            "elements": list(structure.elements),
+            "element_counts": dict(structure.element_counts),
+            "atomic_numbers": np.asarray(
+                structure.atomic_numbers,
+                dtype=float,
+            ).tolist(),
+            "atomic_masses": np.asarray(
+                structure.atomic_masses,
+                dtype=float,
+            ).tolist(),
+            "center_of_mass": np.asarray(
+                structure.center_of_mass,
+                dtype=float,
+            ).tolist(),
+            "geometric_center": np.asarray(
+                structure.geometric_center,
+                dtype=float,
+            ).tolist(),
+            "reference_element": str(structure.reference_element),
+            "reference_element_geometric_center": np.asarray(
+                structure.reference_element_geometric_center,
+                dtype=float,
+            ).tolist(),
+            "reference_element_offset_from_geometric_center": float(
+                structure.reference_element_offset_from_geometric_center
+            ),
+            "active_center": np.asarray(
+                structure.active_center,
+                dtype=float,
+            ).tolist(),
+            "center_mode": str(structure.center_mode),
+            "nearest_atom_index": int(structure.nearest_atom_index),
+            "nearest_atom_distance": float(structure.nearest_atom_distance),
+            "bonds": [list(bond) for bond in structure.bonds],
+            "rmax": float(structure.rmax),
+        }
+
+    @staticmethod
+    def _deserialize_structure(
+        payload: dict[str, object]
+    ) -> ElectronDensityStructure:
+        return ElectronDensityStructure(
+            file_path=Path(str(payload.get("file_path") or ""))
+            .expanduser()
+            .resolve(),
+            display_label=str(payload.get("display_label") or ""),
+            structure_comment=str(payload.get("structure_comment") or ""),
+            coordinates=np.asarray(
+                payload.get("coordinates") or [], dtype=float
+            ),
+            centered_coordinates=np.asarray(
+                payload.get("centered_coordinates") or [],
+                dtype=float,
+            ),
+            elements=tuple(
+                str(value) for value in (payload.get("elements") or [])
+            ),
+            element_counts={
+                str(key): int(value)
+                for key, value in dict(
+                    payload.get("element_counts") or {}
+                ).items()
+            },
+            atomic_numbers=np.asarray(
+                payload.get("atomic_numbers") or [],
+                dtype=float,
+            ),
+            atomic_masses=np.asarray(
+                payload.get("atomic_masses") or [],
+                dtype=float,
+            ),
+            center_of_mass=np.asarray(
+                payload.get("center_of_mass") or [0.0, 0.0, 0.0],
+                dtype=float,
+            ),
+            geometric_center=np.asarray(
+                payload.get("geometric_center") or [0.0, 0.0, 0.0],
+                dtype=float,
+            ),
+            reference_element=str(payload.get("reference_element") or ""),
+            reference_element_geometric_center=np.asarray(
+                payload.get("reference_element_geometric_center")
+                or [0.0, 0.0, 0.0],
+                dtype=float,
+            ),
+            reference_element_offset_from_geometric_center=float(
+                payload.get("reference_element_offset_from_geometric_center")
+                or 0.0
+            ),
+            active_center=np.asarray(
+                payload.get("active_center") or [0.0, 0.0, 0.0],
+                dtype=float,
+            ),
+            center_mode=str(payload.get("center_mode") or "center_of_mass"),
+            nearest_atom_index=int(payload.get("nearest_atom_index") or 0),
+            nearest_atom_distance=float(
+                payload.get("nearest_atom_distance") or 0.0
+            ),
+            bonds=tuple(
+                (int(bond[0]), int(bond[1]))
+                for bond in (payload.get("bonds") or [])
+                if isinstance(bond, (list, tuple)) and len(bond) >= 2
+            ),
+            rmax=float(payload.get("rmax") or 0.0),
+        )
+
+    @staticmethod
+    def _serialize_mesh_geometry(
+        geometry: ElectronDensityMeshGeometry,
+    ) -> dict[str, object]:
+        return {
+            "settings": geometry.settings.to_dict(),
+            "domain_max_radius": float(geometry.domain_max_radius),
+            "radial_edges": np.asarray(
+                geometry.radial_edges, dtype=float
+            ).tolist(),
+            "theta_edges": np.asarray(
+                geometry.theta_edges, dtype=float
+            ).tolist(),
+            "phi_edges": np.asarray(geometry.phi_edges, dtype=float).tolist(),
+        }
+
+    @staticmethod
+    def _deserialize_mesh_geometry(
+        payload: dict[str, object],
+    ) -> ElectronDensityMeshGeometry:
+        settings_payload = dict(payload.get("settings") or {})
+        default_settings = ElectronDensityMeshSettings()
+        return ElectronDensityMeshGeometry(
+            settings=ElectronDensityMeshSettings(
+                rstep=float(
+                    settings_payload.get("rstep_a") or default_settings.rstep
+                ),
+                theta_divisions=int(
+                    settings_payload.get("theta_divisions") or 120
+                ),
+                phi_divisions=int(settings_payload.get("phi_divisions") or 60),
+                rmax=float(settings_payload.get("rmax_a") or 1.0),
+                pin_contiguous_geometric_tracking=bool(
+                    settings_payload.get(
+                        "pin_contiguous_geometric_tracking",
+                        default_settings.pin_contiguous_geometric_tracking,
+                    )
+                ),
+            ),
+            domain_max_radius=float(payload.get("domain_max_radius") or 0.0),
+            radial_edges=np.asarray(
+                payload.get("radial_edges") or [], dtype=float
+            ),
+            theta_edges=np.asarray(
+                payload.get("theta_edges") or [], dtype=float
+            ),
+            phi_edges=np.asarray(payload.get("phi_edges") or [], dtype=float),
+        )
+
+    @staticmethod
+    def _deserialize_mesh_settings(
+        payload: dict[str, object],
+    ) -> ElectronDensityMeshSettings:
+        default_settings = ElectronDensityMeshSettings()
+        return ElectronDensityMeshSettings(
+            rstep=float(payload.get("rstep_a") or default_settings.rstep),
+            theta_divisions=int(payload.get("theta_divisions") or 120),
+            phi_divisions=int(payload.get("phi_divisions") or 60),
+            rmax=float(payload.get("rmax_a") or 1.0),
+            pin_contiguous_geometric_tracking=bool(
+                payload.get(
+                    "pin_contiguous_geometric_tracking",
+                    default_settings.pin_contiguous_geometric_tracking,
+                )
+            ),
+        ).normalized()
+
+    @staticmethod
+    def _deserialize_density_estimate(
+        payload: dict[str, object],
+    ) -> ContrastElectronDensityEstimate:
+        reference_path = payload.get("reference_structure_file")
+        reference_box_spans = payload.get("reference_box_spans")
+        translated_center = payload.get("translated_volume_center")
+        return ContrastElectronDensityEstimate(
+            method=str(payload.get("method") or ""),
+            label=str(payload.get("label") or ""),
+            volume_a3=float(payload.get("volume_a3") or 0.0),
+            total_electrons=float(payload.get("total_electrons") or 0.0),
+            electron_density_e_per_a3=float(
+                payload.get("electron_density_e_per_a3") or 0.0
+            ),
+            electron_density_e_per_cm3=float(
+                payload.get("electron_density_e_per_cm3") or 0.0
+            ),
+            atom_count=(
+                None
+                if payload.get("atom_count") is None
+                else int(payload.get("atom_count"))
+            ),
+            element_counts={
+                str(key): int(value)
+                for key, value in dict(
+                    payload.get("element_counts") or {}
+                ).items()
+            },
+            formula=(
+                None
+                if payload.get("formula") is None
+                else str(payload.get("formula"))
+            ),
+            source_density_g_per_cm3=(
+                None
+                if payload.get("source_density_g_per_cm3") is None
+                else float(payload.get("source_density_g_per_cm3"))
+            ),
+            reference_structure_file=(
+                None
+                if reference_path is None
+                else Path(str(reference_path)).expanduser().resolve()
+            ),
+            reference_box_spans=(
+                None
+                if not isinstance(reference_box_spans, list)
+                else tuple(float(value) for value in reference_box_spans[:3])
+            ),
+            translated_volume_center=(
+                None
+                if not isinstance(translated_center, list)
+                else tuple(float(value) for value in translated_center[:3])
+            ),
+        )
+
+    @staticmethod
+    def _deserialize_debye_waller_pair_term(
+        payload: dict[str, object],
+    ) -> ElectronDensityDebyeWallerPairTerm:
+        return ElectronDensityDebyeWallerPairTerm(
+            scope=str(payload.get("scope") or ""),
+            type_definition=str(payload.get("type_definition") or ""),
+            pair_label_a=str(payload.get("pair_label_a") or ""),
+            pair_label_b=str(payload.get("pair_label_b") or ""),
+            pair_label=str(payload.get("pair_label") or ""),
+            mean_distance_a=float(payload.get("mean_distance_a") or 0.0),
+            sigma_a=float(payload.get("sigma_a") or 0.0),
+            sigma_std_a=float(payload.get("sigma_std_a") or 0.0),
+            sigma_squared_a2=float(payload.get("sigma_squared_a2") or 0.0),
+            sigma_squared_std_a2=float(
+                payload.get("sigma_squared_std_a2") or 0.0
+            ),
+            b_factor_a2=float(payload.get("b_factor_a2") or 0.0),
+            b_factor_std_a2=float(payload.get("b_factor_std_a2") or 0.0),
+        ).normalized()
+
+    @staticmethod
+    def _serialize_profile_result(
+        result: ElectronDensityProfileResult,
+    ) -> dict[str, object]:
+        return {
+            "structure": ElectronDensityMappingMainWindow._serialize_structure(
+                result.structure
+            ),
+            "input_mode": str(result.input_mode),
+            "source_files": [str(path) for path in result.source_files],
+            "source_structure_count": int(result.source_structure_count),
+            "averaging_mode": str(result.averaging_mode),
+            "contiguous_frame_mode_requested": bool(
+                result.contiguous_frame_mode_requested
+            ),
+            "contiguous_frame_mode_applied": bool(
+                result.contiguous_frame_mode_applied
+            ),
+            "pinned_geometric_tracking_requested": bool(
+                result.pinned_geometric_tracking_requested
+            ),
+            "pinned_geometric_tracking_applied": bool(
+                result.pinned_geometric_tracking_applied
+            ),
+            "averaging_notes": [str(note) for note in result.averaging_notes],
+            "contiguous_frame_sets": [
+                frame_set.to_dict()
+                for frame_set in result.contiguous_frame_sets
+            ],
+            "mesh_geometry": ElectronDensityMappingMainWindow._serialize_mesh_geometry(
+                result.mesh_geometry
+            ),
+            "smearing_settings": result.smearing_settings.to_dict(),
+            "radial_centers": np.asarray(
+                result.radial_centers, dtype=float
+            ).tolist(),
+            "orientation_average_density": np.asarray(
+                result.orientation_average_density,
+                dtype=float,
+            ).tolist(),
+            "orientation_density_variance": np.asarray(
+                result.orientation_density_variance,
+                dtype=float,
+            ).tolist(),
+            "orientation_density_stddev": np.asarray(
+                result.orientation_density_stddev,
+                dtype=float,
+            ).tolist(),
+            "smeared_orientation_average_density": np.asarray(
+                result.smeared_orientation_average_density,
+                dtype=float,
+            ).tolist(),
+            "smeared_orientation_density_variance": np.asarray(
+                result.smeared_orientation_density_variance,
+                dtype=float,
+            ).tolist(),
+            "smeared_orientation_density_stddev": np.asarray(
+                result.smeared_orientation_density_stddev,
+                dtype=float,
+            ).tolist(),
+            "shell_volume_average_density": np.asarray(
+                result.shell_volume_average_density,
+                dtype=float,
+            ).tolist(),
+            "shell_electron_counts": np.asarray(
+                result.shell_electron_counts,
+                dtype=float,
+            ).tolist(),
+            "shell_volumes": np.asarray(
+                result.shell_volumes,
+                dtype=float,
+            ).tolist(),
+            "excluded_atom_count": int(result.excluded_atom_count),
+            "excluded_electron_count": float(result.excluded_electron_count),
+            "solvent_contrast": (
+                None
+                if result.solvent_contrast is None
+                else result.solvent_contrast.to_dict()
+            ),
+        }
+
+    @staticmethod
+    def _deserialize_profile_result(
+        payload: dict[str, object],
+    ) -> ElectronDensityProfileResult:
+        smearing_payload = dict(payload.get("smearing_settings") or {})
+        pair_specific_terms = tuple(
+            ElectronDensityMappingMainWindow._deserialize_debye_waller_pair_term(
+                dict(entry)
+            )
+            for entry in (smearing_payload.get("pair_specific_terms") or [])
+            if isinstance(entry, dict)
+        )
+        imported_pair_specific_terms = tuple(
+            ElectronDensityMappingMainWindow._deserialize_debye_waller_pair_term(
+                dict(entry)
+            )
+            for entry in (
+                smearing_payload.get("imported_pair_specific_terms") or []
+            )
+            if isinstance(entry, dict)
+        )
+        solvent_payload = payload.get("solvent_contrast")
+        solvent_contrast = None
+        if isinstance(solvent_payload, dict):
+            settings_payload = dict(solvent_payload.get("settings") or {})
+            solvent_contrast = ElectronDensitySolventContrastResult(
+                settings=ContrastSolventDensitySettings.from_values(
+                    method=settings_payload.get("method"),
+                    solvent_formula=settings_payload.get("solvent_formula"),
+                    solvent_density_g_per_ml=settings_payload.get(
+                        "solvent_density_g_per_ml"
+                    ),
+                    reference_structure_file=settings_payload.get(
+                        "reference_structure_file"
+                    ),
+                    direct_electron_density_e_per_a3=settings_payload.get(
+                        "direct_electron_density_e_per_a3"
+                    ),
+                ),
+                solvent_name=str(solvent_payload.get("solvent_name") or ""),
+                density_estimate=ElectronDensityMappingMainWindow._deserialize_density_estimate(
+                    dict(solvent_payload.get("density_estimate") or {})
+                ),
+                solvent_density_e_per_a3=float(
+                    solvent_payload.get("solvent_density_e_per_a3") or 0.0
+                ),
+                cutoff_radius_a=(
+                    None
+                    if solvent_payload.get("cutoff_radius_a") is None
+                    else float(solvent_payload.get("cutoff_radius_a"))
+                ),
+                solvent_subtracted_smeared_density=np.asarray(
+                    solvent_payload.get(
+                        "solvent_subtracted_smeared_density_e_per_a3"
+                    )
+                    or [],
+                    dtype=float,
+                ),
+            )
+        orientation_average_density = np.asarray(
+            payload.get("orientation_average_density") or [],
+            dtype=float,
+        )
+        contiguous_frame_sets = tuple(
+            ElectronDensityContiguousFrameSetSummary(
+                series_label=str(entry.get("series_label") or "default"),
+                frame_ids=tuple(
+                    int(value) for value in (entry.get("frame_ids") or [])
+                ),
+                frame_labels=tuple(
+                    str(value) for value in (entry.get("frame_labels") or [])
+                ),
+                file_paths=tuple(
+                    Path(str(value)).expanduser().resolve()
+                    for value in (entry.get("file_paths") or [])
+                ),
+            )
+            for entry in (payload.get("contiguous_frame_sets") or [])
+            if isinstance(entry, dict)
+        )
+        return ElectronDensityProfileResult(
+            structure=ElectronDensityMappingMainWindow._deserialize_structure(
+                dict(payload.get("structure") or {})
+            ),
+            input_mode=str(payload.get("input_mode") or "folder"),
+            source_files=tuple(
+                Path(str(value)).expanduser().resolve()
+                for value in (payload.get("source_files") or [])
+            ),
+            source_structure_count=int(
+                payload.get("source_structure_count") or 0
+            ),
+            member_summaries=tuple(),
+            member_orientation_average_densities=(
+                np.asarray(orientation_average_density, dtype=float).copy(),
+            ),
+            mesh_geometry=ElectronDensityMappingMainWindow._deserialize_mesh_geometry(
+                dict(payload.get("mesh_geometry") or {})
+            ),
+            smearing_settings=ElectronDensitySmearingSettings(
+                debye_waller_factor=float(
+                    smearing_payload.get("debye_waller_factor_a2") or 0.0
+                ),
+                debye_waller_mode=str(
+                    smearing_payload.get("debye_waller_mode") or "universal"
+                ),
+                pair_specific_terms=pair_specific_terms,
+                imported_pair_specific_terms=imported_pair_specific_terms,
+            ).normalized(),
+            radial_centers=np.asarray(
+                payload.get("radial_centers") or [],
+                dtype=float,
+            ),
+            orientation_average_density=orientation_average_density,
+            orientation_density_variance=np.asarray(
+                payload.get("orientation_density_variance") or [],
+                dtype=float,
+            ),
+            orientation_density_stddev=np.asarray(
+                payload.get("orientation_density_stddev") or [],
+                dtype=float,
+            ),
+            smeared_orientation_average_density=np.asarray(
+                payload.get("smeared_orientation_average_density") or [],
+                dtype=float,
+            ),
+            smeared_orientation_density_variance=np.asarray(
+                payload.get("smeared_orientation_density_variance") or [],
+                dtype=float,
+            ),
+            smeared_orientation_density_stddev=np.asarray(
+                payload.get("smeared_orientation_density_stddev") or [],
+                dtype=float,
+            ),
+            shell_volume_average_density=np.asarray(
+                payload.get("shell_volume_average_density") or [],
+                dtype=float,
+            ),
+            shell_electron_counts=np.asarray(
+                payload.get("shell_electron_counts") or [],
+                dtype=float,
+            ),
+            shell_volumes=np.asarray(
+                payload.get("shell_volumes") or [],
+                dtype=float,
+            ),
+            excluded_atom_count=int(payload.get("excluded_atom_count") or 0),
+            excluded_electron_count=float(
+                payload.get("excluded_electron_count") or 0.0
+            ),
+            averaging_mode=str(
+                payload.get("averaging_mode") or "complete_average"
+            ),
+            contiguous_frame_mode_requested=bool(
+                payload.get("contiguous_frame_mode_requested", False)
+            ),
+            contiguous_frame_mode_applied=bool(
+                payload.get("contiguous_frame_mode_applied", False)
+            ),
+            pinned_geometric_tracking_requested=bool(
+                payload.get("pinned_geometric_tracking_requested", False)
+            ),
+            pinned_geometric_tracking_applied=bool(
+                payload.get("pinned_geometric_tracking_applied", False)
+            ),
+            averaging_notes=tuple(
+                str(note) for note in (payload.get("averaging_notes") or [])
+            ),
+            contiguous_frame_sets=contiguous_frame_sets,
+            solvent_contrast=solvent_contrast,
+        )
+
+    @staticmethod
+    def _serialize_transform_result(
+        result: ElectronDensityScatteringTransformResult,
+    ) -> dict[str, object]:
+        return {
+            "settings": result.preview.settings.to_dict(),
+            "q_values": np.asarray(result.q_values, dtype=float).tolist(),
+            "scattering_amplitude": np.asarray(
+                result.scattering_amplitude,
+                dtype=float,
+            ).tolist(),
+            "intensity": np.asarray(result.intensity, dtype=float).tolist(),
+        }
+
+    @staticmethod
+    def _deserialize_transform_result(
+        payload: dict[str, object],
+        profile_result: ElectronDensityProfileResult | None,
+        *,
+        single_atom_only: bool = False,
+    ) -> ElectronDensityScatteringTransformResult | None:
+        settings_payload = dict(payload.get("settings") or {})
+        domain_mode = settings_payload.get("domain_mode")
+        inferred_domain_mode = (
+            "legacy" if domain_mode is None else str(domain_mode)
+        )
+        settings = ElectronDensityFourierTransformSettings(
+            r_min=float(settings_payload.get("r_min_a") or 0.0),
+            r_max=float(settings_payload.get("r_max_a") or 1.0),
+            domain_mode=inferred_domain_mode,
+            window_function=str(
+                settings_payload.get("window_function") or "none"
+            ),
+            resampling_points=int(
+                settings_payload.get("resampling_points") or 2048
+            ),
+            q_min=float(settings_payload.get("q_min_a_inverse") or 0.02),
+            q_max=float(settings_payload.get("q_max_a_inverse") or 1.2),
+            q_step=float(settings_payload.get("q_step_a_inverse") or 0.01),
+            use_solvent_subtracted_profile=bool(
+                settings_payload.get("use_solvent_subtracted_profile", True)
+            ),
+            log_q_axis=bool(settings_payload.get("log_q_axis", True)),
+            log_intensity_axis=bool(
+                settings_payload.get("log_intensity_axis", True)
+            ),
+        )
+        if single_atom_only:
+            preview = prepare_single_atom_debye_scattering_preview(settings)
+        else:
+            if profile_result is None:
+                return None
+            try:
+                preview = prepare_electron_density_fourier_transform(
+                    profile_result,
+                    settings,
+                )
+            except Exception:
+                return None
+        return ElectronDensityScatteringTransformResult(
+            preview=preview,
+            q_values=np.asarray(payload.get("q_values") or [], dtype=float),
+            scattering_amplitude=np.asarray(
+                payload.get("scattering_amplitude") or [],
+                dtype=float,
+            ),
+            intensity=np.asarray(payload.get("intensity") or [], dtype=float),
+        )
+
+    @staticmethod
+    def _serialize_debye_scattering_result(
+        result: ElectronDensityDebyeScatteringAverageResult,
+    ) -> dict[str, object]:
+        return {
+            "q_values": np.asarray(result.q_values, dtype=float).tolist(),
+            "mean_intensity": np.asarray(
+                result.mean_intensity,
+                dtype=float,
+            ).tolist(),
+            "std_intensity": np.asarray(
+                result.std_intensity,
+                dtype=float,
+            ).tolist(),
+            "se_intensity": np.asarray(
+                result.se_intensity,
+                dtype=float,
+            ).tolist(),
+            "source_files": [str(path) for path in result.source_files],
+            "source_structure_count": int(result.source_structure_count),
+            "unique_elements": [
+                str(value) for value in result.unique_elements
+            ],
+            "notes": [str(note) for note in result.notes],
+        }
+
+    @staticmethod
+    def _deserialize_debye_scattering_result(
+        payload: dict[str, object],
+    ) -> ElectronDensityDebyeScatteringAverageResult:
+        return ElectronDensityDebyeScatteringAverageResult(
+            q_values=np.asarray(payload.get("q_values") or [], dtype=float),
+            mean_intensity=np.asarray(
+                payload.get("mean_intensity") or [],
+                dtype=float,
+            ),
+            std_intensity=np.asarray(
+                payload.get("std_intensity") or [],
+                dtype=float,
+            ),
+            se_intensity=np.asarray(
+                payload.get("se_intensity") or [],
+                dtype=float,
+            ),
+            source_files=tuple(
+                Path(str(value)).expanduser().resolve()
+                for value in (payload.get("source_files") or [])
+            ),
+            source_structure_count=int(
+                payload.get("source_structure_count") or 0
+            ),
+            unique_elements=tuple(
+                str(value) for value in (payload.get("unique_elements") or [])
+            ),
+            notes=tuple(str(value) for value in (payload.get("notes") or [])),
+        )
+
+    @staticmethod
+    def _deserialize_fourier_settings(
+        payload: dict[str, object],
+    ) -> ElectronDensityFourierTransformSettings:
+        domain_mode = payload.get("domain_mode")
+        return ElectronDensityFourierTransformSettings(
+            r_min=float(payload.get("r_min_a") or 0.0),
+            r_max=float(payload.get("r_max_a") or 1.0),
+            domain_mode=(
+                "legacy" if domain_mode is None else str(domain_mode)
+            ),
+            window_function=str(payload.get("window_function") or "none"),
+            resampling_points=int(payload.get("resampling_points") or 2048),
+            q_min=float(payload.get("q_min_a_inverse") or 0.02),
+            q_max=float(payload.get("q_max_a_inverse") or 1.2),
+            q_step=float(payload.get("q_step_a_inverse") or 0.01),
+            use_solvent_subtracted_profile=bool(
+                payload.get("use_solvent_subtracted_profile", True)
+            ),
+            log_q_axis=bool(payload.get("log_q_axis", True)),
+            log_intensity_axis=bool(payload.get("log_intensity_axis", True)),
+        ).normalized()
+
+    @staticmethod
+    def _serialize_saved_output_entry(
+        entry: _SavedOutputEntry,
+    ) -> dict[str, object]:
+        return {
+            "entry_id": entry.entry_id,
+            "created_at": entry.created_at,
+            "entry_kind": entry.entry_kind,
+            "input_path": (
+                None if entry.input_path is None else str(entry.input_path)
+            ),
+            "output_basename": entry.output_basename,
+            "preview_mode": bool(entry.preview_mode),
+            "group_key": entry.group_key,
+            "group_label": entry.group_label,
+            "use_contiguous_frame_mode": bool(entry.use_contiguous_frame_mode),
+            "profile_result": ElectronDensityMappingMainWindow._serialize_profile_result(
+                entry.profile_result
+            ),
+            "fourier_settings": entry.fourier_settings.to_dict(),
+            "transform_result": (
+                None
+                if entry.transform_result is None
+                else ElectronDensityMappingMainWindow._serialize_transform_result(
+                    entry.transform_result
+                )
+            ),
+        }
+
+    @staticmethod
+    def _deserialize_saved_output_entry(
+        payload: dict[str, object],
+    ) -> _SavedOutputEntry | None:
+        profile_payload = payload.get("profile_result")
+        if not isinstance(profile_payload, dict):
+            return None
+        profile_result = (
+            ElectronDensityMappingMainWindow._deserialize_profile_result(
+                profile_payload
+            )
+        )
+        fourier_settings = (
+            ElectronDensityMappingMainWindow._deserialize_fourier_settings(
+                dict(payload.get("fourier_settings") or {})
+            )
+        )
+        transform_payload = payload.get("transform_result")
+        transform_result = None
+        if isinstance(transform_payload, dict):
+            transform_result = (
+                ElectronDensityMappingMainWindow._deserialize_transform_result(
+                    transform_payload,
+                    profile_result,
+                    single_atom_only=False,
+                )
+            )
+        input_path = payload.get("input_path")
+        return _SavedOutputEntry(
+            entry_id=str(payload.get("entry_id") or ""),
+            created_at=str(payload.get("created_at") or ""),
+            entry_kind=str(payload.get("entry_kind") or "density"),
+            input_path=(
+                None
+                if input_path is None or not str(input_path).strip()
+                else Path(str(input_path)).expanduser().resolve()
+            ),
+            output_basename=str(payload.get("output_basename") or ""),
+            preview_mode=bool(payload.get("preview_mode", True)),
+            group_key=(
+                None
+                if payload.get("group_key") is None
+                else str(payload.get("group_key"))
+            ),
+            group_label=(
+                None
+                if payload.get("group_label") is None
+                else str(payload.get("group_label"))
+            ),
+            use_contiguous_frame_mode=bool(
+                payload.get("use_contiguous_frame_mode", True)
+            ),
+            profile_result=profile_result,
+            fourier_settings=fourier_settings,
+            transform_result=transform_result,
+        )
+
+    def _current_input_path(self) -> Path | None:
+        text = self.input_path_edit.text().strip()
+        if not text:
+            return None
+        try:
+            return Path(text).expanduser().resolve()
+        except Exception:
+            return None
+
+    def _preview_saved_output_history_path(self) -> Path | None:
+        output_dir_text = self.output_dir_edit.text().strip()
+        if not output_dir_text:
+            return None
+        try:
+            output_dir = Path(output_dir_text).expanduser().resolve()
+        except Exception:
+            return None
+        return output_dir / "electron_density_saved_output_history.json"
+
+    def _distribution_saved_output_history_path(self) -> Path | None:
+        if self._distribution_root_dir is None:
+            return None
+        return (
+            self._distribution_root_dir
+            / "electron_density_mapping"
+            / "saved_output_history.json"
+        )
+
+    def _saved_output_history_write_path(self) -> Path | None:
+        if not self._preview_mode:
+            history_path = self._distribution_saved_output_history_path()
+            if history_path is not None:
+                return history_path
+        return self._preview_saved_output_history_path()
+
+    def _saved_output_history_restore_candidates(self) -> list[Path]:
+        candidates: list[Path] = []
+        distribution_history = self._distribution_saved_output_history_path()
+        preview_history = self._preview_saved_output_history_path()
+        if not self._preview_mode and distribution_history is not None:
+            candidates.append(distribution_history)
+        if preview_history is not None and preview_history not in candidates:
+            candidates.append(preview_history)
+        return candidates
+
+    def _write_saved_output_history(self) -> None:
+        history_path = self._saved_output_history_write_path()
+        current_input_path = self._current_input_path()
+        if history_path is None or current_input_path is None:
+            self._update_output_history_summary()
+            return
+        payload = {
+            "schema_version": 1,
+            "generated_at": datetime.now().isoformat(timespec="seconds"),
+            "preview_mode": self._preview_mode,
+            "distribution_id": self._distribution_id,
+            "input_path": str(current_input_path),
+            "entries": [
+                self._serialize_saved_output_entry(entry)
+                for entry in self._saved_output_entries
+            ],
+        }
+        try:
+            history_path.parent.mkdir(parents=True, exist_ok=True)
+            history_path.write_text(
+                json.dumps(payload, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        except Exception as exc:
+            self._append_status(
+                f"Could not write saved output history to {history_path}: {exc}"
+            )
+        self._update_output_history_summary()
+
+    def _restore_saved_output_history_if_available(self) -> None:
+        current_input_path = self._current_input_path()
+        if current_input_path is None:
+            return
+        for history_path in self._saved_output_history_restore_candidates():
+            if not history_path.is_file():
+                continue
+            try:
+                payload = json.loads(history_path.read_text(encoding="utf-8"))
+            except Exception as exc:
+                self._append_status(
+                    f"Could not read saved output history from {history_path}: {exc}"
+                )
+                continue
+            saved_input_path = str(payload.get("input_path") or "").strip()
+            if saved_input_path:
+                try:
+                    resolved_saved_input = (
+                        Path(saved_input_path).expanduser().resolve()
+                    )
+                except Exception:
+                    resolved_saved_input = None
+                if (
+                    resolved_saved_input is not None
+                    and resolved_saved_input != current_input_path
+                ):
+                    continue
+            entries = [
+                entry
+                for entry in (
+                    self._deserialize_saved_output_entry(dict(entry_payload))
+                    for entry_payload in (payload.get("entries") or [])
+                    if isinstance(entry_payload, dict)
+                )
+                if entry is not None
+            ]
+            if not entries:
+                continue
+            self._restoring_saved_output_history = True
+            try:
+                self._saved_output_entries = entries
+                self._populate_output_history_table()
+            finally:
+                self._restoring_saved_output_history = False
+            self._append_status(
+                f"Restored {len(entries)} saved output set"
+                f"{'' if len(entries) == 1 else 's'} from {history_path}."
+            )
+            return
+
+    @staticmethod
+    def _preview_for_saved_output_entry(
+        entry: _SavedOutputEntry,
+    ) -> ElectronDensityFourierTransformPreview | None:
+        if entry.transform_result is not None:
+            return entry.transform_result.preview
+        try:
+            return prepare_electron_density_fourier_transform(
+                entry.profile_result,
+                entry.fourier_settings,
+            )
+        except Exception:
+            return None
+
+    @staticmethod
+    def _constrain_fourier_settings_for_result(
+        result: ElectronDensityProfileResult,
+        settings: ElectronDensityFourierTransformSettings,
+        *,
+        prefer_solvent_cutoff: bool = False,
+    ) -> ElectronDensityFourierTransformSettings:
+        normalized = settings.normalized()
+        radial_values = np.asarray(result.radial_centers, dtype=float)
+        if radial_values.size < 1:
+            return normalized
+        domain_min = 0.0
+        domain_max = float(radial_values[-1])
+        if domain_max <= domain_min:
+            return normalized
+        if normalized.domain_mode == "mirrored":
+            minimum_radius = max(min(domain_max, 1.0e-3), 1.0e-6)
+            constrained_r_max = float(
+                np.clip(
+                    float(normalized.r_max),
+                    minimum_radius,
+                    domain_max,
+                )
+            )
+            if (
+                prefer_solvent_cutoff
+                and result.solvent_contrast is not None
+                and result.solvent_contrast.cutoff_radius_a is not None
+            ):
+                constrained_r_max = float(
+                    np.clip(
+                        float(result.solvent_contrast.cutoff_radius_a),
+                        minimum_radius,
+                        domain_max,
+                    )
+                )
+            constrained_r_min = -constrained_r_max
+        else:
+            minimum_span = max(min(domain_max - domain_min, 1.0e-3), 1.0e-6)
+            constrained_r_min = float(
+                np.clip(
+                    float(normalized.r_min),
+                    domain_min,
+                    max(domain_max - minimum_span, domain_min),
+                )
+            )
+            constrained_r_max = float(
+                np.clip(
+                    float(normalized.r_max),
+                    constrained_r_min + minimum_span,
+                    domain_max,
+                )
+            )
+            if (
+                prefer_solvent_cutoff
+                and result.solvent_contrast is not None
+                and result.solvent_contrast.cutoff_radius_a is not None
+            ):
+                constrained_r_max = float(
+                    np.clip(
+                        float(result.solvent_contrast.cutoff_radius_a),
+                        constrained_r_min + minimum_span,
+                        domain_max,
+                    )
+                )
+        return ElectronDensityFourierTransformSettings(
+            r_min=constrained_r_min,
+            r_max=constrained_r_max,
+            domain_mode=normalized.domain_mode,
+            window_function=normalized.window_function,
+            resampling_points=normalized.resampling_points,
+            q_min=normalized.q_min,
+            q_max=normalized.q_max,
+            q_step=normalized.q_step,
+            use_solvent_subtracted_profile=(
+                normalized.use_solvent_subtracted_profile
+            ),
+            log_q_axis=normalized.log_q_axis,
+            log_intensity_axis=normalized.log_intensity_axis,
+        ).normalized()
+
+    def _capture_saved_output_entry(
+        self,
+        entry_kind: str,
+        *,
+        group_state: _ClusterDensityGroupState | None = None,
+        profile_result: ElectronDensityProfileResult | None = None,
+        transform_result: (
+            ElectronDensityScatteringTransformResult | None
+        ) = None,
+    ) -> None:
+        if self._restoring_saved_output_history:
+            return
+        result = profile_result
+        if result is None and group_state is not None:
+            result = group_state.profile_result
+        if result is None:
+            result = self._profile_result
+        if result is None:
+            return
+        current_transform = transform_result
+        if current_transform is None and group_state is not None:
+            current_transform = group_state.transform_result
+        elif current_transform is None:
+            current_transform = self._fourier_result
+        if current_transform is not None:
+            fourier_settings = current_transform.preview.settings
+        else:
+            if group_state is not None:
+                fourier_settings = self._cluster_state_fourier_settings(
+                    group_state
+                )
+            else:
+                try:
+                    fourier_settings = self._fourier_settings_from_controls()
+                except Exception:
+                    fourier_settings = self._active_fourier_settings
+                fourier_settings = self._constrain_fourier_settings_for_result(
+                    result,
+                    fourier_settings,
+                )
+        snapshot = _SavedOutputEntry(
+            entry_id=datetime.now().strftime("%Y%m%dT%H%M%S%f"),
+            created_at=datetime.now().isoformat(timespec="seconds"),
+            entry_kind=str(entry_kind).strip() or "density",
+            input_path=self._current_input_path(),
+            output_basename=self._output_basename(),
+            preview_mode=self._preview_mode,
+            group_key=None if group_state is None else group_state.key,
+            group_label=(
+                None if group_state is None else group_state.display_name
+            ),
+            use_contiguous_frame_mode=self._use_contiguous_frame_mode(),
+            profile_result=result,
+            fourier_settings=fourier_settings,
+            transform_result=current_transform,
+        )
+        self._saved_output_entries.append(snapshot)
+        self._populate_output_history_table()
+        self._write_saved_output_history()
+        self._sync_workspace_state()
+
+    def _restore_contrast_controls_from_result(
+        self,
+        result: ElectronDensityProfileResult,
+    ) -> None:
+        contrast = result.solvent_contrast
+        if contrast is None:
+            self._active_contrast_settings = None
+            self._active_contrast_name = None
+            self._refresh_contrast_display()
+            return
+        settings = contrast.settings
+        self.solvent_method_combo.blockSignals(True)
+        try:
+            method_index = max(
+                self.solvent_method_combo.findData(settings.method),
+                0,
+            )
+            self.solvent_method_combo.setCurrentIndex(method_index)
+        finally:
+            self.solvent_method_combo.blockSignals(False)
+        self._sync_density_method_controls()
+        self.solvent_preset_combo.blockSignals(True)
+        try:
+            if settings.method == CONTRAST_SOLVENT_METHOD_NEAT:
+                preset_index = max(
+                    self.solvent_preset_combo.findData(contrast.solvent_name),
+                    0,
+                )
+                self.solvent_preset_combo.setCurrentIndex(preset_index)
+            else:
+                self.solvent_preset_combo.setCurrentIndex(0)
+        finally:
+            self.solvent_preset_combo.blockSignals(False)
+        self.solvent_formula_edit.setText(settings.solvent_formula or "")
+        self.solvent_density_spin.setValue(
+            float(settings.solvent_density_g_per_ml or 0.0)
+        )
+        self.reference_solvent_file_edit.setText(
+            ""
+            if settings.reference_structure_file is None
+            else str(settings.reference_structure_file)
+        )
+        self.direct_density_spin.setValue(
+            float(settings.direct_electron_density_e_per_a3 or 0.0)
+        )
+        self._active_contrast_settings = settings
+        self._active_contrast_name = (
+            contrast.solvent_name or contrast.legend_label
+        )
+        self._refresh_contrast_display()
+
+    def _restore_saved_output_entry(
+        self,
+        entry: _SavedOutputEntry,
+        *,
+        announce: bool,
+    ) -> bool:
+        target_state = None
+        row_index = -1
+        if entry.group_key is not None and self._cluster_group_states:
+            for index, state in enumerate(self._cluster_group_states):
+                if state.key == entry.group_key:
+                    target_state = state
+                    row_index = index
+                    break
+            if target_state is None:
+                self._show_error(
+                    "Saved Output Unavailable",
+                    "This saved output references a stoichiometry that is not "
+                    "available in the current input.",
+                )
+                return False
+
+        self._restoring_saved_output_history = True
+        try:
+            if target_state is not None:
+                target_state.profile_result = entry.profile_result
+                target_state.transform_result = entry.transform_result
+                target_state.debye_scattering_result = None
+                self._sync_cluster_state_solvent_metadata(target_state)
+                self._populate_cluster_group_table()
+                if row_index >= 0:
+                    self.cluster_group_table.blockSignals(True)
+                    try:
+                        self.cluster_group_table.selectRow(row_index)
+                    finally:
+                        self.cluster_group_table.blockSignals(False)
+                self._set_active_cluster_group(target_state.key)
+            else:
+                self._profile_result = entry.profile_result
+                self._fourier_result = entry.transform_result
+                self._debye_scattering_result = None
+                self._structure = entry.profile_result.structure
+                self._active_mesh_settings = (
+                    entry.profile_result.mesh_geometry.settings
+                )
+                self._active_mesh_geometry = entry.profile_result.mesh_geometry
+                self.reference_file_value.setText(
+                    str(self._structure.file_path)
+                )
+                self._sync_reference_element_controls()
+                self._refresh_center_display()
+                self._refresh_structure_summary()
+                self._refresh_active_mesh_display()
+                self._refresh_mesh_notice()
+                self.structure_viewer.set_structure(
+                    self._structure,
+                    mesh_geometry=self._active_mesh_geometry,
+                    reset_view=True,
+                )
+
+            self.contiguous_frame_mode_checkbox.setChecked(
+                bool(entry.use_contiguous_frame_mode)
+            )
+
+            self.smearing_factor_spin.blockSignals(True)
+            try:
+                self.smearing_factor_spin.setValue(
+                    float(
+                        entry.profile_result.smearing_settings.debye_waller_factor
+                    )
+                )
+            finally:
+                self.smearing_factor_spin.blockSignals(False)
+            self._active_smearing_settings = (
+                entry.profile_result.smearing_settings
+            )
+            self._refresh_smearing_display()
+
+            mesh_settings = entry.profile_result.mesh_geometry.settings
+            for widget, value in (
+                (self.rstep_spin, float(mesh_settings.rstep)),
+                (
+                    self.theta_divisions_spin,
+                    int(mesh_settings.theta_divisions),
+                ),
+                (self.phi_divisions_spin, int(mesh_settings.phi_divisions)),
+                (self.rmax_spin, float(mesh_settings.rmax)),
+            ):
+                widget.blockSignals(True)
+                try:
+                    widget.setValue(value)
+                finally:
+                    widget.blockSignals(False)
+            self._active_mesh_settings = mesh_settings
+            self._active_mesh_geometry = entry.profile_result.mesh_geometry
+            self._sync_pinned_geometric_tracking_control_to_settings(
+                mesh_settings
+            )
+            self._refresh_active_mesh_display()
+            self._refresh_mesh_notice()
+            self._set_mesh_settings_confirmed_for_run(True)
+
+            self._restore_contrast_controls_from_result(entry.profile_result)
+
+            self._profile_result = entry.profile_result
+            self._fourier_result = entry.transform_result
+            self._sync_fourier_controls_to_domain(reset_bounds=False)
+            self._sync_fourier_controls_to_settings(entry.fourier_settings)
+            self._refresh_profile_plots()
+            self._refresh_contrast_display()
+            self._refresh_fourier_preview_from_controls(
+                clear_transform=entry.transform_result is None
+            )
+            if entry.transform_result is not None:
+                self._fourier_result = entry.transform_result
+            self._refresh_scattering_plot()
+            self._update_push_to_model_state()
+            self._close_debye_scattering_compare_dialog()
+            self._refresh_debye_scattering_group()
+        finally:
+            self._restoring_saved_output_history = False
+
+        if announce:
+            self._append_status(
+                "Loaded saved output: "
+                + self._saved_output_entry_heading(entry)
+                + "."
+            )
+            self.statusBar().showMessage("Loaded saved output")
+        return True
+
+    @Slot()
+    def _load_selected_output_history_entry(self) -> None:
+        selected_entries = self._selected_output_history_entries()
+        if len(selected_entries) != 1:
+            self._show_error(
+                "Select One Saved Output",
+                "Select exactly one saved output row to load it into the main pane.",
+            )
+            return
+        self._restore_saved_output_entry(selected_entries[0], announce=True)
+
+    @Slot()
+    def _compare_selected_output_history_entries(self) -> None:
+        selected_entries = self._selected_output_history_entries()
+        if not selected_entries:
+            self._show_error(
+                "No Saved Outputs Selected",
+                "Select one or more saved output rows before opening the comparison window.",
+            )
+            return
+        if self._output_history_compare_dialog is not None:
+            self._output_history_compare_dialog.close()
+        dialog = _SavedOutputComparisonDialog(
+            selected_entries,
+            show_variance_shading=self.show_variance_checkbox.isChecked(),
+            parent=self,
+        )
+        dialog.finished.connect(
+            lambda _result: setattr(
+                self,
+                "_output_history_compare_dialog",
+                None,
+            )
+        )
+        self._output_history_compare_dialog = dialog
+        dialog.show()
+        dialog.raise_()
+        dialog.activateWindow()
+
+    def _close_debye_scattering_compare_dialog(self) -> None:
+        dialog = self._debye_scattering_compare_dialog
+        if dialog is None:
+            return
+        self._debye_scattering_compare_dialog = None
+        dialog.close()
+
+    @staticmethod
+    def _debye_result_matches_transform(
+        transform_result: ElectronDensityScatteringTransformResult | None,
+        debye_result: ElectronDensityDebyeScatteringAverageResult | None,
+    ) -> bool:
+        if transform_result is None or debye_result is None:
+            return False
+        born_q = np.asarray(transform_result.q_values, dtype=float)
+        debye_q = np.asarray(debye_result.q_values, dtype=float)
+        return bool(
+            born_q.shape == debye_q.shape
+            and born_q.size > 0
+            and np.allclose(
+                born_q,
+                debye_q,
+                rtol=1.0e-9,
+                atol=1.0e-12,
+            )
+        )
+
+    @staticmethod
+    def _is_density_fourier_transform(
+        transform_result: ElectronDensityScatteringTransformResult | None,
+    ) -> bool:
+        return bool(
+            transform_result is not None
+            and transform_result.preview.source_mode == "density_fourier"
+        )
+
+    @staticmethod
+    def _debye_comparison_info_text(
+        label: str,
+        born_result: ElectronDensityScatteringTransformResult,
+        debye_result: ElectronDensityDebyeScatteringAverageResult,
+    ) -> str:
+        q_values = np.asarray(born_result.q_values, dtype=float)
+        q_text = "q grid unavailable"
+        if q_values.size > 0:
+            q_text = (
+                f"q={float(q_values[0]):.4f}"
+                f"–{float(q_values[-1]):.4f} Å⁻¹ "
+                f"({len(q_values)} points)"
+            )
+        notes = " ".join(
+            str(note).strip()
+            for note in debye_result.notes
+            if str(note).strip()
+        )
+        base = (
+            f"{label}: {debye_result.source_structure_count} structure"
+            f"{'' if debye_result.source_structure_count == 1 else 's'}; "
+            f"{q_text}."
+        )
+        return base if not notes else base + " " + notes
+
+    def _debye_comparison_entries(self) -> list[_DebyeComparisonEntry]:
+        if self._cluster_group_states:
+            entries: list[_DebyeComparisonEntry] = []
+            for state in self._cluster_group_states:
+                born_result = state.transform_result
+                debye_result = state.debye_scattering_result
+                if (
+                    state.single_atom_only
+                    or not self._is_density_fourier_transform(born_result)
+                    or not self._debye_result_matches_transform(
+                        born_result,
+                        debye_result,
+                    )
+                ):
+                    continue
+                entries.append(
+                    _DebyeComparisonEntry(
+                        entry_id=state.key,
+                        label=state.display_name,
+                        color=state.trace_color,
+                        born_result=born_result,
+                        debye_result=debye_result,
+                        info_text=self._debye_comparison_info_text(
+                            state.display_name,
+                            born_result,
+                            debye_result,
+                        ),
+                    )
+                )
+            return entries
+
+        born_result = self._fourier_result
+        debye_result = self._debye_scattering_result
+        if not self._debye_result_matches_transform(born_result, debye_result):
+            return []
+        if not self._is_density_fourier_transform(born_result):
+            return []
+        current_input = self._current_input_path()
+        label = (
+            current_input.name
+            if current_input is not None
+            else self._output_basename()
+        )
+        return [
+            _DebyeComparisonEntry(
+                entry_id="active",
+                label=label,
+                color="#b45309",
+                born_result=born_result,
+                debye_result=debye_result,
+                info_text=self._debye_comparison_info_text(
+                    label,
+                    born_result,
+                    debye_result,
+                ),
+            )
+        ]
+
+    def _refresh_debye_scattering_group(self) -> None:
+        if not hasattr(self, "debye_scattering_status_label"):
+            return
+        running = self._is_calculation_running()
+        has_clusters = bool(self._cluster_group_states)
+        self.apply_debye_to_all_button.setVisible(has_clusters)
+        self.apply_debye_to_all_button.setEnabled(has_clusters and not running)
+
+        comparison_entries = self._debye_comparison_entries()
+        self.open_debye_scattering_compare_button.setEnabled(
+            (not running) and bool(comparison_entries)
+        )
+
+        if has_clusters:
+            (
+                target_states,
+                scope_label,
+                _selected_keys,
+            ) = self._batch_target_cluster_group_states(
+                apply_to_all=bool(self.apply_debye_to_all_button.isChecked())
+            )
+            eligible_states = [
+                state
+                for state in target_states
+                if (
+                    not state.single_atom_only
+                    and self._is_density_fourier_transform(
+                        state.transform_result
+                    )
+                )
+            ]
+            ready_count = sum(
+                1
+                for state in eligible_states
+                if self._debye_result_matches_transform(
+                    state.transform_result,
+                    state.debye_scattering_result,
+                )
+            )
+            stale_count = sum(
+                1
+                for state in eligible_states
+                if (
+                    state.debye_scattering_result is not None
+                    and not self._debye_result_matches_transform(
+                        state.transform_result,
+                        state.debye_scattering_result,
+                    )
+                )
+            )
+            skipped_single_atom = sum(
+                1 for state in target_states if state.single_atom_only
+            )
+            skipped_pending = max(
+                len(target_states)
+                - len(eligible_states)
+                - skipped_single_atom,
+                0,
+            )
+            self.calculate_debye_scattering_button.setEnabled(
+                (not running) and bool(eligible_states)
+            )
+            if not target_states:
+                self.debye_scattering_status_label.setText(
+                    "Select a stoichiometry row with a Born-approximation "
+                    "Fourier trace to compute a matching Debye average."
+                )
+                return
+            if eligible_states:
+                message = (
+                    f"{ready_count}/{len(eligible_states)} target row"
+                    f"{'' if len(eligible_states) == 1 else 's'} across "
+                    f"{scope_label} already have Debye averages on their "
+                    "Born q-grid."
+                )
+                if stale_count > 0:
+                    message += (
+                        f" {stale_count} row"
+                        f"{'' if stale_count == 1 else 's'} need recalculation "
+                        "because the Born q-grid changed."
+                    )
+                if comparison_entries:
+                    message += (
+                        f" {len(comparison_entries)} comparison pair"
+                        f"{'' if len(comparison_entries) == 1 else 's'} are "
+                        "ready for overlay."
+                    )
+                else:
+                    message += " Compute a Debye average to unlock the comparison plot."
+                self.debye_scattering_status_label.setText(message)
+                return
+            if skipped_single_atom > 0 and skipped_pending == 0:
+                self.debye_scattering_status_label.setText(
+                    "The current target rows already use direct Debye "
+                    "scattering only, so a separate Born-vs-Debye "
+                    "comparison trace is not needed."
+                )
+                return
+            self.debye_scattering_status_label.setText(
+                "Evaluate the Born-approximation Fourier transform for the "
+                f"target rows in {scope_label} first. Debye averages will "
+                "reuse that exact q-grid."
+            )
+            return
+
+        born_result = self._fourier_result
+        has_density_born = self._is_density_fourier_transform(born_result)
+        self.calculate_debye_scattering_button.setEnabled(
+            (not running) and self._inspection is not None and has_density_born
+        )
+        if self._inspection is None:
+            self.debye_scattering_status_label.setText(
+                "Load a structure or folder input before computing Debye scattering."
+            )
+            return
+        if not has_density_born:
+            self.debye_scattering_status_label.setText(
+                "Evaluate the Born-approximation Fourier transform first. "
+                "The Debye average will reuse that q-grid exactly."
+            )
+            return
+        q_values = np.asarray(born_result.q_values, dtype=float)
+        ready = self._debye_result_matches_transform(
+            born_result,
+            self._debye_scattering_result,
+        )
+        stale = self._debye_scattering_result is not None and not ready
+        q_text = (
+            "q grid unavailable"
+            if q_values.size == 0
+            else (
+                f"q={float(q_values[0]):.4f}"
+                f"–{float(q_values[-1]):.4f} Å⁻¹ "
+                f"({len(q_values)} points)"
+            )
+        )
+        message = (
+            f"Ready to compute a Debye average across "
+            f"{self._inspection.total_files} structure"
+            f"{'' if self._inspection.total_files == 1 else 's'} on the "
+            f"active Born q-grid ({q_text})."
+        )
+        if ready:
+            message = (
+                f"Debye scattering average ready for the active Born trace "
+                f"({q_text}). Open Comparison Plot to overlay the pair."
+            )
+        elif stale:
+            message += " A previous Debye average exists but no longer matches the current Born q-grid."
+        self.debye_scattering_status_label.setText(message)
+
+    @Slot()
+    def _calculate_debye_scattering_action(self) -> None:
+        if self._is_calculation_running():
+            self._show_error(
+                "Calculation Running",
+                "Wait for the active electron-density calculation to finish "
+                "before computing Debye scattering.",
+            )
+            return
+        if self._cluster_group_states:
+            self._calculate_debye_scattering_for_target_clusters(
+                apply_to_all=bool(self.apply_debye_to_all_button.isChecked())
+            )
+            return
+        if self._inspection is None:
+            self._show_error(
+                "No Structure Loaded",
+                "Load a structure or folder input before computing Debye scattering.",
+            )
+            return
+        if not self._is_density_fourier_transform(self._fourier_result):
+            self._show_error(
+                "Born Transform Required",
+                "Evaluate the Born-approximation Fourier transform before "
+                "computing the Debye comparison trace.",
+            )
+            return
+        self._close_debye_scattering_compare_dialog()
+        progress_total = self._debye_scattering_progress_total_for_inspection(
+            self._inspection
+        )
+        self._set_calculation_running(True)
+        self.stop_calculation_button.setEnabled(False)
+        self._begin_debye_scattering_progress(
+            total=progress_total,
+            message="Preparing Debye scattering average calculation...",
+        )
+        result: ElectronDensityDebyeScatteringAverageResult | None = None
+        error_message: str | None = None
+        try:
+            result = compute_average_debye_scattering_profile_for_input(
+                self._inspection,
+                q_values=np.asarray(
+                    self._fourier_result.q_values, dtype=float
+                ),
+                progress_callback=self._update_debye_scattering_progress,
+            )
+        except Exception as exc:
+            error_message = str(exc)
+        finally:
+            self._set_calculation_running(False)
+            self.stop_calculation_button.setEnabled(False)
+            self._reset_debye_scattering_progress()
+        if error_message is not None:
+            self._show_error("Debye Scattering Error", error_message)
+            return
+        if result is None:
+            self._show_error(
+                "Debye Scattering Error",
+                "Debye scattering calculation finished without a result.",
+            )
+            return
+        self._debye_scattering_result = result
+        self._refresh_debye_scattering_group()
+        q_values = np.asarray(result.q_values, dtype=float)
+        self._append_status(
+            "Computed Debye scattering average on the active Born q-grid: "
+            f"{result.source_structure_count} structure"
+            f"{'' if result.source_structure_count == 1 else 's'}, "
+            f"{len(q_values)} q points."
+        )
+        for note in result.notes:
+            self._append_status(note)
+        self.statusBar().showMessage("Debye scattering average ready")
+        self._sync_workspace_state()
+
+    def _calculate_debye_scattering_for_target_clusters(
+        self,
+        *,
+        apply_to_all: bool,
+    ) -> None:
+        if not self._cluster_group_states:
+            self._show_error(
+                "No Stoichiometry Table",
+                "Load a cluster-folder input before computing Debye "
+                "comparison traces across stoichiometries.",
+            )
+            return
+        (
+            target_states,
+            scope_label,
+            selected_keys,
+        ) = self._batch_target_cluster_group_states(apply_to_all=apply_to_all)
+        updated_count = 0
+        skipped_pending = 0
+        skipped_single_atom = 0
+        failures: list[str] = []
+        eligible_states = [
+            state
+            for state in target_states
+            if (
+                not state.single_atom_only
+                and self._is_density_fourier_transform(state.transform_result)
+            )
+        ]
+        self._close_debye_scattering_compare_dialog()
+        progress_total = sum(
+            self._debye_scattering_progress_total_for_inspection(
+                state.inspection
+            )
+            for state in eligible_states
+        )
+        if progress_total > 0:
+            skipped_count = len(target_states) - len(eligible_states)
+            progress_message = (
+                "Preparing Debye scattering averages across "
+                f"{len(eligible_states)} target row"
+                f"{'' if len(eligible_states) == 1 else 's'} in "
+                f"{scope_label}."
+            )
+            if skipped_count > 0:
+                progress_message += (
+                    f" {skipped_count} row"
+                    f"{'' if skipped_count == 1 else 's'} will be skipped."
+                )
+            self._set_calculation_running(True)
+            self.stop_calculation_button.setEnabled(False)
+            self._begin_debye_scattering_progress(
+                total=progress_total,
+                message=progress_message,
+            )
+        progress_offset = 0
+        eligible_index = 0
+        try:
+            for state in target_states:
+                if state.single_atom_only:
+                    skipped_single_atom += 1
+                    state.debye_scattering_result = None
+                    continue
+                born_result = state.transform_result
+                if not self._is_density_fourier_transform(born_result):
+                    skipped_pending += 1
+                    state.debye_scattering_result = None
+                    continue
+                eligible_index += 1
+                state_progress_total = (
+                    self._debye_scattering_progress_total_for_inspection(
+                        state.inspection
+                    )
+                )
+
+                def emit_state_progress(
+                    current: int,
+                    total: int,
+                    message: str,
+                    *,
+                    _state=state,
+                    _offset=progress_offset,
+                    _scope_label=scope_label,
+                    _scope_index=eligible_index,
+                    _scope_total=len(eligible_states),
+                ) -> None:
+                    self._update_debye_scattering_progress(
+                        _offset
+                        + min(max(int(current), 0), max(int(total), 1)),
+                        progress_total,
+                        "Debye "
+                        f"{_scope_index}/{_scope_total} "
+                        f"[{_state.display_name}] in {_scope_label}: "
+                        f"{str(message).strip()}",
+                    )
+
+                try:
+                    result = (
+                        compute_average_debye_scattering_profile_for_input(
+                            state.inspection,
+                            q_values=np.asarray(
+                                born_result.q_values,
+                                dtype=float,
+                            ),
+                            progress_callback=emit_state_progress,
+                        )
+                    )
+                except Exception as exc:
+                    failures.append(f"{state.display_name}: {exc}")
+                    progress_offset += state_progress_total
+                    if progress_total > 0:
+                        self._update_debye_scattering_progress(
+                            progress_offset,
+                            progress_total,
+                            f"Debye {eligible_index}/{len(eligible_states)} "
+                            f"[{state.display_name}] in {scope_label} failed.",
+                        )
+                    continue
+                state.debye_scattering_result = result
+                if state.key == self._selected_cluster_group_key:
+                    self._debye_scattering_result = result
+                updated_count += 1
+                progress_offset += state_progress_total
+        finally:
+            if progress_total > 0:
+                self._set_calculation_running(False)
+                self.stop_calculation_button.setEnabled(False)
+                self._reset_debye_scattering_progress()
+        if updated_count <= 0:
+            self._refresh_debye_scattering_group()
+            if failures:
+                self._show_error(
+                    "Debye Scattering Error",
+                    "\n".join(failures[:6]),
+                )
+                return
+            if skipped_single_atom > 0 and skipped_pending == 0:
+                self._show_error(
+                    "No Debye Targets Updated",
+                    "The selected target rows already use direct Debye "
+                    "scattering only, so a separate Born-vs-Debye "
+                    "comparison trace is not needed.",
+                )
+                return
+            self._show_error(
+                "Born Transform Required",
+                "Evaluate the Born-approximation Fourier transform for the "
+                "target rows before computing Debye comparison traces.",
+            )
+            return
+        self._refresh_cluster_views_after_batch_update(
+            target_states,
+            selected_keys=selected_keys,
+        )
+        summary_parts = [
+            f"computed {updated_count} Debye scattering average"
+            f"{'' if updated_count == 1 else 's'}"
+        ]
+        if skipped_pending > 0:
+            summary_parts.append(
+                f"skipped {skipped_pending} row"
+                f"{'' if skipped_pending == 1 else 's'} without a Born trace"
+            )
+        if skipped_single_atom > 0:
+            summary_parts.append(
+                f"skipped {skipped_single_atom} direct-Debye row"
+                f"{'' if skipped_single_atom == 1 else 's'}"
+            )
+        if failures:
+            summary_parts.append(
+                f"{len(failures)} row"
+                f"{'' if len(failures) == 1 else 's'} failed"
+            )
+        self._append_status(
+            "Debye scattering batch update: "
+            + "; ".join(summary_parts)
+            + f" across {scope_label}. Each trace reused the q-grid from its "
+            "matching Born-approximation transform."
+        )
+        for failure in failures:
+            self._append_status(f"Debye scattering warning: {failure}")
+        self.statusBar().showMessage("Debye scattering averages ready")
+        self._sync_workspace_state()
+
+    @Slot()
+    def _open_debye_scattering_comparison_plot(self) -> None:
+        entries = self._debye_comparison_entries()
+        if not entries:
+            self._show_error(
+                "No Debye Comparison Traces",
+                "Compute at least one matching Born and Debye trace before "
+                "opening the comparison plot.",
+            )
+            return
+        self._close_debye_scattering_compare_dialog()
+        dialog = _DebyeScatteringComparisonDialog(entries, parent=self)
+        dialog.finished.connect(
+            lambda _result: setattr(
+                self,
+                "_debye_scattering_compare_dialog",
+                None,
+            )
+        )
+        self._debye_scattering_compare_dialog = dialog
+        dialog.show()
+        dialog.raise_()
+        dialog.activateWindow()
+
+    def _build_component_summary_payload(self) -> dict[str, object]:
+        return {
+            "schema_version": 1,
+            "generated_at": datetime.now().isoformat(timespec="seconds"),
+            "distribution_id": self._distribution_id,
+            "project_dir": (
+                None if self._project_dir is None else str(self._project_dir)
+            ),
+            "input_path": self.input_path_edit.text().strip() or None,
+            "output_dir": self.output_dir_edit.text().strip() or None,
+            "output_basename": self.output_basename_edit.text().strip()
+            or None,
+            "use_contiguous_frame_mode": self._use_contiguous_frame_mode(),
+            "auto_save_smearing_outputs": (
+                self._auto_save_smearing_outputs_enabled()
+            ),
+            "active_group_key": self._selected_cluster_group_key,
+            "show_all_cluster_transforms": bool(
+                self.show_all_cluster_transforms_checkbox.isChecked()
+            ),
+            "manual_mode_enabled": bool(self.manual_mode_checkbox.isChecked()),
+            "manual_mesh_lock_settings": (
+                None
+                if self._manual_mesh_lock_settings is None
+                else self._manual_mesh_lock_settings.to_dict()
+            ),
+            "active_mesh_settings": self._active_mesh_settings.to_dict(),
+            "cluster_groups": [
+                {
+                    "key": state.key,
+                    "display_name": state.display_name,
+                    "structure_name": state.structure_name,
+                    "motif_name": state.motif_name,
+                    "source_dir": str(state.source_dir),
+                    "single_atom_only": bool(state.single_atom_only),
+                    "trace_color": state.trace_color,
+                    "average_atom_count": float(state.average_atom_count),
+                    "solvent_density_e_per_a3": state.solvent_density_e_per_a3,
+                    "solvent_cutoff_radius_a": state.solvent_cutoff_radius_a,
+                    "reference_structure": self._serialize_structure(
+                        state.reference_structure
+                    ),
+                    "fourier_settings": (
+                        None
+                        if state.fourier_settings is None
+                        else state.fourier_settings.to_dict()
+                    ),
+                    "profile_result": (
+                        None
+                        if state.profile_result is None
+                        else self._serialize_profile_result(
+                            state.profile_result
+                        )
+                    ),
+                    "transform_result": (
+                        None
+                        if state.transform_result is None
+                        else self._serialize_transform_result(
+                            state.transform_result
+                        )
+                    ),
+                    "debye_scattering_result": (
+                        None
+                        if state.debye_scattering_result is None
+                        else self._serialize_debye_scattering_result(
+                            state.debye_scattering_result
+                        )
+                    ),
+                }
+                for state in self._cluster_group_states
+            ],
+        }
+
+    def _write_component_trace_file(
+        self,
+        state: _ClusterDensityGroupState,
+        component_dir: Path,
+    ) -> str:
+        transform_result = state.transform_result
+        if transform_result is None:
+            raise ValueError(
+                f"Cluster {state.display_name} does not have a Fourier transform yet."
+            )
+        profile_file = self._component_profile_filename(
+            state.structure_name,
+            state.motif_name,
+        )
+        output_path = component_dir / profile_file
+        header = (
+            f"# Number of files: {state.inspection.total_files}\n"
+            "# Columns: q, S(q)_avg, S(q)_std, S(q)_se\n"
+        )
+        q_values = np.asarray(transform_result.q_values, dtype=float)
+        intensity = np.asarray(transform_result.intensity, dtype=float)
+        data = np.column_stack(
+            [
+                q_values,
+                intensity,
+                np.zeros_like(q_values, dtype=float),
+                np.zeros_like(q_values, dtype=float),
+            ]
+        )
+        np.savetxt(
+            output_path,
+            data,
+            comments="",
+            header=header,
+            fmt=["%.8f", "%.8f", "%.8f", "%.8f"],
+        )
+        return profile_file
+
+    def _write_distribution_component_summary(
+        self,
+        summary_path: Path,
+    ) -> None:
+        summary_path.parent.mkdir(parents=True, exist_ok=True)
+        summary_path.write_text(
+            json.dumps(self._build_component_summary_payload(), indent=2)
+            + "\n",
+            encoding="utf-8",
+        )
+
+    def _distribution_state_restore_candidates(self) -> list[Path]:
+        candidates: list[Path] = []
+        workspace_state_path = self._workspace_state_path()
+        if workspace_state_path is not None:
+            candidates.append(workspace_state_path)
+        summary_path = self._component_summary_path()
+        if summary_path is not None and summary_path not in candidates:
+            candidates.append(summary_path)
+        return candidates
+
+    def _delete_saved_output_history_storage(
+        self,
+        *,
+        announce: bool,
+    ) -> None:
+        removed_paths: list[Path] = []
+        for history_path in self._saved_output_history_restore_candidates():
+            if not history_path.is_file():
+                continue
+            try:
+                history_path.unlink()
+            except Exception as exc:
+                self._append_status(
+                    "Could not remove saved output history from "
+                    f"{history_path}: {exc}"
+                )
+                continue
+            removed_paths.append(history_path)
+        if announce and removed_paths:
+            self._append_status(
+                "Removed saved output history from "
+                + ", ".join(str(path) for path in removed_paths)
+                + "."
+            )
+
+    def _delete_workspace_state(
+        self,
+        *,
+        announce: bool,
+    ) -> None:
+        workspace_state_path = self._workspace_state_path()
+        if workspace_state_path is None or not workspace_state_path.is_file():
+            return
+        try:
+            workspace_state_path.unlink()
+        except Exception as exc:
+            self._append_status(
+                "Could not remove the saved workspace state from "
+                f"{workspace_state_path}: {exc}"
+            )
+            return
+        if announce:
+            self._append_status(
+                f"Removed the saved workspace state from {workspace_state_path}."
+            )
+
+    def _sync_workspace_state(self) -> None:
+        if (
+            self._preview_mode
+            or self._restoring_saved_distribution_state
+            or self._restoring_saved_output_history
+        ):
+            return
+        workspace_state_path = self._workspace_state_path()
+        current_input_path = self._current_input_path()
+        if workspace_state_path is None or current_input_path is None:
+            return
+        if not self._has_calculated_density_outputs():
+            self._delete_workspace_state(announce=False)
+            return
+        payload = self._build_component_summary_payload()
+        payload["state_kind"] = "workspace_session"
+        try:
+            workspace_state_path.parent.mkdir(parents=True, exist_ok=True)
+            workspace_state_path.write_text(
+                json.dumps(payload, indent=2) + "\n",
+                encoding="utf-8",
+            )
+        except Exception as exc:
+            self._append_status(
+                "Could not write workspace state to "
+                f"{workspace_state_path}: {exc}"
+            )
+
+    def _update_distribution_metadata_after_push(
+        self,
+        *,
+        component_dir: Path,
+        component_map_path: Path,
+        summary_path: Path,
+    ) -> None:
+        if self._distribution_root_dir is None:
+            return
+        metadata_path = self._distribution_root_dir / "distribution.json"
+        if not metadata_path.is_file():
+            return
+        try:
+            payload = json.loads(metadata_path.read_text(encoding="utf-8"))
+        except Exception:
+            payload = {}
+        payload["updated_at"] = datetime.now().isoformat(timespec="seconds")
+        payload["component_artifacts_ready"] = bool(
+            component_dir.is_dir()
+            and any(component_dir.glob("*.txt"))
+            and component_map_path.is_file()
+        )
+        payload["electron_density_component_summary"] = str(summary_path)
+        metadata_path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    @Slot()
+    def _push_components_to_model(self) -> None:
+        lock_reason = self._distribution_push_lock_reason()
+        if lock_reason is not None:
+            self._show_error("Push to Model unavailable", lock_reason)
+            return
+        artifact_targets = self._component_artifact_targets()
+        summary_path = self._component_summary_path()
+        if artifact_targets is None or summary_path is None:
+            self._show_error(
+                "Push to Model unavailable",
+                "This window is not linked to a computed distribution.",
+            )
+            return
+        if not self._cluster_group_states:
+            self._show_error(
+                "Push to Model unavailable",
+                "Load a cluster-folder input before pushing Born-approximation traces.",
+            )
+            return
+        pending = [
+            state.display_name
+            for state in self._cluster_group_states
+            if state.transform_result is None
+        ]
+        if pending:
+            self._show_error(
+                "Push to Model unavailable",
+                "Evaluate the Fourier transform for every cluster before pushing. "
+                "Pending: " + ", ".join(pending),
+            )
+            return
+        component_dir, component_map_path = artifact_targets
+        component_dir.mkdir(parents=True, exist_ok=True)
+        saxs_map: dict[str, dict[str, str]] = {}
+        for state in self._cluster_group_states:
+            profile_file = self._write_component_trace_file(
+                state,
+                component_dir,
+            )
+            saxs_map.setdefault(state.structure_name, {})
+            saxs_map[state.structure_name][state.motif_name] = profile_file
+        component_map_path.write_text(
+            json.dumps({"saxs_map": saxs_map}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        self._write_distribution_component_summary(summary_path)
+        self._update_distribution_metadata_after_push(
+            component_dir=component_dir,
+            component_map_path=component_map_path,
+            summary_path=summary_path,
+        )
+        mismatch_text = self._project_q_range_mismatch_text()
+        if mismatch_text:
+            self._append_status(mismatch_text)
+        self._append_status(
+            "Pushed Born-approximation component traces into the linked "
+            f"computed distribution: {component_map_path}"
+        )
+        self.statusBar().showMessage(
+            "Born-approximation components pushed to model"
+        )
+        self.born_components_built.emit(
+            {
+                "project_dir": (
+                    None
+                    if self._project_dir is None
+                    else str(self._project_dir)
+                ),
+                "distribution_id": self._distribution_id,
+                "distribution_dir": (
+                    None
+                    if self._distribution_root_dir is None
+                    else str(self._distribution_root_dir)
+                ),
+                "component_dir": str(component_dir),
+                "component_map_path": str(component_map_path),
+                "component_summary_path": str(summary_path),
+            }
+        )
+        self._update_push_to_model_state()
+
+    def _restore_distribution_state_from_payload(
+        self,
+        payload: dict[str, object],
+        *,
+        source_path: Path,
+    ) -> bool:
+        if not self._cluster_group_states:
+            return False
+        state_by_key = {
+            state.key: state for state in self._cluster_group_states
+        }
+        restored_count = 0
+        self._restoring_saved_distribution_state = True
+        try:
+            self.contiguous_frame_mode_checkbox.setChecked(
+                bool(payload.get("use_contiguous_frame_mode", True))
+            )
+            if hasattr(self, "auto_save_smearing_outputs_checkbox"):
+                self.auto_save_smearing_outputs_checkbox.setChecked(
+                    bool(payload.get("auto_save_smearing_outputs", False))
+                )
+            self.manual_mode_checkbox.blockSignals(True)
+            try:
+                self.manual_mode_checkbox.setChecked(
+                    bool(payload.get("manual_mode_enabled", False))
+                )
+            finally:
+                self.manual_mode_checkbox.blockSignals(False)
+            manual_mesh_lock_payload = payload.get("manual_mesh_lock_settings")
+            if isinstance(manual_mesh_lock_payload, dict):
+                try:
+                    self._manual_mesh_lock_settings = (
+                        self._deserialize_mesh_settings(
+                            manual_mesh_lock_payload
+                        )
+                    )
+                except Exception:
+                    self._manual_mesh_lock_settings = None
+            else:
+                self._manual_mesh_lock_settings = None
+            restored_mesh_settings = None
+            active_mesh_settings_payload = payload.get("active_mesh_settings")
+            if isinstance(active_mesh_settings_payload, dict):
+                try:
+                    restored_mesh_settings = self._deserialize_mesh_settings(
+                        active_mesh_settings_payload
+                    )
+                except Exception:
+                    restored_mesh_settings = None
+            for group_payload in payload.get("cluster_groups") or []:
+                if not isinstance(group_payload, dict):
+                    continue
+                key = str(group_payload.get("key") or "").strip()
+                state = state_by_key.get(key)
+                if state is None:
+                    continue
+                state.trace_color = str(
+                    group_payload.get("trace_color") or state.trace_color
+                )
+                state.average_atom_count = float(
+                    group_payload.get("average_atom_count")
+                    or state.average_atom_count
+                )
+                state.solvent_density_e_per_a3 = (
+                    None
+                    if group_payload.get("solvent_density_e_per_a3") is None
+                    else float(group_payload.get("solvent_density_e_per_a3"))
+                )
+                state.solvent_cutoff_radius_a = (
+                    None
+                    if group_payload.get("solvent_cutoff_radius_a") is None
+                    else float(group_payload.get("solvent_cutoff_radius_a"))
+                )
+                reference_structure_payload = group_payload.get(
+                    "reference_structure"
+                )
+                if isinstance(reference_structure_payload, dict):
+                    try:
+                        state.reference_structure = (
+                            self._deserialize_structure(
+                                reference_structure_payload
+                            )
+                        )
+                    except Exception:
+                        pass
+                profile_payload = group_payload.get("profile_result")
+                if isinstance(profile_payload, dict):
+                    state.profile_result = self._deserialize_profile_result(
+                        profile_payload
+                    )
+                    if not isinstance(reference_structure_payload, dict):
+                        state.reference_structure = (
+                            state.profile_result.structure
+                        )
+                    self._sync_cluster_state_solvent_metadata(state)
+                elif state.solvent_cutoff_radius_a is None:
+                    legacy_cutoff = group_payload.get(
+                        "solvent_intercept_e_per_a3"
+                    )
+                    state.solvent_cutoff_radius_a = (
+                        None if legacy_cutoff is None else float(legacy_cutoff)
+                    )
+                transform_payload = group_payload.get("transform_result")
+                if isinstance(transform_payload, dict):
+                    state.transform_result = (
+                        self._deserialize_transform_result(
+                            transform_payload,
+                            state.profile_result,
+                            single_atom_only=state.single_atom_only,
+                        )
+                    )
+                else:
+                    state.transform_result = None
+                debye_payload = group_payload.get("debye_scattering_result")
+                if isinstance(debye_payload, dict):
+                    try:
+                        state.debye_scattering_result = (
+                            self._deserialize_debye_scattering_result(
+                                debye_payload
+                            )
+                        )
+                    except Exception:
+                        state.debye_scattering_result = None
+                else:
+                    state.debye_scattering_result = None
+                fourier_settings_payload = group_payload.get(
+                    "fourier_settings"
+                )
+                if isinstance(fourier_settings_payload, dict):
+                    state.fourier_settings = (
+                        self._deserialize_fourier_settings(
+                            fourier_settings_payload
+                        )
+                    )
+                elif state.transform_result is not None:
+                    state.fourier_settings = (
+                        state.transform_result.preview.settings
+                    )
+                elif state.fourier_settings is None:
+                    state.fourier_settings = (
+                        self._active_fourier_settings.normalized()
+                    )
+                restored_count += 1
+            if restored_mesh_settings is None:
+                active_key = str(payload.get("active_group_key") or "").strip()
+                fallback_state = self._cluster_group_state_by_key(active_key)
+                if (
+                    fallback_state is None
+                    or fallback_state.profile_result is None
+                ):
+                    fallback_state = next(
+                        (
+                            state
+                            for state in self._cluster_group_states
+                            if state.profile_result is not None
+                        ),
+                        None,
+                    )
+                if (
+                    fallback_state is not None
+                    and fallback_state.profile_result is not None
+                ):
+                    restored_mesh_settings = (
+                        fallback_state.profile_result.mesh_geometry.settings
+                    )
+            if restored_mesh_settings is not None:
+                self._active_mesh_settings = restored_mesh_settings
+                self._sync_mesh_controls_to_settings(restored_mesh_settings)
+                self._set_mesh_settings_confirmed_for_run(True)
+            self.show_all_cluster_transforms_checkbox.setChecked(
+                bool(payload.get("show_all_cluster_transforms"))
+            )
+            self._populate_cluster_group_table()
+            active_key = str(payload.get("active_group_key") or "").strip()
+            if active_key and active_key in state_by_key:
+                for row_index, state in enumerate(self._cluster_group_states):
+                    if state.key == active_key:
+                        self.cluster_group_table.selectRow(row_index)
+                        break
+                self._set_active_cluster_group(active_key)
+            elif self._cluster_group_states:
+                self.cluster_group_table.selectRow(0)
+                self._set_active_cluster_group(
+                    self._cluster_group_states[0].key
+                )
+        finally:
+            self._restoring_saved_distribution_state = False
+        self._refresh_manual_mode_notice()
+        self._refresh_mesh_notice()
+        if restored_count > 0:
+            self._append_status(
+                "Restored saved electron-density mapping state for "
+                f"{restored_count} cluster group"
+                f"{'' if restored_count == 1 else 's'} from {source_path}."
+            )
+        self._update_push_to_model_state()
+        return restored_count > 0
+
+    def _restore_saved_distribution_state_if_available(self) -> bool:
+        if self._preview_mode:
+            self._update_push_to_model_state()
+            return False
+        for state_path in self._distribution_state_restore_candidates():
+            if not state_path.is_file():
+                continue
+            try:
+                payload = json.loads(state_path.read_text(encoding="utf-8"))
+            except Exception as exc:
+                self._append_status(
+                    "Could not restore saved electron-density mapping state "
+                    f"from {state_path}: {exc}"
+                )
+                continue
+            saved_input_path = str(payload.get("input_path") or "").strip()
+            resolved_saved_input: Path | None = None
+            if saved_input_path:
+                try:
+                    resolved_saved_input = (
+                        Path(saved_input_path).expanduser().resolve()
+                    )
+                except Exception:
+                    resolved_saved_input = None
+            current_input_path = self._current_input_path()
+            if (
+                resolved_saved_input is not None
+                and current_input_path is not None
+                and resolved_saved_input != current_input_path
+            ):
+                continue
+            if (
+                resolved_saved_input is not None
+                and current_input_path is None
+                and not self._cluster_group_states
+            ):
+                try:
+                    self.input_path_edit.setText(str(resolved_saved_input))
+                    self._load_input_path(
+                        resolved_saved_input,
+                        asynchronous=True,
+                        restore_saved_distribution_state=True,
+                    )
+                except Exception as exc:
+                    self._append_status(
+                        "Could not reload saved cluster input "
+                        f"{resolved_saved_input}: {exc}"
+                    )
+                    continue
+                return True
+            if self._restore_distribution_state_from_payload(
+                payload,
+                source_path=state_path,
+            ):
+                return False
+        self._update_push_to_model_state()
+        return False
 
     def _apply_mesh_settings(
         self,
@@ -2060,6 +10720,7 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         *,
         announce: bool,
         preserve_viewer_display: bool = False,
+        update_viewer: bool = True,
     ) -> None:
         self._active_mesh_settings = settings.normalized()
         self._active_mesh_geometry = None
@@ -2070,7 +10731,7 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             )
         self._refresh_active_mesh_display()
         self._refresh_mesh_notice()
-        if self._structure is not None:
+        if self._structure is not None and update_viewer:
             if preserve_viewer_display:
                 self.structure_viewer.set_structure_preserving_display(
                     self._structure,
@@ -2101,26 +10762,74 @@ class ElectronDensityMappingMainWindow(QMainWindow):
                 "Load a structure before changing the active center.",
             )
             return
-        try:
-            self._structure = recenter_electron_density_structure(
-                self._structure,
-                center_mode=center_mode,
-                reference_element=self._selected_reference_element(),
-            )
-        except Exception as exc:
-            self._show_error("Center Update Error", str(exc))
-            return
-        self._reset_density_results()
-        self._sync_controls_to_structure()
-        self._apply_mesh_settings(
-            self._mesh_settings_from_controls(),
-            announce=False,
-            preserve_viewer_display=True,
+        preserve_mesh_confirmation = (
+            self._mesh_confirmation_carries_forward_on_auto_apply()
         )
+        active_cluster_state = self._active_cluster_group_state()
+        if self._cluster_group_states:
+            updated_structures: dict[str, ElectronDensityStructure] = {}
+            try:
+                for state in self._cluster_group_states:
+                    updated_structures[state.key] = (
+                        recenter_electron_density_structure(
+                            state.reference_structure,
+                            center_mode=center_mode,
+                            reference_element=state.reference_structure.reference_element,
+                        )
+                    )
+            except Exception as exc:
+                self._show_error("Center Update Error", str(exc))
+                return
+            for state in self._cluster_group_states:
+                state.reference_structure = updated_structures[state.key]
+            if active_cluster_state is not None:
+                self._structure = updated_structures[active_cluster_state.key]
+            self._reset_density_results()
+            self._clear_cluster_group_outputs(clear_manual_mesh_lock=True)
+            self._sync_controls_to_structure(sync_mesh_rmax=False)
+            self._apply_mesh_settings(
+                self._active_mesh_settings,
+                announce=False,
+                preserve_viewer_display=True,
+            )
+        else:
+            try:
+                self._structure = recenter_electron_density_structure(
+                    self._structure,
+                    center_mode=center_mode,
+                    reference_element=self._selected_reference_element(),
+                )
+            except Exception as exc:
+                self._show_error("Center Update Error", str(exc))
+                return
+            self._reset_density_results()
+            self._sync_controls_to_structure(sync_mesh_rmax=True)
+            self._apply_mesh_settings(
+                self._mesh_settings_from_controls(),
+                announce=False,
+                preserve_viewer_display=True,
+            )
+        self._set_mesh_settings_confirmed_for_run(preserve_mesh_confirmation)
         self._sync_fourier_controls_to_domain(reset_bounds=True)
         self._refresh_fourier_info_labels(None)
         self._refresh_contrast_display()
-        if self._structure.center_mode == "nearest_atom":
+        if self._cluster_group_states:
+            if self._structure.center_mode == "nearest_atom":
+                self._append_status(
+                    "Snapped the active center for every stoichiometry to "
+                    "its nearest atom."
+                )
+            elif self._structure.center_mode == "reference_element":
+                self._append_status(
+                    "Snapped every stoichiometry to its selected "
+                    "reference-element geometric center."
+                )
+            else:
+                self._append_status(
+                    "Reset the active center for every stoichiometry to its "
+                    "geometric mass center."
+                )
+        elif self._structure.center_mode == "nearest_atom":
             self._append_status(
                 "Snapped the active center to the nearest atom: "
                 f"{self._structure.nearest_atom_element} "
@@ -2134,16 +10843,124 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             )
         else:
             self._append_status(
-                "Reset the active center to the calculated mass-weighted center of mass."
+                "Reset the active center to the geometric mass center."
             )
         self.statusBar().showMessage("Updated active center")
+        self._sync_workspace_state()
 
     @Slot()
     def _apply_mesh_from_controls(self) -> None:
+        if self._manual_mesh_lock_settings is not None:
+            self.statusBar().showMessage(
+                "Mesh settings are locked until the calculated densities are reset.",
+                5000,
+            )
+            return
         self._apply_mesh_settings(
             self._mesh_settings_from_controls(), announce=True
         )
+        self._set_mesh_settings_confirmed_for_run(True)
         self.statusBar().showMessage("Updated mesh overlay")
+        self._sync_workspace_state()
+
+    @Slot()
+    def _request_calculation_stop(self) -> None:
+        if self._calculation_worker is None:
+            return
+        self._calculation_cancel_requested = True
+        self.stop_calculation_button.setEnabled(False)
+        self._calculation_worker.cancel()
+        if not self._is_calculation_running():
+            if not self._cluster_group_states:
+                self._reset_density_results()
+                self._set_calculation_overall_progress_visible(False)
+            self.calculation_progress_bar.setRange(0, 1)
+            self.calculation_progress_bar.setValue(0)
+            self.calculation_progress_bar.setFormat("%v / %m steps")
+            self.calculation_progress_message.setText(
+                "Electron-density calculation stopped."
+            )
+            self.statusBar().showMessage(
+                "Discarding pending electron-density result...",
+                5000,
+            )
+            self._append_status(
+                "Discarded the pending electron-density calculation result."
+            )
+            return
+        self.cancel_calculation_requested.emit()
+        self.calculation_progress_message.setText(
+            "Stopping electron-density calculation..."
+        )
+        self.statusBar().showMessage(
+            "Stopping electron-density calculation...",
+            5000,
+        )
+        self._append_status(
+            "Requested a stop for the active electron-density calculation."
+        )
+
+    @Slot()
+    def _reset_calculated_densities(self) -> None:
+        if self._is_calculation_running():
+            self._show_error(
+                "Calculation Running",
+                "Stop the active electron-density calculation before resetting the results.",
+            )
+            return
+        if not self._has_calculated_density_outputs():
+            return
+        response = QMessageBox.question(
+            self,
+            "Reset Calculated Densities",
+            "This will clear the active electron-density calculations and "
+            "unlock the mesh settings for a fresh run. Continue?",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if response != QMessageBox.StandardButton.Yes:
+            return
+        confirmation_text, accepted = QInputDialog.getText(
+            self,
+            "Secondary Authentication",
+            "Type RESET to clear the calculated densities:",
+            QLineEdit.EchoMode.Normal,
+            "",
+        )
+        if not accepted:
+            return
+        if str(confirmation_text).strip().upper() != "RESET":
+            self._show_error(
+                "Reset Canceled",
+                "Secondary authentication failed. Type RESET to clear the calculated densities.",
+            )
+            return
+        cleared_cluster_outputs = self._clear_cluster_group_outputs(
+            clear_manual_mesh_lock=True
+        )
+        self._reset_density_results()
+        self._refresh_contrast_display()
+        self._refresh_fourier_info_labels(None)
+        self._reset_progress_display("Idle")
+        self._clear_saved_output_history(announce=False)
+        self._delete_saved_output_history_storage(announce=False)
+        self._delete_workspace_state(announce=False)
+        if self._cluster_group_states:
+            active_key = (
+                self._selected_cluster_group_key
+                or self._cluster_group_states[0].key
+            )
+            self._set_active_cluster_group(active_key)
+        cleared_text = (
+            f"Cleared {cleared_cluster_outputs} stoichiometry calculation"
+            f"{'' if cleared_cluster_outputs == 1 else 's'}."
+            if cleared_cluster_outputs > 0
+            else "Cleared the active electron-density results."
+        )
+        self._append_status(
+            cleared_text + " Mesh settings are editable again."
+        )
+        self.statusBar().showMessage("Cleared calculated densities")
 
     @Slot()
     def _choose_input_file(self) -> None:
@@ -2158,7 +10975,6 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         self.input_path_edit.setText(
             str(Path(selected).expanduser().resolve())
         )
-        self._load_input_from_edit()
 
     @Slot()
     def _choose_input_folder(self) -> None:
@@ -2172,7 +10988,6 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         self.input_path_edit.setText(
             str(Path(selected).expanduser().resolve())
         )
-        self._load_input_from_edit()
 
     @Slot()
     def _choose_output_dir(self) -> None:
@@ -2197,7 +11012,7 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             )
             return
         try:
-            self._load_input_path(Path(text))
+            self._load_input_path(Path(text), asynchronous=True)
         except Exception as exc:
             self._show_error("Input Error", str(exc))
 
@@ -2218,24 +11033,49 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             self._output_basename(),
         )
 
+    def _set_calculation_overall_progress_visible(
+        self,
+        visible: bool,
+    ) -> None:
+        show = bool(visible)
+        self.calculation_overall_progress_message.setHidden(not show)
+        self.calculation_overall_progress_bar.setHidden(not show)
+
     def _reset_progress_display(self, message: str = "Idle") -> None:
         self.calculation_progress_message.setText(str(message))
         self.calculation_progress_bar.setRange(0, 1)
         self.calculation_progress_bar.setValue(0)
+        self.calculation_progress_bar.setFormat("%v / %m steps")
+        self.calculation_overall_progress_message.setText(
+            "Overall progress: idle"
+        )
+        self.calculation_overall_progress_bar.setRange(0, 1)
+        self.calculation_overall_progress_bar.setValue(0)
+        self.calculation_overall_progress_bar.setFormat(
+            "%v / %m cluster groups"
+        )
+        self._set_calculation_overall_progress_visible(False)
 
     def _set_calculation_running(self, running: bool) -> None:
+        self._calculation_ui_running = bool(running)
         enabled = not bool(running)
         for widget in (
             self.load_input_button,
             self.run_button,
+            self.cluster_group_table,
+            self.contiguous_frame_mode_checkbox,
+            self.pinned_geometric_tracking_checkbox,
+            self.manual_mode_checkbox,
             self.update_mesh_button,
             self.snap_center_button,
             self.reset_center_button,
+            self.snap_reference_center_button,
             self.rstep_spin,
             self.theta_divisions_spin,
             self.phi_divisions_spin,
             self.rmax_spin,
             self.smearing_factor_spin,
+            self.auto_save_smearing_outputs_checkbox,
             self.solvent_method_combo,
             self.solvent_preset_combo,
             self.save_custom_solvent_button,
@@ -2245,7 +11085,10 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             self.direct_density_spin,
             self.reference_solvent_file_edit,
             self.reference_solvent_browse_button,
+            self.apply_smearing_button,
+            self.apply_smearing_to_all_button,
             self.compute_solvent_density_button,
+            self.apply_contrast_to_all_button,
             self.fourier_rmin_spin,
             self.fourier_rmax_spin,
             self.fourier_window_combo,
@@ -2256,12 +11099,39 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             self.fourier_use_solvent_subtracted_checkbox,
             self.fourier_log_q_checkbox,
             self.fourier_log_intensity_checkbox,
+            self.apply_fourier_to_all_button,
+            self.calculate_debye_scattering_button,
+            self.apply_debye_to_all_button,
+            self.open_debye_scattering_compare_button,
+            self.fourier_settings_table,
+            self.show_all_cluster_transforms_checkbox,
             self.evaluate_fourier_button,
+            self.push_to_model_button,
             self.input_path_edit,
             self.output_dir_edit,
             self.output_basename_edit,
         ):
             widget.setEnabled(enabled)
+        pending_thread_teardown = (
+            not bool(running)
+            and self._calculation_worker is not None
+            and self._calculation_thread is not None
+            and not getattr(
+                self._calculation_worker, "_cancel_requested", False
+            )
+        )
+        self.stop_calculation_button.setEnabled(
+            bool(running) or pending_thread_teardown
+        )
+        self.reset_calculations_button.setEnabled(
+            (not bool(running)) and self._has_calculated_density_outputs()
+        )
+        self._refresh_mesh_control_lock()
+        if enabled:
+            self._refresh_pinned_geometric_tracking_controls()
+            self._update_push_to_model_state()
+        self._refresh_fourier_table_interaction_state()
+        self._refresh_run_action_state()
 
     @Slot(int, int, str)
     def _on_calculation_progress(
@@ -2274,17 +11144,237 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         bounded_current = min(max(int(current), 0), bounded_total)
         self.calculation_progress_bar.setRange(0, bounded_total)
         self.calculation_progress_bar.setValue(bounded_current)
+        self.calculation_progress_bar.setFormat("%v / %m steps")
         text = str(message).strip()
         if text:
             self.calculation_progress_message.setText(text)
-            self.statusBar().showMessage(text)
-            if text != self._last_progress_message:
-                self._append_status(text)
-                self._last_progress_message = text
+
+    @Slot(int, int, str)
+    def _on_calculation_overall_progress(
+        self,
+        current: int,
+        total: int,
+        message: str,
+    ) -> None:
+        if self._current_group_run_manual:
+            return
+        bounded_total = max(int(total), 1)
+        bounded_current = min(max(int(current), 0), bounded_total)
+        self._set_calculation_overall_progress_visible(True)
+        self.calculation_overall_progress_bar.setRange(0, bounded_total)
+        self.calculation_overall_progress_bar.setValue(bounded_current)
+        self.calculation_overall_progress_bar.setFormat(
+            "%v / %m cluster groups"
+        )
+        text = str(message).strip()
+        if text:
+            self.calculation_overall_progress_message.setText(text)
+
+    def _apply_group_run_payload(
+        self,
+        data: dict[str, object],
+    ) -> tuple[
+        list[_ClusterDensityGroupState],
+        list[_ClusterDensityGroupState],
+        dict[str, ElectronDensityOutputArtifacts],
+    ]:
+        group_results = data.get("group_results")
+        group_transform_results = data.get("group_transform_results")
+        group_artifacts = data.get("group_artifacts")
+        updated_density_states: list[_ClusterDensityGroupState] = []
+        updated_transform_states: list[_ClusterDensityGroupState] = []
+        written_artifacts: dict[str, ElectronDensityOutputArtifacts] = {}
+        for state in self._cluster_group_states:
+            preserved_fourier_settings = self._cluster_state_fourier_settings(
+                state
+            )
+            result = (
+                group_results.get(state.key)
+                if isinstance(group_results, dict)
+                else None
+            )
+            if isinstance(result, ElectronDensityProfileResult):
+                state.profile_result = result
+                state.transform_result = None
+                state.debye_scattering_result = None
+                state.solvent_density_e_per_a3 = None
+                state.solvent_cutoff_radius_a = None
+                self._capture_saved_output_entry(
+                    "density",
+                    group_state=state,
+                    profile_result=result,
+                )
+                if self._active_contrast_settings is not None:
+                    updated_result = apply_solvent_contrast_to_profile_result(
+                        state.profile_result,
+                        self._active_contrast_settings,
+                        solvent_name=self._active_contrast_name,
+                    )
+                    state.profile_result = updated_result
+                    self._sync_cluster_state_solvent_metadata(state)
+                    if updated_result.solvent_contrast is not None:
+                        self._capture_saved_output_entry(
+                            "solvent_subtraction",
+                            group_state=state,
+                            profile_result=updated_result,
+                        )
+                self._set_cluster_state_fourier_settings(
+                    state,
+                    preserved_fourier_settings,
+                    prefer_solvent_cutoff=bool(state.solvent_cutoff_radius_a),
+                )
+                updated_density_states.append(state)
+                continue
+            transform_result = (
+                group_transform_results.get(state.key)
+                if isinstance(group_transform_results, dict)
+                else None
+            )
+            if state.single_atom_only and isinstance(
+                transform_result,
+                ElectronDensityScatteringTransformResult,
+            ):
+                state.profile_result = None
+                state.fourier_settings = transform_result.preview.settings
+                state.transform_result = transform_result
+                state.debye_scattering_result = None
+                state.solvent_density_e_per_a3 = None
+                state.solvent_cutoff_radius_a = None
+                updated_transform_states.append(state)
+        if isinstance(group_artifacts, dict):
+            for group_key, artifacts in group_artifacts.items():
+                if isinstance(artifacts, ElectronDensityOutputArtifacts):
+                    written_artifacts[str(group_key)] = artifacts
+        self._populate_cluster_group_table()
+        active_state = self._active_cluster_group_state()
+        if active_state is not None:
+            self._set_active_cluster_group(active_state.key)
+        return (
+            updated_density_states,
+            updated_transform_states,
+            written_artifacts,
+        )
 
     @Slot(object)
     def _on_calculation_finished(self, payload: object) -> None:
+        if self._calculation_cancel_requested or (
+            self._calculation_worker is not None
+            and getattr(self._calculation_worker, "_cancel_requested", False)
+        ):
+            self._on_calculation_canceled(payload)
+            return
+        if self._calculation_worker is not None and getattr(
+            self._calculation_worker, "_cancel_requested", False
+        ):
+            self._on_calculation_canceled(payload)
+            return
+        self._calculation_cancel_requested = False
         data = payload if isinstance(payload, dict) else {}
+        group_results = data.get("group_results")
+        if isinstance(group_results, dict):
+            (
+                updated_density_states,
+                updated_transform_states,
+                written_artifacts,
+            ) = self._apply_group_run_payload(data)
+            if self._current_group_run_manual and (
+                updated_density_states or updated_transform_states
+            ):
+                self._manual_mesh_lock_settings = self._active_mesh_settings
+                self._refresh_mesh_notice()
+            completed_count = self._completed_cluster_group_count()
+            cluster_group_count = max(len(self._cluster_group_states), 1)
+            self._set_calculation_overall_progress_visible(True)
+            self.calculation_overall_progress_bar.setRange(
+                0,
+                cluster_group_count,
+            )
+            self.calculation_overall_progress_bar.setValue(completed_count)
+            self.calculation_overall_progress_bar.setFormat(
+                "%v / %m cluster groups"
+            )
+            self.calculation_overall_progress_message.setText(
+                "Overall cluster progress: "
+                f"{completed_count}/{len(self._cluster_group_states)} "
+                "groups complete."
+            )
+            self.calculation_progress_bar.setRange(0, 1)
+            self.calculation_progress_bar.setValue(1)
+            self.calculation_progress_bar.setFormat("%v / %m steps")
+            self.calculation_progress_message.setText(
+                (
+                    "Manual stoichiometry calculation complete."
+                    if self._current_group_run_manual
+                    else "Cluster-folder scattering preparation complete."
+                )
+            )
+            self._set_calculation_running(False)
+            summary_parts: list[str] = []
+            if updated_density_states:
+                summary_parts.append(
+                    f"{len(updated_density_states)} electron-density profile"
+                    f"{'' if len(updated_density_states) == 1 else 's'}"
+                )
+            if updated_transform_states:
+                summary_parts.append(
+                    f"{len(updated_transform_states)} direct Debye scattering trace"
+                    f"{'' if len(updated_transform_states) == 1 else 's'}"
+                )
+            if not summary_parts:
+                summary_parts.append("no cluster outputs")
+            if self._current_group_run_manual:
+                active_label = (
+                    updated_density_states[0].display_name
+                    if updated_density_states
+                    else (
+                        updated_transform_states[0].display_name
+                        if updated_transform_states
+                        else "the selected stoichiometry"
+                    )
+                )
+                self._append_status(
+                    "Prepared "
+                    + " and ".join(summary_parts)
+                    + f" for {active_label}. "
+                    f"{completed_count}/{len(self._cluster_group_states)} "
+                    "stoichiometry groups are now complete."
+                )
+            else:
+                self._append_status(
+                    "Prepared "
+                    + " and ".join(summary_parts)
+                    + f" across {len(self._cluster_group_states)} stoichiometry folders."
+                )
+            for state in updated_density_states:
+                self._append_averaging_status(
+                    state.profile_result,
+                    prefix=f"{state.display_name}:",
+                )
+            for state in updated_transform_states:
+                self._append_status(
+                    f"{state.display_name}: built direct Debye I(Q) for a "
+                    "single-atom cluster bin and skipped electron-density "
+                    "and Fourier-profile evaluation."
+                )
+            for group_key, artifacts in sorted(written_artifacts.items()):
+                self._append_status(
+                    f"Wrote {group_key} CSV to {artifacts.csv_path}"
+                )
+                self._append_status(
+                    f"Wrote {group_key} JSON to {artifacts.json_path}"
+                )
+            self.statusBar().showMessage(
+                (
+                    "Manual stoichiometry calculation complete"
+                    if self._current_group_run_manual
+                    else "Cluster-folder scattering preparation complete"
+                )
+            )
+            self._current_group_run_manual = False
+            self._refresh_run_action_state()
+            self._schedule_cluster_view_cache_prewarm()
+            self._sync_workspace_state()
+            return
         result = data.get("result")
         artifacts = data.get("artifacts")
         if not isinstance(result, ElectronDensityProfileResult):
@@ -2295,17 +11385,58 @@ class ElectronDensityMappingMainWindow(QMainWindow):
 
         self._profile_result = result
         self._fourier_result = None
+        self._debye_scattering_result = None
+        active_cluster_state = self._active_cluster_group_state()
+        preserved_fourier_settings = (
+            None
+            if active_cluster_state is None
+            else self._cluster_state_fourier_settings(active_cluster_state)
+        )
+        if active_cluster_state is not None:
+            active_cluster_state.profile_result = result
+            active_cluster_state.transform_result = None
+            active_cluster_state.debye_scattering_result = None
+            active_cluster_state.solvent_density_e_per_a3 = None
+            active_cluster_state.solvent_cutoff_radius_a = None
+        self._capture_saved_output_entry(
+            "density",
+            group_state=active_cluster_state,
+            profile_result=result,
+        )
         if self._active_contrast_settings is not None:
             self._apply_active_contrast_to_profile(
                 show_error=False,
                 announce=False,
             )
+            if (
+                active_cluster_state is not None
+                and self._profile_result is not None
+                and self._profile_result.solvent_contrast is not None
+            ):
+                active_cluster_state.profile_result = self._profile_result
+                self._sync_cluster_state_solvent_metadata(active_cluster_state)
+        if (
+            active_cluster_state is not None
+            and preserved_fourier_settings is not None
+        ):
+            updated_settings = self._set_cluster_state_fourier_settings(
+                active_cluster_state,
+                preserved_fourier_settings,
+                prefer_solvent_cutoff=bool(
+                    active_cluster_state.solvent_cutoff_radius_a
+                ),
+            )
+            self._sync_fourier_controls_to_settings(updated_settings)
         self._refresh_profile_plots()
+        self._populate_cluster_group_table()
         self._refresh_contrast_display()
         self._sync_fourier_controls_to_domain(reset_bounds=False)
         self._refresh_fourier_preview_from_controls(clear_transform=True)
+        self._close_debye_scattering_compare_dialog()
+        self._set_calculation_overall_progress_visible(False)
         self.calculation_progress_bar.setRange(0, 1)
         self.calculation_progress_bar.setValue(1)
+        self.calculation_progress_bar.setFormat("%v / %m steps")
         self.calculation_progress_message.setText(
             "Electron-density calculation complete."
         )
@@ -2327,6 +11458,7 @@ class ElectronDensityMappingMainWindow(QMainWindow):
                 f"{len(active_result.radial_centers)} shells, "
                 f"{average_total_electrons:.0f} total electrons placed on the mesh."
             )
+        self._append_averaging_status(active_result)
         self._append_status(
             "Applied Gaussian smearing with "
             f"factor={active_result.smearing_settings.debye_waller_factor:.6f} Å² "
@@ -2366,13 +11498,77 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         if isinstance(artifacts, ElectronDensityOutputArtifacts):
             self._append_status(f"Wrote profile CSV to {artifacts.csv_path}")
             self._append_status(f"Wrote summary JSON to {artifacts.json_path}")
+        self._current_group_run_manual = False
+        self._refresh_run_action_state()
         self.statusBar().showMessage("Electron-density calculation complete")
+        self._sync_workspace_state()
 
     @Slot(str)
     def _on_calculation_failed(self, message: str) -> None:
+        self._calculation_cancel_requested = False
         self._set_calculation_running(False)
         self._reset_progress_display("Calculation failed.")
+        self._current_group_run_manual = False
+        self._refresh_run_action_state()
         self._show_error("Calculation Error", str(message))
+
+    @Slot(object)
+    def _on_calculation_canceled(self, payload: object) -> None:
+        self._calculation_cancel_requested = False
+        data = payload if isinstance(payload, dict) else {}
+        group_results = data.get("group_results")
+        if self._cluster_group_states and isinstance(group_results, dict):
+            (
+                updated_density_states,
+                updated_transform_states,
+                written_artifacts,
+            ) = self._apply_group_run_payload(data)
+            completed_count = self._completed_cluster_group_count()
+            total_count = max(len(self._cluster_group_states), 1)
+            self._set_calculation_overall_progress_visible(True)
+            self.calculation_overall_progress_bar.setRange(0, total_count)
+            self.calculation_overall_progress_bar.setValue(completed_count)
+            self.calculation_overall_progress_bar.setFormat(
+                "%v / %m cluster groups"
+            )
+            self.calculation_overall_progress_message.setText(
+                "Overall cluster progress: "
+                f"{completed_count}/{len(self._cluster_group_states)} "
+                "groups complete."
+            )
+            for state in updated_density_states:
+                self._append_averaging_status(
+                    state.profile_result,
+                    prefix=f"{state.display_name}:",
+                )
+            for state in updated_transform_states:
+                self._append_status(
+                    f"{state.display_name}: built direct Debye I(Q) for a "
+                    "single-atom cluster bin and skipped electron-density "
+                    "and Fourier-profile evaluation."
+                )
+            for group_key, artifacts in sorted(written_artifacts.items()):
+                self._append_status(
+                    f"Wrote {group_key} CSV to {artifacts.csv_path}"
+                )
+                self._append_status(
+                    f"Wrote {group_key} JSON to {artifacts.json_path}"
+                )
+        else:
+            self._reset_density_results()
+            self._set_calculation_overall_progress_visible(False)
+        self.calculation_progress_bar.setRange(0, 1)
+        self.calculation_progress_bar.setValue(0)
+        self.calculation_progress_bar.setFormat("%v / %m steps")
+        self.calculation_progress_message.setText(
+            "Electron-density calculation stopped."
+        )
+        self._set_calculation_running(False)
+        self._current_group_run_manual = False
+        self._refresh_run_action_state()
+        self._schedule_cluster_view_cache_prewarm()
+        self._append_status("Stopped the active electron-density calculation.")
+        self.statusBar().showMessage("Electron-density calculation stopped")
 
     @Slot()
     def _cleanup_calculation_thread(self) -> None:
@@ -2382,15 +11578,30 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         if self._calculation_thread is not None:
             self._calculation_thread.deleteLater()
             self._calculation_thread = None
+        self.stop_calculation_button.setEnabled(False)
+        self._refresh_run_action_state()
 
     @Slot()
     def _run_calculation(self) -> None:
         if self._structure is None or self._inspection is None:
-            self._show_error(
-                "No Structure Loaded",
-                "Load an XYZ or PDB structure before running the calculation.",
-            )
-            return
+            if not self._cluster_group_states:
+                self._show_error(
+                    "No Structure Loaded",
+                    "Load an XYZ or PDB structure before running the calculation.",
+                )
+                return
+        target_group_states = list(self._cluster_group_states)
+        self._current_group_run_manual = False
+        if self._cluster_group_states and self._manual_mode_enabled_for_run():
+            active_state = self._active_cluster_group_state()
+            if active_state is None:
+                self._show_error(
+                    "No Stoichiometry Selected",
+                    "Select a stoichiometry row before running manual mode.",
+                )
+                return
+            target_group_states = [active_state]
+            self._current_group_run_manual = True
         if self._active_mesh_geometry is None:
             self._apply_mesh_settings(
                 self._mesh_settings_from_controls(),
@@ -2405,37 +11616,158 @@ class ElectronDensityMappingMainWindow(QMainWindow):
                 "Wait for the current electron-density calculation to finish before starting another run.",
             )
             return
-        self._last_progress_message = ""
+        pending_mesh_settings = self._mesh_settings_from_controls()
+        needs_mesh_confirmation = (
+            pending_mesh_settings != self._active_mesh_settings
+            or not self._mesh_settings_confirmed_for_run
+        )
+        if needs_mesh_confirmation:
+            warning_lines: list[str] = []
+            if not self._mesh_settings_confirmed_for_run:
+                warning_lines.append(
+                    "Mesh settings were not updated from the defaults "
+                    "currently shown in the UI."
+                )
+            if pending_mesh_settings != self._active_mesh_settings:
+                warning_lines.append(
+                    "Pending mesh field values differ from the active mesh, "
+                    "so this calculation will use the last updated mesh "
+                    "instead of the values currently shown in the fields."
+                )
+            warning_lines.append(
+                "Active mesh: "
+                f"{self._format_mesh_settings_summary(self._active_mesh_settings)}; "
+                "center mode="
+                f"{self._center_mode_label_for_structure(self._structure)}."
+            )
+            if pending_mesh_settings != self._active_mesh_settings:
+                warning_lines.append(
+                    "Pending fields: "
+                    f"{self._format_mesh_settings_summary(pending_mesh_settings)}."
+                )
+            response = QMessageBox.question(
+                self,
+                "Mesh Settings Not Updated",
+                " ".join(warning_lines)
+                + " Proceed with the electron-density calculation?",
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
+            )
+            if response != QMessageBox.StandardButton.Yes:
+                self.statusBar().showMessage(
+                    "Electron-density calculation canceled",
+                    5000,
+                )
+                self._append_status(
+                    "Canceled electron-density calculation so the mesh "
+                    "settings can be reviewed."
+                )
+                return
+            self._set_mesh_settings_confirmed_for_run(True)
+        self._initial_workspace_load_timer.stop()
+        self._deferred_initial_input_path = None
+        self._deferred_restore_saved_distribution_state = False
+        self._calculation_cancel_requested = False
         self._set_calculation_running(True)
-        self.calculation_progress_bar.setRange(
-            0,
-            max(len(self._inspection.structure_files) * 2 + 3, 1),
-        )
-        self.calculation_progress_bar.setValue(0)
-        self.calculation_progress_message.setText(
-            "Preparing electron-density calculation..."
-        )
+        self.stop_calculation_button.setEnabled(True)
+        grouped_run = bool(self._cluster_group_states)
+        if grouped_run:
+            group_total = max(len(target_group_states), 1)
+            self._set_calculation_overall_progress_visible(True)
+            if self._current_group_run_manual:
+                completed_count = self._completed_cluster_group_count()
+                self.calculation_overall_progress_bar.setRange(
+                    0,
+                    max(len(self._cluster_group_states), 1),
+                )
+                self.calculation_overall_progress_bar.setValue(completed_count)
+                self.calculation_overall_progress_bar.setFormat(
+                    "%v / %m cluster groups"
+                )
+                self.calculation_overall_progress_message.setText(
+                    "Overall cluster progress: "
+                    f"{completed_count}/{len(self._cluster_group_states)} "
+                    "groups complete. Manual mode is running the selected row."
+                )
+            else:
+                self.calculation_overall_progress_bar.setRange(0, group_total)
+                self.calculation_overall_progress_bar.setValue(0)
+                self.calculation_overall_progress_bar.setFormat(
+                    "%v / %m cluster groups"
+                )
+                self.calculation_overall_progress_message.setText(
+                    "Overall cluster progress: "
+                    f"0/{len(target_group_states)} groups complete."
+                )
+            self.calculation_progress_bar.setRange(0, 1)
+            self.calculation_progress_bar.setValue(0)
+            self.calculation_progress_bar.setFormat("%v / %m steps")
+            self.calculation_progress_message.setText(
+                (
+                    "Preparing manual stoichiometry calculation..."
+                    if self._current_group_run_manual
+                    else "Waiting for the first cluster-group progress update..."
+                )
+            )
+        else:
+            self._set_calculation_overall_progress_visible(False)
+            self.calculation_progress_bar.setRange(
+                0,
+                max(len(self._inspection.structure_files) * 2 + 3, 1),
+            )
+            self.calculation_progress_bar.setValue(0)
+            self.calculation_progress_bar.setFormat("%v / %m steps")
+            self.calculation_progress_message.setText(
+                "Preparing electron-density calculation..."
+            )
         self.statusBar().showMessage("Computing electron-density profile...")
         self._calculation_thread = QThread(self)
         self._calculation_worker = ElectronDensityCalculationWorker(
             inspection=self._inspection,
+            reference_structure=self._structure,
             mesh_settings=self._active_mesh_settings,
             smearing_settings=self._smearing_settings_from_controls(),
             center_mode=self._structure.center_mode,
             reference_element=self._structure.reference_element,
             output_dir=self.output_dir_edit.text().strip(),
             output_basename=self._output_basename(),
+            use_contiguous_frame_mode=self._use_contiguous_frame_mode(),
+            grouped_inspections=tuple(
+                (state.key, state.inspection) for state in target_group_states
+            ),
+            grouped_reference_structures=tuple(
+                (state.key, state.reference_structure)
+                for state in target_group_states
+            ),
+            single_atom_group_keys=tuple(
+                state.key
+                for state in target_group_states
+                if state.single_atom_only
+            ),
+            debye_scattering_settings=self._fourier_settings_from_controls(),
         )
         self._calculation_worker.moveToThread(self._calculation_thread)
         self._calculation_thread.started.connect(self._calculation_worker.run)
+        self.cancel_calculation_requested.connect(
+            self._calculation_worker.cancel
+        )
         self._calculation_worker.progress.connect(
             self._on_calculation_progress
+        )
+        self._calculation_worker.overall_progress.connect(
+            self._on_calculation_overall_progress
         )
         self._calculation_worker.finished.connect(
             self._on_calculation_finished
         )
+        self._calculation_worker.canceled.connect(
+            self._on_calculation_canceled
+        )
         self._calculation_worker.failed.connect(self._on_calculation_failed)
         self._calculation_worker.finished.connect(
+            self._calculation_thread.quit
+        )
+        self._calculation_worker.canceled.connect(
             self._calculation_thread.quit
         )
         self._calculation_worker.failed.connect(self._calculation_thread.quit)
@@ -2443,6 +11775,133 @@ class ElectronDensityMappingMainWindow(QMainWindow):
             self._cleanup_calculation_thread
         )
         self._calculation_thread.start(QThread.Priority.LowPriority)
+
+    @staticmethod
+    def _build_plot_trace_columns(
+        *,
+        profile_result: ElectronDensityProfileResult | None,
+        fourier_preview: ElectronDensityFourierTransformPreview | None,
+        transform_result: ElectronDensityScatteringTransformResult | None,
+    ) -> tuple[list[str], list[list[str]]]:
+        headers: list[str] = []
+        columns: list[list[str]] = []
+
+        result = profile_result
+        if result is not None:
+            r_values = np.asarray(result.radial_centers, dtype=float)
+            raw_values = np.asarray(
+                result.orientation_average_density,
+                dtype=float,
+            )
+            raw_std = np.asarray(
+                result.orientation_density_stddev,
+                dtype=float,
+            )
+            smeared_values = np.asarray(
+                result.smeared_orientation_average_density,
+                dtype=float,
+            )
+            smeared_std = np.asarray(
+                result.smeared_orientation_density_stddev,
+                dtype=float,
+            )
+            headers += [
+                "r_center_a",
+                "raw_density_e_per_a3",
+                "raw_stddev_e_per_a3",
+                "smeared_density_e_per_a3",
+                "smeared_stddev_e_per_a3",
+            ]
+            columns += [
+                [f"{value:.10g}" for value in r_values],
+                [f"{value:.10g}" for value in raw_values],
+                [f"{value:.10g}" for value in raw_std],
+                [f"{value:.10g}" for value in smeared_values],
+                [f"{value:.10g}" for value in smeared_std],
+            ]
+            if result.solvent_contrast is not None:
+                residual = np.asarray(
+                    result.solvent_contrast.solvent_subtracted_smeared_density,
+                    dtype=float,
+                )
+                headers += [
+                    "solvent_density_e_per_a3",
+                    "solvent_subtracted_density_e_per_a3",
+                ]
+                columns += [
+                    [
+                        f"{float(result.solvent_contrast.solvent_density_e_per_a3):.10g}"
+                        for _value in r_values
+                    ],
+                    [f"{value:.10g}" for value in residual],
+                ]
+
+        preview = fourier_preview
+        if preview is not None:
+            preview_r = np.asarray(preview.resampled_r_values, dtype=float)
+            preview_density = np.asarray(
+                preview.resampled_density_values,
+                dtype=float,
+            )
+            windowed_density = np.asarray(
+                preview.windowed_density_values,
+                dtype=float,
+            )
+            headers += [
+                "fourier_preview_r_a",
+                "fourier_preview_resampled_density",
+                "fourier_preview_windowed_density",
+            ]
+            columns += [
+                [f"{value:.10g}" for value in preview_r],
+                [f"{value:.10g}" for value in preview_density],
+                [f"{value:.10g}" for value in windowed_density],
+            ]
+
+        ft_result = transform_result
+        if ft_result is not None:
+            q_values = np.asarray(ft_result.q_values, dtype=float)
+            amplitude = np.asarray(
+                ft_result.scattering_amplitude,
+                dtype=float,
+            )
+            intensity = np.asarray(ft_result.intensity, dtype=float)
+            headers += [
+                "q_a_inv",
+                "scattering_amplitude",
+                "intensity",
+            ]
+            columns += [
+                [f"{value:.10g}" for value in q_values],
+                [f"{value:.10g}" for value in amplitude],
+                [f"{value:.10g}" for value in intensity],
+            ]
+        return headers, columns
+
+    @staticmethod
+    def _write_plot_trace_csv(
+        csv_path: Path,
+        *,
+        profile_result: ElectronDensityProfileResult | None,
+        fourier_preview: ElectronDensityFourierTransformPreview | None,
+        transform_result: ElectronDensityScatteringTransformResult | None,
+    ) -> None:
+        headers, columns = (
+            ElectronDensityMappingMainWindow._build_plot_trace_columns(
+                profile_result=profile_result,
+                fourier_preview=fourier_preview,
+                transform_result=transform_result,
+            )
+        )
+        max_rows = max((len(column) for column in columns), default=0)
+        with csv_path.open("w", encoding="utf-8", newline="") as handle:
+            writer = csv.writer(handle)
+            writer.writerow(headers)
+            for row_index in range(max_rows):
+                writer.writerow(
+                    column[row_index] if row_index < len(column) else ""
+                    for column in columns
+                )
 
     @Slot()
     def _export_plot_traces(self) -> None:
@@ -2482,97 +11941,13 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         chosen_dir.mkdir(parents=True, exist_ok=True)
         basename = self._output_basename()
         csv_path = chosen_dir / f"{basename}_plot_traces.csv"
-
-        # Collect all trace columns
-        headers: list[str] = []
-        columns: list[list[str]] = []
-
-        result = self._profile_result
-        if result is not None:
-            r = np.asarray(result.radial_centers, dtype=float)
-            raw = np.asarray(result.orientation_average_density, dtype=float)
-            raw_std = np.asarray(
-                result.orientation_density_stddev, dtype=float
-            )
-            smeared = np.asarray(
-                result.smeared_orientation_average_density, dtype=float
-            )
-            smeared_std = np.asarray(
-                result.smeared_orientation_density_stddev, dtype=float
-            )
-            headers += [
-                "r_center_a",
-                "raw_density_e_per_a3",
-                "raw_stddev_e_per_a3",
-                "smeared_density_e_per_a3",
-                "smeared_stddev_e_per_a3",
-            ]
-            columns += [
-                [f"{v:.10g}" for v in r],
-                [f"{v:.10g}" for v in raw],
-                [f"{v:.10g}" for v in raw_std],
-                [f"{v:.10g}" for v in smeared],
-                [f"{v:.10g}" for v in smeared_std],
-            ]
-            if result.solvent_contrast is not None:
-                residual = np.asarray(
-                    result.solvent_contrast.solvent_subtracted_smeared_density,
-                    dtype=float,
-                )
-                headers += [
-                    "solvent_density_e_per_a3",
-                    "solvent_subtracted_density_e_per_a3",
-                ]
-                columns += [
-                    [
-                        f"{float(result.solvent_contrast.solvent_density_e_per_a3):.10g}"
-                        for _value in r
-                    ],
-                    [f"{v:.10g}" for v in residual],
-                ]
-
-        preview = self._fourier_preview
-        if preview is not None:
-            r_pre = np.asarray(preview.resampled_r_values, dtype=float)
-            d_pre = np.asarray(preview.resampled_density_values, dtype=float)
-            w_pre = np.asarray(preview.windowed_density_values, dtype=float)
-            headers += [
-                "fourier_preview_r_a",
-                "fourier_preview_resampled_density",
-                "fourier_preview_windowed_density",
-            ]
-            columns += [
-                [f"{v:.10g}" for v in r_pre],
-                [f"{v:.10g}" for v in d_pre],
-                [f"{v:.10g}" for v in w_pre],
-            ]
-
-        ft = self._fourier_result
-        if ft is not None:
-            q_vals = np.asarray(ft.q_values, dtype=float)
-            amp = np.asarray(ft.scattering_amplitude, dtype=float)
-            intensity = np.asarray(ft.intensity, dtype=float)
-            headers += [
-                "q_a_inv",
-                "scattering_amplitude",
-                "intensity",
-            ]
-            columns += [
-                [f"{v:.10g}" for v in q_vals],
-                [f"{v:.10g}" for v in amp],
-                [f"{v:.10g}" for v in intensity],
-            ]
-
-        max_rows = max((len(col) for col in columns), default=0)
         try:
-            with csv_path.open("w", encoding="utf-8", newline="") as handle:
-                writer = csv.writer(handle)
-                writer.writerow(headers)
-                for row_idx in range(max_rows):
-                    writer.writerow(
-                        col[row_idx] if row_idx < len(col) else ""
-                        for col in columns
-                    )
+            self._write_plot_trace_csv(
+                csv_path,
+                profile_result=self._profile_result,
+                fourier_preview=self._fourier_preview,
+                transform_result=self._fourier_result,
+            )
         except Exception as exc:
             self._show_error("Export Failed", str(exc))
             return
@@ -2593,6 +11968,31 @@ class ElectronDensityMappingMainWindow(QMainWindow):
         QMessageBox.critical(self, title, message)
         self.statusBar().showMessage(message, 5000)
 
+    def closeEvent(self, event: QCloseEvent) -> None:
+        self._initial_workspace_load_timer.stop()
+        self._cluster_view_cache_prewarm_timer.stop()
+        self._cluster_view_cache_prewarm_queue = []
+        self.structure_viewer.clear_scene_cache()
+        self._sync_workspace_state()
+        self._close_workspace_load_progress_dialog()
+        self._close_batch_operation_progress_dialog()
+        if (
+            self._calculation_worker is not None
+            and self._calculation_thread is not None
+            and self._calculation_thread.isRunning()
+        ):
+            self._calculation_worker.cancel()
+            self.cancel_calculation_requested.emit()
+            self._calculation_thread.quit()
+            self._calculation_thread.wait(1000)
+        if (
+            self._workspace_load_thread is not None
+            and self._workspace_load_thread.isRunning()
+        ):
+            self._workspace_load_thread.quit()
+            self._workspace_load_thread.wait(1000)
+        super().closeEvent(event)
+
 
 def _forget_open_window(window: ElectronDensityMappingMainWindow) -> None:
     if window in _OPEN_WINDOWS:
@@ -2603,6 +12003,13 @@ def launch_electron_density_mapping_ui(
     *,
     initial_project_dir: str | Path | None = None,
     initial_input_path: str | Path | None = None,
+    initial_output_dir: str | Path | None = None,
+    initial_project_q_min: float | None = None,
+    initial_project_q_max: float | None = None,
+    initial_distribution_id: str | None = None,
+    initial_distribution_root_dir: str | Path | None = None,
+    initial_use_predicted_structure_weights: bool = False,
+    preview_mode: bool = True,
 ) -> ElectronDensityMappingMainWindow:
     app = QApplication.instance()
     if app is None:
@@ -2615,11 +12022,33 @@ def launch_electron_density_mapping_ui(
             if initial_project_dir is None
             else Path(initial_project_dir).expanduser().resolve()
         ),
+        initial_input_path=None,
+        initial_output_dir=(
+            None
+            if initial_output_dir is None
+            else Path(initial_output_dir).expanduser().resolve()
+        ),
+        initial_project_q_min=initial_project_q_min,
+        initial_project_q_max=initial_project_q_max,
+        initial_distribution_id=initial_distribution_id,
+        initial_distribution_root_dir=(
+            None
+            if initial_distribution_root_dir is None
+            else Path(initial_distribution_root_dir).expanduser().resolve()
+        ),
+        initial_use_predicted_structure_weights=(
+            initial_use_predicted_structure_weights
+        ),
+        preview_mode=preview_mode,
+        restore_saved_distribution_state_on_init=False,
+    )
+    window.schedule_initial_workspace_load(
         initial_input_path=(
             None
             if initial_input_path is None
             else Path(initial_input_path).expanduser().resolve()
         ),
+        restore_saved_distribution_state=not preview_mode,
     )
     window.show()
     window.raise_()

--- a/src/saxshell/saxs/electron_density_mapping/ui/viewer.py
+++ b/src/saxshell/saxs/electron_density_mapping/ui/viewer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from collections import OrderedDict
+from dataclasses import dataclass, field
 
 import numpy as np
 from matplotlib.backend_bases import MouseButton
@@ -11,7 +12,7 @@ from matplotlib.backends.backend_qtagg import (
 from matplotlib.figure import Figure
 from matplotlib.lines import Line2D
 from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
-from PySide6.QtCore import Qt, QTimer
+from PySide6.QtCore import QSignalBlocker, Qt, QTimer
 from PySide6.QtGui import QColor
 from PySide6.QtWidgets import (
     QCheckBox,
@@ -20,6 +21,7 @@ from PySide6.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QPushButton,
+    QStackedWidget,
     QVBoxLayout,
     QWidget,
 )
@@ -60,6 +62,27 @@ _POINT_ATOM_SIZE = 26.0
 _ACTIVE_READOUT_COLOR = "#9ad8ff"
 _ACTIVE_READOUT_BACKGROUND = (0.05, 0.10, 0.17, 0.78)
 _VIEW_UPDATE_INTERVAL_MS = 16
+_DEFAULT_VIEW_RADIUS_REBASE = 0.5
+_SCENE_CACHE_MAX_BYTES = 96 * 1024 * 1024
+_SCENE_CACHE_MAX_ENTRIES = 20
+_SCENE_CACHE_BYTES_PER_PIXEL = 8
+_SCENE_KEY_SENTINEL = object()
+
+
+def _integrated_electron_total(
+    density_values: np.ndarray,
+    shell_volumes: np.ndarray,
+) -> float | None:
+    density_array = np.asarray(density_values, dtype=float)
+    shell_volume_array = np.asarray(shell_volumes, dtype=float)
+    if (
+        density_array.ndim != 1
+        or shell_volume_array.ndim != 1
+        or density_array.size == 0
+        or density_array.size != shell_volume_array.size
+    ):
+        return None
+    return float(np.sum(density_array * shell_volume_array))
 
 
 @dataclass(slots=True)
@@ -70,6 +93,39 @@ class ElectronDensityProfileOverlay:
     cutoff_label: str | None = None
     solvent_subtracted_density: np.ndarray | None = None
     solvent_subtracted_label: str | None = None
+
+
+@dataclass(slots=True)
+class ElectronDensityStructureViewerDisplayState:
+    view_center: np.ndarray = field(
+        default_factory=lambda: np.zeros(3, dtype=float)
+    )
+    view_radius: float = 1.0
+    scene_rotation: np.ndarray = field(
+        default_factory=lambda: np.eye(3, dtype=float)
+    )
+    mesh_visible: bool = True
+    atom_contrast: float = _DEFAULT_ATOM_CONTRAST
+    mesh_contrast: float = _DEFAULT_MESH_CONTRAST
+    mesh_linewidth: float = _DEFAULT_MESH_LINEWIDTH
+    mesh_color: str = _DEFAULT_MESH_COLOR
+    atom_render_mode: str = "points"
+    interaction_mode: str = "rotate"
+
+
+@dataclass(slots=True)
+class _ViewerSceneCacheEntry:
+    scene_key: str
+    figure: Figure
+    canvas: FigureCanvas
+    axis: object | None = None
+    axis_reference: object | None = None
+    active_settings_artist: object | None = None
+    structure: ElectronDensityStructure | None = None
+    mesh_geometry: ElectronDensityMeshGeometry | None = None
+    content_signature: tuple[int, int] | None = None
+    estimated_bytes: int = 0
+    complexity_score: float = 0.0
 
 
 def _clamp_fraction(value: float) -> float:
@@ -151,6 +207,7 @@ class ElectronDensityProfilePlot(QWidget):
         super().__init__(parent)
         self.current_result: ElectronDensityProfileResult | None = None
         self.current_overlay: ElectronDensityProfileOverlay | None = None
+        self.current_integrated_electron_count: float | None = None
         self._title = str(title)
         self._legend_label = str(legend_label)
         self._trace_color = str(trace_color)
@@ -178,6 +235,7 @@ class ElectronDensityProfilePlot(QWidget):
     def draw_placeholder(self) -> None:
         self.current_result = None
         self.current_overlay = None
+        self.current_integrated_electron_count = None
         self.figure.clear()
         axis = self.figure.add_subplot(111)
         axis.text(
@@ -227,6 +285,10 @@ class ElectronDensityProfilePlot(QWidget):
                 getattr(result, self._spread_attribute),
                 dtype=float,
             )
+        self.current_integrated_electron_count = _integrated_electron_total(
+            density_values,
+            np.asarray(result.shell_volumes, dtype=float),
+        )
         if self._as_step_trace:
             axis.step(
                 radial_values,
@@ -346,6 +408,23 @@ class ElectronDensityProfilePlot(QWidget):
                 linestyle="--",
                 alpha=0.95,
                 label=overlay.cutoff_label or "Cutoff",
+            )
+        if self.current_integrated_electron_count is not None:
+            axis.text(
+                0.015,
+                0.985,
+                "Integrated electrons: "
+                f"{self.current_integrated_electron_count:.6f}",
+                ha="left",
+                va="top",
+                fontsize=9,
+                transform=axis.transAxes,
+                bbox={
+                    "boxstyle": "round,pad=0.25",
+                    "facecolor": "#ffffff",
+                    "edgecolor": "#cbd5e1",
+                    "alpha": 0.92,
+                },
             )
         axis.set_xlabel("r (Å)")
         axis.set_ylabel("ρ(r) (e/Å³)")
@@ -507,14 +586,39 @@ class ElectronDensityFourierPreviewPlot(QWidget):
         self.canvas.setMinimumHeight(280)
         layout.addWidget(self.canvas, stretch=1)
 
+    @staticmethod
+    def _style_axis(axis) -> None:
+        axis.set_facecolor("#fbfcfe")
+        axis.grid(
+            True, which="major", color="#cbd5e1", alpha=0.45, linewidth=0.8
+        )
+        axis.grid(
+            True, which="minor", color="#e2e8f0", alpha=0.30, linewidth=0.55
+        )
+        axis.minorticks_on()
+        axis.axhline(0.0, color="#64748b", linewidth=0.9, alpha=0.35, zorder=0)
+        axis.axvline(0.0, color="#64748b", linewidth=1.1, alpha=0.55, zorder=0)
+        axis.spines["top"].set_visible(False)
+        axis.spines["right"].set_visible(False)
+        axis.spines["left"].set_color("#94a3b8")
+        axis.spines["bottom"].set_color("#94a3b8")
+        axis.tick_params(
+            axis="both",
+            which="both",
+            colors="#475569",
+            labelsize=8.5,
+            width=0.8,
+        )
+
     def draw_placeholder(self) -> None:
         self.current_preview = None
         self.figure.clear()
         axis = self.figure.add_subplot(111)
+        self._style_axis(axis)
         axis.text(
             0.5,
             0.60,
-            "Run the electron-density calculation to prepare the Fourier-transform preview.",
+            "Run the electron-density calculation to prepare the mirrored Fourier-transform preview.",
             ha="center",
             va="center",
             wrap=True,
@@ -523,8 +627,8 @@ class ElectronDensityFourierPreviewPlot(QWidget):
         axis.text(
             0.5,
             0.40,
-            "This panel will show the smeared ρ(r), the selected transform bounds, "
-            "the resampled points, and the active modification window.",
+            "This panel will show the real-space trace that is actually sent "
+            "into the transform over the active r domain.",
             ha="center",
             va="center",
             wrap=True,
@@ -544,100 +648,61 @@ class ElectronDensityFourierPreviewPlot(QWidget):
         self.current_preview = preview
         self.figure.clear()
         axis = self.figure.add_subplot(111)
+        self._style_axis(axis)
         settings = preview.settings
-        full_r = np.asarray(preview.source_radial_values, dtype=float)
-        full_density = np.asarray(preview.source_density_values, dtype=float)
-        resampled_r = np.asarray(preview.resampled_r_values, dtype=float)
-        resampled_density = np.asarray(
-            preview.resampled_density_values, dtype=float
+        plot_r = np.asarray(preview.resampled_r_values, dtype=float)
+        plot_density = np.asarray(preview.windowed_density_values, dtype=float)
+        plot_r_max = float(np.max(np.abs(plot_r))) if plot_r.size else 0.0
+        plot_r_max = max(plot_r_max, float(settings.r_max), 1.0e-6)
+        trace_label = (
+            f"Windowed {preview.source_profile_label}"
+            if settings.window_function != "none"
+            else preview.source_profile_label
         )
-        windowed_density = np.asarray(
-            preview.windowed_density_values, dtype=float
+        mirrored_mode = (
+            getattr(settings, "domain_mode", "legacy") == "mirrored"
         )
-        window_values = np.asarray(preview.window_values, dtype=float)
 
-        axis.plot(
-            full_r,
-            full_density,
-            color="#9bd5a6",
-            linewidth=1.6,
-            alpha=0.95,
-            label=preview.source_profile_label,
-        )
-        axis.axvspan(
-            float(settings.r_min),
-            float(settings.r_max),
-            color="#dbeafe",
-            alpha=0.45,
-            label="Transform bounds",
+        axis.fill_between(
+            plot_r,
+            plot_density,
+            0.0,
+            color="#99f6e4",
+            alpha=0.28,
+            linewidth=0.0,
+            zorder=1,
         )
         axis.plot(
-            resampled_r,
-            resampled_density,
-            color="#22c55e",
-            linewidth=1.3,
-            alpha=0.70,
-            label=f"Resampled {preview.source_profile_label}",
+            plot_r,
+            plot_density,
+            color="#0f766e",
+            linewidth=2.25,
+            label=trace_label,
+            zorder=2,
         )
-        axis.plot(
-            resampled_r,
-            windowed_density,
-            color="#15803d",
-            linewidth=2.2,
-            label=f"Windowed {preview.source_profile_label}",
-        )
-        sample_stride = max(int(np.ceil(len(resampled_r) / 80.0)), 1)
-        axis.scatter(
-            resampled_r[::sample_stride],
-            resampled_density[::sample_stride],
-            s=10,
-            color="#14532d",
-            alpha=0.55,
-            label="Resampled points",
-            zorder=3,
-        )
-        window_axis = axis.twinx()
-        window_axis.plot(
-            resampled_r,
-            window_values,
-            color="#7c3aed",
-            linewidth=1.5,
-            linestyle="--",
-            alpha=0.95,
-            label=f"Window ({settings.window_function})",
-        )
-        window_axis.set_ylabel("Window")
-        window_axis.set_ylim(-0.05, 1.10)
-        axis.set_xlabel("r (Å)")
+        if mirrored_mode:
+            axis.set_xlim(-plot_r_max * 1.02, plot_r_max * 1.02)
+        else:
+            axis.set_xlim(float(np.min(plot_r)), float(np.max(plot_r)) * 1.02)
+        axis.set_xlabel("Mirrored r (Å)" if mirrored_mode else "r (Å)")
         axis.set_ylabel("ρ(r) (e/Å³)")
-        axis.set_title("Fourier-Transform Preparation")
-        axis.grid(True, alpha=0.28)
-        handles, labels = axis.get_legend_handles_labels()
-        window_handles, window_labels = window_axis.get_legend_handles_labels()
-        axis.legend(
-            handles + window_handles,
-            labels + window_labels,
-            loc="upper right",
-            frameon=True,
-            fontsize=8.1,
-        )
+        axis.set_title("Fourier-Transform Preparation", loc="left", pad=10)
         axis.text(
-            0.02,
-            0.02,
-            (
-                f"Δr={preview.resampling_step_a:.4f} Å | "
-                f"Nyquist qmax≈{preview.nyquist_q_max_a_inverse:.3f} Å⁻¹ | "
-                f"Independent Δq≈{preview.independent_q_step_a_inverse:.3f} Å⁻¹"
-            ),
+            0.99,
+            0.98,
+            "source: "
+            f"{preview.source_profile_label}  ·  "
+            f"window: {settings.window_function}  ·  "
+            f"points: {settings.resampling_points}",
+            ha="right",
+            va="top",
             transform=axis.transAxes,
-            ha="left",
-            va="bottom",
             fontsize=8.0,
-            color="#334155",
+            color="#475569",
             bbox={
-                "facecolor": "#f8fafc",
+                "boxstyle": "round,pad=0.25",
+                "facecolor": "#ffffff",
                 "edgecolor": "#cbd5e1",
-                "boxstyle": "round,pad=0.28",
                 "alpha": 0.92,
             },
         )
@@ -698,6 +763,9 @@ class ElectronDensityScatteringPlot(QWidget):
         *,
         log_q_axis: bool,
         log_intensity_axis: bool,
+        additional_series: list[dict[str, object]] | None = None,
+        primary_label: str = "Born-approximation intensity",
+        primary_color: str = "#b45309",
     ) -> None:
         if result is None:
             self.draw_placeholder()
@@ -730,10 +798,31 @@ class ElectronDensityScatteringPlot(QWidget):
         axis.plot(
             plot_q,
             plot_intensity,
-            color="#b45309",
+            color=str(primary_color),
             linewidth=2.2,
-            label="Born-approximation intensity",
+            label=str(primary_label),
         )
+        for series in additional_series or []:
+            raw_q = np.asarray(series.get("q_values"), dtype=float)
+            raw_intensity = np.asarray(series.get("intensity"), dtype=float)
+            overlay_mask = np.ones_like(raw_q, dtype=bool)
+            if log_q_axis:
+                overlay_mask &= raw_q > 0.0
+            if log_intensity_axis:
+                overlay_mask &= raw_intensity > 0.0
+            overlay_q = raw_q[overlay_mask]
+            overlay_intensity = raw_intensity[overlay_mask]
+            if overlay_q.size == 0 or overlay_intensity.size == 0:
+                continue
+            axis.plot(
+                overlay_q,
+                overlay_intensity,
+                color=str(series.get("color") or "#64748b"),
+                linewidth=1.3,
+                alpha=0.78,
+                linestyle="--",
+                label=str(series.get("label") or "Additional transform"),
+            )
         if log_q_axis:
             axis.set_xscale("log")
         if log_intensity_axis:
@@ -743,28 +832,7 @@ class ElectronDensityScatteringPlot(QWidget):
         axis.set_title("q-Space Scattering Profile")
         axis.grid(True, which="both", alpha=0.28)
         axis.legend(loc="upper right", frameon=True)
-        settings = result.preview.settings
-        axis.text(
-            0.02,
-            0.02,
-            (
-                f"Window={settings.window_function} | "
-                f"r={settings.r_min:.3f} to {settings.r_max:.3f} Å | "
-                f"{len(result.q_values)} q points"
-            ),
-            transform=axis.transAxes,
-            ha="left",
-            va="bottom",
-            fontsize=8.0,
-            color="#7c2d12",
-            bbox={
-                "facecolor": "#fff7ed",
-                "edgecolor": "#fdba74",
-                "boxstyle": "round,pad=0.28",
-                "alpha": 0.92,
-            },
-        )
-        self.figure.tight_layout(rect=(0.0, 0.06, 1.0, 1.0))
+        self.figure.tight_layout()
         self.canvas.draw_idle()
 
 
@@ -782,6 +850,7 @@ class ElectronDensityStructureViewer(QWidget):
         self.canvas = _PassiveWheelFigureCanvas(self.figure)
         self._axis = None
         self._axis_reference = None
+        self._active_settings_artist = None
         self._view_center = np.zeros(3, dtype=float)
         self._view_radius = 1.0
         self._interaction_mode = "rotate"
@@ -796,15 +865,26 @@ class ElectronDensityStructureViewer(QWidget):
         self._mesh_contrast = _DEFAULT_MESH_CONTRAST
         self._mesh_linewidth = _DEFAULT_MESH_LINEWIDTH
         self._mesh_color = _DEFAULT_MESH_COLOR
-        self._atom_render_mode = "balls"
+        self._atom_render_mode = "points"
         self._pending_view_update = False
         self._pending_axis_reference_refresh = False
+        self._scene_cache: OrderedDict[str, _ViewerSceneCacheEntry] = (
+            OrderedDict()
+        )
+        self._scene_display_states: dict[
+            str,
+            ElectronDensityStructureViewerDisplayState,
+        ] = {}
+        self._active_scene_key: str | None = None
+        self._scratch_scene: _ViewerSceneCacheEntry | None = None
+        self._scene_cache_max_bytes = _SCENE_CACHE_MAX_BYTES
+        self._scene_cache_max_entries = _SCENE_CACHE_MAX_ENTRIES
+        self._scene_cache_bytes_per_pixel = _SCENE_CACHE_BYTES_PER_PIXEL
         self._view_update_timer = QTimer(self)
         self._view_update_timer.setSingleShot(True)
         self._view_update_timer.setTimerType(Qt.TimerType.PreciseTimer)
         self._view_update_timer.timeout.connect(self._flush_view_update)
         self._build_ui()
-        self._connect_canvas_events()
         self.draw_placeholder()
 
     def _build_ui(self) -> None:
@@ -898,6 +978,7 @@ class ElectronDensityStructureViewer(QWidget):
         contrast_row.addWidget(self.mesh_color_button)
 
         self.point_atoms_checkbox = QCheckBox("Point Atoms")
+        self.point_atoms_checkbox.setChecked(True)
         self.point_atoms_checkbox.toggled.connect(
             self._handle_point_atoms_toggle
         )
@@ -906,15 +987,30 @@ class ElectronDensityStructureViewer(QWidget):
         layout.addLayout(contrast_row)
         self._update_mesh_color_button_style()
 
-        self.canvas.setMinimumHeight(520)
-        layout.addWidget(self.canvas, stretch=1)
+        self._canvas_stack = QStackedWidget(self)
+        self._canvas_stack.setMinimumHeight(380)
+        layout.addWidget(self._canvas_stack, stretch=1)
         self.setMinimumHeight(self.minimumSizeHint().height())
+        self._scratch_scene = self._create_scene_entry("__scratch__")
+        self._activate_scene_entry(self._scratch_scene, scene_key=None)
         self._set_interaction_mode("rotate")
 
-    def _connect_canvas_events(self) -> None:
-        self.canvas.mpl_connect("button_press_event", self._handle_press)
-        self.canvas.mpl_connect("button_release_event", self._handle_release)
-        self.canvas.mpl_connect("motion_notify_event", self._handle_motion)
+    def _connect_canvas_events(self, canvas: FigureCanvas) -> None:
+        canvas.mpl_connect("button_press_event", self._handle_press)
+        canvas.mpl_connect("button_release_event", self._handle_release)
+        canvas.mpl_connect("motion_notify_event", self._handle_motion)
+
+    def _create_scene_entry(self, scene_key: str) -> _ViewerSceneCacheEntry:
+        figure = Figure(figsize=(8.4, 6.2))
+        canvas = _PassiveWheelFigureCanvas(figure)
+        canvas.setMinimumHeight(520)
+        self._connect_canvas_events(canvas)
+        self._canvas_stack.addWidget(canvas)
+        return _ViewerSceneCacheEntry(
+            scene_key=str(scene_key),
+            figure=figure,
+            canvas=canvas,
+        )
 
     def _set_interaction_mode(self, mode: str) -> None:
         if mode not in {"rotate", "pan", "zoom"}:
@@ -937,9 +1033,321 @@ class ElectronDensityStructureViewer(QWidget):
             cursor = Qt.CursorShape.OpenHandCursor
         self.canvas.setCursor(cursor)
 
+    def _capture_display_state(
+        self,
+    ) -> ElectronDensityStructureViewerDisplayState:
+        return ElectronDensityStructureViewerDisplayState(
+            view_center=np.asarray(self._view_center, dtype=float).copy(),
+            view_radius=max(float(self._view_radius), 0.2),
+            scene_rotation=np.asarray(
+                self._scene_rotation,
+                dtype=float,
+            ).copy(),
+            mesh_visible=bool(self._mesh_visible),
+            atom_contrast=_clamp_fraction(self._atom_contrast),
+            mesh_contrast=_clamp_fraction(self._mesh_contrast),
+            mesh_linewidth=max(float(self._mesh_linewidth), 0.2),
+            mesh_color=str(self._mesh_color),
+            atom_render_mode=str(self._atom_render_mode),
+            interaction_mode=str(self._interaction_mode),
+        )
+
+    def _apply_display_state(
+        self,
+        state: ElectronDensityStructureViewerDisplayState,
+        *,
+        sync_controls: bool,
+    ) -> None:
+        self._view_center = np.asarray(state.view_center, dtype=float).copy()
+        self._view_radius = max(float(state.view_radius), 0.2)
+        self._scene_rotation = _orthonormalize_rotation(
+            np.asarray(state.scene_rotation, dtype=float)
+        )
+        self._mesh_visible = bool(state.mesh_visible)
+        self._atom_contrast = _clamp_fraction(state.atom_contrast)
+        self._mesh_contrast = _clamp_fraction(state.mesh_contrast)
+        self._mesh_linewidth = max(float(state.mesh_linewidth), 0.2)
+        self._mesh_color = str(state.mesh_color)
+        self._atom_render_mode = (
+            "points" if str(state.atom_render_mode) == "points" else "balls"
+        )
+        self._interaction_mode = (
+            str(state.interaction_mode)
+            if str(state.interaction_mode) in {"rotate", "pan", "zoom"}
+            else "rotate"
+        )
+        self._update_mesh_color_button_style()
+        if not sync_controls:
+            return
+        blockers = [
+            QSignalBlocker(widget)
+            for widget in (
+                self.rotate_button,
+                self.pan_button,
+                self.zoom_button,
+                self.show_mesh_checkbox,
+                self.atom_contrast_spin,
+                self.mesh_contrast_spin,
+                self.mesh_linewidth_spin,
+                self.point_atoms_checkbox,
+            )
+        ]
+        try:
+            self.rotate_button.setChecked(self._interaction_mode == "rotate")
+            self.pan_button.setChecked(self._interaction_mode == "pan")
+            self.zoom_button.setChecked(self._interaction_mode == "zoom")
+            self.show_mesh_checkbox.setChecked(self._mesh_visible)
+            self.atom_contrast_spin.setValue(self._atom_contrast * 100.0)
+            self.mesh_contrast_spin.setValue(self._mesh_contrast * 100.0)
+            self.mesh_linewidth_spin.setValue(self._mesh_linewidth)
+            self.point_atoms_checkbox.setChecked(
+                self._atom_render_mode == "points"
+            )
+        finally:
+            del blockers
+        self._update_canvas_cursor()
+
+    def _scene_signature(
+        self,
+        structure: ElectronDensityStructure,
+        mesh_geometry: ElectronDensityMeshGeometry | None,
+    ) -> tuple[int, int]:
+        return (
+            id(structure),
+            0 if mesh_geometry is None else id(mesh_geometry),
+        )
+
+    def _estimated_scene_bytes(self, canvas: FigureCanvas) -> int:
+        width = max(int(canvas.width()), int(canvas.minimumWidth()), 1)
+        height = max(int(canvas.height()), int(canvas.minimumHeight()), 1)
+        return int(width * height * self._scene_cache_bytes_per_pixel)
+
+    def _activate_scene_entry(
+        self,
+        entry: _ViewerSceneCacheEntry,
+        *,
+        scene_key: str | None,
+    ) -> None:
+        self.figure = entry.figure
+        self.canvas = entry.canvas
+        self._axis = entry.axis
+        self._axis_reference = entry.axis_reference
+        self._active_settings_artist = entry.active_settings_artist
+        self.current_structure = entry.structure
+        self.current_mesh_geometry = entry.mesh_geometry
+        self._active_scene_key = scene_key
+        self._canvas_stack.setCurrentWidget(entry.canvas)
+        if scene_key is not None:
+            state = self._scene_display_states.get(scene_key)
+            if state is not None:
+                self._apply_display_state(state, sync_controls=True)
+        self._update_canvas_cursor()
+
+    def _default_scene_state(
+        self,
+        structure: ElectronDensityStructure,
+        *,
+        mesh_geometry: ElectronDensityMeshGeometry | None,
+        reset_view: bool,
+        preserve_zoom_percentage: float | None,
+    ) -> ElectronDensityStructureViewerDisplayState:
+        if reset_view:
+            view_center = np.zeros(3, dtype=float)
+            scene_rotation = np.eye(3, dtype=float)
+            view_radius = self._view_radius_for_zoom_percentage(
+                structure,
+                preserve_zoom_percentage,
+                mesh_geometry=mesh_geometry,
+            )
+        else:
+            view_center = np.asarray(self._view_center, dtype=float).copy()
+            scene_rotation = np.asarray(
+                self._scene_rotation,
+                dtype=float,
+            ).copy()
+            view_radius = max(float(self._view_radius), 0.2)
+        return ElectronDensityStructureViewerDisplayState(
+            view_center=view_center,
+            view_radius=view_radius,
+            scene_rotation=scene_rotation,
+            mesh_visible=bool(self._mesh_visible),
+            atom_contrast=_clamp_fraction(self._atom_contrast),
+            mesh_contrast=_clamp_fraction(self._mesh_contrast),
+            mesh_linewidth=max(float(self._mesh_linewidth), 0.2),
+            mesh_color=str(self._mesh_color),
+            atom_render_mode=str(self._atom_render_mode),
+            interaction_mode=str(self._interaction_mode),
+        )
+
+    def _sync_active_scene_cache_entry(self) -> None:
+        if self._active_scene_key is None:
+            return
+        entry = self._scene_cache.get(self._active_scene_key)
+        if entry is None:
+            return
+        entry.axis = self._axis
+        entry.axis_reference = self._axis_reference
+        entry.active_settings_artist = self._active_settings_artist
+        entry.structure = self.current_structure
+        entry.mesh_geometry = self.current_mesh_geometry
+        if self.current_structure is not None:
+            entry.content_signature = self._scene_signature(
+                self.current_structure,
+                self.current_mesh_geometry,
+            )
+        else:
+            entry.content_signature = None
+        entry.estimated_bytes = self._estimated_scene_bytes(entry.canvas)
+        self._scene_display_states[self._active_scene_key] = (
+            self._capture_display_state()
+        )
+
+    def _mark_scene_recent(self, scene_key: str) -> None:
+        if scene_key not in self._scene_cache:
+            return
+        entry = self._scene_cache.pop(scene_key)
+        self._scene_cache[scene_key] = entry
+
+    def _remove_cached_scene(self, scene_key: str) -> None:
+        entry = self._scene_cache.pop(scene_key, None)
+        if entry is None:
+            return
+        self._canvas_stack.removeWidget(entry.canvas)
+        entry.figure.clear()
+        entry.canvas.setParent(None)
+        entry.canvas.deleteLater()
+
+    def _enforce_scene_cache_budget(self) -> None:
+        if not self._scene_cache:
+            return
+        total_bytes = sum(
+            max(int(entry.estimated_bytes), 1)
+            for entry in self._scene_cache.values()
+        )
+        while (
+            len(self._scene_cache) > self._scene_cache_max_entries
+            or total_bytes > self._scene_cache_max_bytes
+        ):
+            evicted_key = None
+            for candidate_key in self._scene_cache:
+                if candidate_key != self._active_scene_key:
+                    evicted_key = candidate_key
+                    break
+            if evicted_key is None:
+                break
+            evicted = self._scene_cache.get(evicted_key)
+            total_bytes -= (
+                0 if evicted is None else max(int(evicted.estimated_bytes), 1)
+            )
+            self._remove_cached_scene(evicted_key)
+
+    def clear_scene_cache(self, *, clear_display_states: bool = True) -> None:
+        self._clear_pending_view_update()
+        if self._scratch_scene is not None:
+            self._activate_scene_entry(self._scratch_scene, scene_key=None)
+        for scene_key in list(self._scene_cache):
+            self._remove_cached_scene(scene_key)
+        self._scene_cache.clear()
+        if clear_display_states:
+            self._scene_display_states.clear()
+        self._active_scene_key = None
+
+    def _render_cached_scene(
+        self,
+        entry: _ViewerSceneCacheEntry,
+        *,
+        scene_key: str,
+        structure: ElectronDensityStructure,
+        mesh_geometry: ElectronDensityMeshGeometry | None,
+        display_state: ElectronDensityStructureViewerDisplayState,
+        complexity_score: float,
+        activate: bool,
+        persist_display_state: bool,
+    ) -> None:
+        previous_context = None
+        if not activate:
+            previous_context = (
+                self.figure,
+                self.canvas,
+                self._axis,
+                self._axis_reference,
+                self._active_settings_artist,
+                self.current_structure,
+                self.current_mesh_geometry,
+                self._active_scene_key,
+                self._capture_display_state(),
+                self._canvas_stack.currentWidget(),
+            )
+        try:
+            if activate:
+                self._activate_scene_entry(entry, scene_key=scene_key)
+            else:
+                self.figure = entry.figure
+                self.canvas = entry.canvas
+                self._axis = entry.axis
+                self._axis_reference = entry.axis_reference
+                self._active_settings_artist = entry.active_settings_artist
+                self.current_structure = structure
+                self.current_mesh_geometry = mesh_geometry
+                self._active_scene_key = (
+                    scene_key if persist_display_state else None
+                )
+            self.current_structure = structure
+            self.current_mesh_geometry = mesh_geometry
+            self._apply_display_state(
+                display_state,
+                sync_controls=activate,
+            )
+            self._draw_view(reset_view=False)
+            if not activate:
+                entry.canvas.draw()
+            entry.axis = self._axis
+            entry.axis_reference = self._axis_reference
+            entry.active_settings_artist = self._active_settings_artist
+            entry.structure = structure
+            entry.mesh_geometry = mesh_geometry
+            entry.content_signature = self._scene_signature(
+                structure,
+                mesh_geometry,
+            )
+            entry.complexity_score = float(complexity_score)
+            entry.estimated_bytes = self._estimated_scene_bytes(entry.canvas)
+            if persist_display_state:
+                self._scene_display_states[scene_key] = (
+                    self._capture_display_state()
+                )
+            else:
+                self._scene_display_states.pop(scene_key, None)
+            self._mark_scene_recent(scene_key)
+            self._enforce_scene_cache_budget()
+        finally:
+            if previous_context is not None:
+                (
+                    self.figure,
+                    self.canvas,
+                    self._axis,
+                    self._axis_reference,
+                    self._active_settings_artist,
+                    self.current_structure,
+                    self.current_mesh_geometry,
+                    self._active_scene_key,
+                    previous_display_state,
+                    current_widget,
+                ) = previous_context
+                self._apply_display_state(
+                    previous_display_state,
+                    sync_controls=False,
+                )
+                if current_widget is not None:
+                    self._canvas_stack.setCurrentWidget(current_widget)
+                self._update_canvas_cursor()
+
     def draw_placeholder(self) -> None:
+        if self._scratch_scene is not None:
+            self._activate_scene_entry(self._scratch_scene, scene_key=None)
         self.current_structure = None
         self._clear_pending_view_update()
+        self._active_settings_artist = None
         self.figure.clear()
         axis = self.figure.add_subplot(111)
         axis.text(
@@ -965,6 +1373,8 @@ class ElectronDensityStructureViewer(QWidget):
         )
         axis.set_axis_off()
         self.canvas.draw_idle()
+        self._axis = axis
+        self._axis_reference = None
 
     def set_structure(
         self,
@@ -972,13 +1382,79 @@ class ElectronDensityStructureViewer(QWidget):
         *,
         mesh_geometry: ElectronDensityMeshGeometry | None = None,
         reset_view: bool = True,
+        preserve_zoom_percentage: float | None = None,
+        scene_key: str | None | object = _SCENE_KEY_SENTINEL,
+        render_complexity: float | None = None,
     ) -> None:
         if structure is None:
             self.draw_placeholder()
             return
-        self.current_structure = structure
-        self.current_mesh_geometry = mesh_geometry
-        self._draw_view(reset_view=reset_view)
+        self._sync_active_scene_cache_entry()
+        resolved_scene_key = (
+            self._active_scene_key
+            if scene_key is _SCENE_KEY_SENTINEL
+            else (None if scene_key is None else str(scene_key))
+        )
+        if resolved_scene_key is None:
+            if self._scratch_scene is not None:
+                self._activate_scene_entry(self._scratch_scene, scene_key=None)
+            self.current_structure = structure
+            self.current_mesh_geometry = mesh_geometry
+            self._draw_view(
+                reset_view=reset_view,
+                preserve_zoom_percentage=preserve_zoom_percentage,
+            )
+            return
+        signature = self._scene_signature(structure, mesh_geometry)
+        cached_entry = self._scene_cache.get(resolved_scene_key)
+        persisted_display_state = self._scene_display_states.get(
+            resolved_scene_key
+        )
+        if (
+            cached_entry is not None
+            and cached_entry.content_signature == signature
+            and persisted_display_state is not None
+        ):
+            self._activate_scene_entry(
+                cached_entry,
+                scene_key=resolved_scene_key,
+            )
+            self.current_structure = structure
+            self.current_mesh_geometry = mesh_geometry
+            self._mark_scene_recent(resolved_scene_key)
+            self.canvas.update()
+            return
+        if persisted_display_state is None:
+            display_state = self._default_scene_state(
+                structure,
+                mesh_geometry=mesh_geometry,
+                reset_view=reset_view,
+                preserve_zoom_percentage=preserve_zoom_percentage,
+            )
+        else:
+            display_state = persisted_display_state
+        if display_state is None:
+            display_state = self._default_scene_state(
+                structure,
+                mesh_geometry=mesh_geometry,
+                reset_view=reset_view,
+                preserve_zoom_percentage=preserve_zoom_percentage,
+            )
+        if cached_entry is None:
+            cached_entry = self._create_scene_entry(resolved_scene_key)
+            self._scene_cache[resolved_scene_key] = cached_entry
+        self._render_cached_scene(
+            cached_entry,
+            scene_key=resolved_scene_key,
+            structure=structure,
+            mesh_geometry=mesh_geometry,
+            display_state=display_state,
+            complexity_score=(
+                0.0 if render_complexity is None else float(render_complexity)
+            ),
+            activate=True,
+            persist_display_state=True,
+        )
 
     def set_structure_preserving_display(
         self,
@@ -989,19 +1465,12 @@ class ElectronDensityStructureViewer(QWidget):
         if structure is None:
             self.draw_placeholder()
             return
+        self._sync_active_scene_cache_entry()
         self.current_structure = structure
         self.current_mesh_geometry = mesh_geometry
-        self._atom_contrast = _clamp_fraction(
-            float(self.atom_contrast_spin.value()) / 100.0
-        )
-        self._mesh_contrast = _clamp_fraction(
-            float(self.mesh_contrast_spin.value()) / 100.0
-        )
-        self._mesh_linewidth = max(
-            float(self.mesh_linewidth_spin.value()), 0.2
-        )
-        self._atom_render_mode = (
-            "points" if self.point_atoms_checkbox.isChecked() else "balls"
+        self._apply_display_state(
+            self._capture_display_state(),
+            sync_controls=True,
         )
         self._draw_view(reset_view=False)
 
@@ -1012,6 +1481,69 @@ class ElectronDensityStructureViewer(QWidget):
         self.current_mesh_geometry = mesh_geometry
         if self.current_structure is not None:
             self._draw_view(reset_view=False)
+
+    def prewarm_scene(
+        self,
+        scene_key: str,
+        *,
+        structure: ElectronDensityStructure,
+        mesh_geometry: ElectronDensityMeshGeometry | None = None,
+        complexity_score: float = 0.0,
+    ) -> bool:
+        resolved_scene_key = str(scene_key)
+        self._sync_active_scene_cache_entry()
+        signature = self._scene_signature(structure, mesh_geometry)
+        cached_entry = self._scene_cache.get(resolved_scene_key)
+        if (
+            cached_entry is not None
+            and cached_entry.content_signature == signature
+        ):
+            cached_entry.complexity_score = float(complexity_score)
+            self._mark_scene_recent(resolved_scene_key)
+            self._enforce_scene_cache_budget()
+            return False
+        if (
+            cached_entry is None
+            and len(self._scene_cache) >= self._scene_cache_max_entries
+        ):
+            evictable_entries = [
+                entry
+                for key, entry in self._scene_cache.items()
+                if key != self._active_scene_key
+            ]
+            if evictable_entries:
+                lowest_complexity_entry = min(
+                    evictable_entries,
+                    key=lambda entry: float(entry.complexity_score),
+                )
+                if float(complexity_score) <= float(
+                    lowest_complexity_entry.complexity_score
+                ):
+                    return False
+                self._remove_cached_scene(lowest_complexity_entry.scene_key)
+        display_state = self._scene_display_states.get(resolved_scene_key)
+        persist_display_state = display_state is not None
+        if display_state is None:
+            display_state = self._default_scene_state(
+                structure,
+                mesh_geometry=mesh_geometry,
+                reset_view=True,
+                preserve_zoom_percentage=100.0,
+            )
+        if cached_entry is None:
+            cached_entry = self._create_scene_entry(resolved_scene_key)
+            self._scene_cache[resolved_scene_key] = cached_entry
+        self._render_cached_scene(
+            cached_entry,
+            scene_key=resolved_scene_key,
+            structure=structure,
+            mesh_geometry=mesh_geometry,
+            display_state=display_state,
+            complexity_score=complexity_score,
+            activate=False,
+            persist_display_state=persist_display_state,
+        )
+        return True
 
     def autoscale_view(self) -> None:
         if self.current_structure is None:
@@ -1028,14 +1560,36 @@ class ElectronDensityStructureViewer(QWidget):
     def _default_view_radius(
         self,
         structure: ElectronDensityStructure,
+        *,
+        mesh_geometry: ElectronDensityMeshGeometry | None = None,
+    ) -> float:
+        legacy_radius = self._legacy_default_view_radius(
+            structure,
+            mesh_geometry=mesh_geometry,
+        )
+        return max(
+            legacy_radius * _DEFAULT_VIEW_RADIUS_REBASE,
+            0.2,
+        )
+
+    def _legacy_default_view_radius(
+        self,
+        structure: ElectronDensityStructure,
+        *,
+        mesh_geometry: ElectronDensityMeshGeometry | None = None,
     ) -> float:
         max_structure_radius = float(
             np.max(np.linalg.norm(structure.centered_coordinates, axis=1))
         )
+        active_mesh_geometry = (
+            self.current_mesh_geometry
+            if mesh_geometry is None
+            else mesh_geometry
+        )
         mesh_radius = (
             0.0
-            if self.current_mesh_geometry is None
-            else float(self.current_mesh_geometry.domain_max_radius)
+            if active_mesh_geometry is None
+            else float(active_mesh_geometry.domain_max_radius)
         )
         return max(
             max_structure_radius * 1.55,
@@ -1043,13 +1597,44 @@ class ElectronDensityStructureViewer(QWidget):
             1.2,
         )
 
-    def _draw_view(self, *, reset_view: bool) -> None:
+    def _view_radius_for_zoom_percentage(
+        self,
+        structure: ElectronDensityStructure,
+        zoom_percentage: float | None,
+        *,
+        mesh_geometry: ElectronDensityMeshGeometry | None = None,
+    ) -> float:
+        if zoom_percentage is None:
+            return self._default_view_radius(
+                structure,
+                mesh_geometry=mesh_geometry,
+            )
+        normalized_zoom = max(float(zoom_percentage) / 100.0, 1.0e-3)
+        return float(
+            np.clip(
+                self._default_view_radius(
+                    structure,
+                    mesh_geometry=mesh_geometry,
+                )
+                / normalized_zoom,
+                0.2,
+                1.0e6,
+            )
+        )
+
+    def _draw_view(
+        self,
+        *,
+        reset_view: bool,
+        preserve_zoom_percentage: float | None = None,
+    ) -> None:
         structure = self.current_structure
         if structure is None:
             self.draw_placeholder()
             return
 
         self._clear_pending_view_update()
+        self._active_settings_artist = None
         self.figure.clear()
         axis = self.figure.add_subplot(
             111,
@@ -1100,7 +1685,10 @@ class ElectronDensityStructureViewer(QWidget):
         if reset_view:
             self._scene_rotation = np.eye(3, dtype=float)
             self._view_center = np.zeros(3, dtype=float)
-            self._view_radius = self._default_view_radius(structure)
+            self._view_radius = self._view_radius_for_zoom_percentage(
+                structure,
+                preserve_zoom_percentage,
+            )
         self._apply_view_to_axes(refresh_axis_reference=True)
         axis.set_title(structure.display_label)
         axis.axis("off")
@@ -1111,6 +1699,7 @@ class ElectronDensityStructureViewer(QWidget):
             top=0.94,
         )
         self.canvas.draw_idle()
+        self._sync_active_scene_cache_entry()
 
     def _clear_pending_view_update(self) -> None:
         self._pending_view_update = False
@@ -1478,18 +2067,10 @@ class ElectronDensityStructureViewer(QWidget):
                 )
 
     def _draw_active_settings_readout(self, axis) -> None:
-        readout = "\n".join(
-            (
-                f"ATOM {self._atom_contrast * 100.0:05.1f}%",
-                f"MESH {self._mesh_contrast * 100.0:05.1f}%",
-                f"LINE {self._mesh_linewidth:04.2f}px",
-                f"COLOR {self._mesh_color.upper()}",
-            )
-        )
         artist = axis.text2D(
             0.02,
             0.98,
-            readout,
+            self._active_settings_readout_text(),
             transform=axis.transAxes,
             ha="left",
             va="top",
@@ -1505,6 +2086,37 @@ class ElectronDensityStructureViewer(QWidget):
             zorder=14,
         )
         artist.set_gid("active-visual-settings")
+        self._active_settings_artist = artist
+
+    def _active_settings_readout_text(self) -> str:
+        zoom_percentage = self._current_zoom_percentage()
+        zoom_text = (
+            "--.-%" if zoom_percentage is None else f"{zoom_percentage:05.1f}%"
+        )
+        return "\n".join(
+            (
+                f"ZOOM {zoom_text}",
+                f"ATOM {self._atom_contrast * 100.0:05.1f}%",
+                f"MESH {self._mesh_contrast * 100.0:05.1f}%",
+                f"LINE {self._mesh_linewidth:04.2f}px",
+                f"COLOR {self._mesh_color.upper()}",
+            )
+        )
+
+    def _current_zoom_percentage(self) -> float | None:
+        structure = self.current_structure
+        if structure is None:
+            return None
+        reference_radius = max(self._default_view_radius(structure), 1.0e-6)
+        current_radius = max(float(self._view_radius), 1.0e-6)
+        return max(reference_radius / current_radius * 100.0, 0.1)
+
+    def _refresh_active_settings_readout(self) -> None:
+        if self._active_settings_artist is None:
+            return
+        self._active_settings_artist.set_text(
+            self._active_settings_readout_text()
+        )
 
     def _update_mesh_color_button_style(self) -> None:
         self.mesh_color_button.setStyleSheet(
@@ -1560,6 +2172,7 @@ class ElectronDensityStructureViewer(QWidget):
         self._pending_axis_reference_refresh = False
         self._apply_view_to_axes(refresh_axis_reference=refresh_axis_reference)
         self.canvas.draw_idle()
+        self._sync_active_scene_cache_entry()
 
     def _apply_view_to_axes(
         self,
@@ -1581,6 +2194,7 @@ class ElectronDensityStructureViewer(QWidget):
             self._view_center[2] + self._view_radius,
         )
         self._axis.view_init(elev=_CAMERA_ELEV, azim=_CAMERA_AZIM)
+        self._refresh_active_settings_readout()
         if refresh_axis_reference:
             self._draw_axis_reference()
 
@@ -1703,6 +2317,8 @@ class ElectronDensityStructureViewer(QWidget):
         if self._view_update_timer.isActive():
             self._view_update_timer.stop()
             self._flush_view_update()
+        else:
+            self._sync_active_scene_cache_entry()
         self._update_canvas_cursor()
 
     def _handle_motion(self, event) -> None:

--- a/src/saxshell/saxs/electron_density_mapping/workflow.py
+++ b/src/saxshell/saxs/electron_density_mapping/workflow.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import csv
 import json
+import os
 import re
 from collections import Counter
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from dataclasses import dataclass, replace
 from functools import lru_cache
 from pathlib import Path
@@ -23,7 +25,12 @@ from saxshell.saxs.contrast.electron_density import (
     ContrastElectronDensityEstimate,
     ContrastSolventDensitySettings,
 )
-from saxshell.saxs.debye import load_structure_file
+from saxshell.saxs.debye import (
+    atomic_form_factor,
+    compute_debye_intensity,
+    load_structure_file,
+)
+from saxshell.saxs.debye.profiles import build_f0_dictionary
 from saxshell.toolbox.blender.workflow import (
     PreviewAtomRecord,
     detect_bonds_records,
@@ -42,9 +49,26 @@ _SUPPORTED_TRANSFORM_WINDOWS = {
     "sine",
     "kaiser_bessel",
 }
+_SUPPORTED_TRANSFORM_DOMAIN_MODES = {
+    "legacy",
+    "mirrored",
+}
+_FRAME_ID_PATTERN = re.compile(r"frame_(\d+)", re.IGNORECASE)
 _AVOGADRO_NUMBER = 6.02214076e23
 _ANGSTROM3_PER_CM3 = 1.0e24
+_DEBYE_WALLER_MODE_UNIVERSAL = "universal"
+_DEBYE_WALLER_MODE_PAIR_SPECIFIC = "pair_specific"
+_SUPPORTED_DEBYE_WALLER_MODES = {
+    _DEBYE_WALLER_MODE_UNIVERSAL,
+    _DEBYE_WALLER_MODE_PAIR_SPECIFIC,
+}
 ElectronDensityProgressCallback = Callable[[int, int, str], None]
+ElectronDensityCancelCallback = Callable[[], bool]
+
+
+class ElectronDensityCalculationCanceled(RuntimeError):
+    """Raised when a UI-driven electron-density calculation is
+    stopped."""
 
 
 def _require_xraydb() -> None:
@@ -69,6 +93,20 @@ def _normalized_element_symbol(raw_value: str) -> str:
     if not text:
         return ""
     return text[:1].upper() + text[1:].lower()
+
+
+def _progress_center_mode_label(
+    center_mode: str,
+    *,
+    reference_element: str | None = None,
+) -> str:
+    normalized_mode = str(center_mode or "").strip().lower()
+    if normalized_mode == "nearest_atom":
+        return "nearest-atom centering"
+    if normalized_mode == "reference_element":
+        element_text = str(reference_element or "").strip() or "auto"
+        return f"reference-element centering ({element_text})"
+    return "geometric-mass-center centering"
 
 
 @lru_cache(maxsize=None)
@@ -97,6 +135,69 @@ def _atomic_number(symbol: str) -> int:
         raise ValueError(
             f"Could not resolve an atomic number for element {normalized!r}."
         ) from exc
+
+
+@lru_cache(maxsize=None)
+def _waasmaier_parameters(
+    symbol: str,
+) -> tuple[np.ndarray, np.ndarray, float]:
+    _require_xraydb()
+    normalized = _normalized_element_symbol(symbol)
+    if not normalized:
+        raise ValueError("Encountered an empty element symbol.")
+    try:
+        rows = [
+            row
+            for row in xraydb.get_xraydb().get_cache("Waasmaier")
+            if normalized == str(row.ion)
+        ]
+    except Exception as exc:  # pragma: no cover - defensive
+        raise ValueError(
+            "Could not load Waasmaier-Kirfel form-factor parameters for "
+            f"{normalized!r}."
+        ) from exc
+    if not rows:
+        raise ValueError(
+            "No Waasmaier-Kirfel form-factor parameters were available for "
+            f"{normalized!r}."
+        )
+    row = rows[0]
+    scales = np.asarray(json.loads(row.scale), dtype=float)
+    exponents = np.asarray(json.loads(row.exponents), dtype=float)
+    offset = float(row.offset)
+    valid_mask = (
+        np.isfinite(scales)
+        & np.isfinite(exponents)
+        & (scales > 0.0)
+        & (exponents > 0.0)
+    )
+    filtered_scales = np.asarray(scales[valid_mask], dtype=float)
+    filtered_exponents = np.asarray(exponents[valid_mask], dtype=float)
+    if filtered_scales.size == 0 or filtered_exponents.size == 0:
+        raise ValueError(
+            "Waasmaier-Kirfel form-factor parameters for "
+            f"{normalized!r} did not include any usable Gaussian terms."
+        )
+    return filtered_scales, filtered_exponents, offset
+
+
+@lru_cache(maxsize=None)
+def _effective_atomic_overlap_radius(symbol: str) -> float:
+    scales, exponents, offset = _waasmaier_parameters(symbol)
+    electron_count = max(float(_atomic_number(symbol)), 1.0)
+    low_q_second_moment = float(
+        np.sum(scales * exponents) * (3.0 / (8.0 * np.pi**2 * electron_count))
+    )
+    sphere_radius = np.sqrt(max((5.0 / 3.0) * low_q_second_moment, 0.0))
+    if sphere_radius > 0.0:
+        return float(sphere_radius)
+    gaussian_electron_count = float(np.sum(scales))
+    if gaussian_electron_count > 0.0:
+        fallback_radius = np.cbrt(
+            max(gaussian_electron_count + max(offset, 0.0), 1.0e-12)
+        ) / max(np.pi, 1.0)
+        return float(max(fallback_radius, 1.0e-3))
+    return 1.0e-3
 
 
 def _sorted_count_dict(elements: tuple[str, ...]) -> dict[str, int]:
@@ -144,6 +245,15 @@ def _default_reference_element(elements: tuple[str, ...]) -> str:
     )
 
 
+def heaviest_reference_element(elements: tuple[str, ...]) -> str | None:
+    """Return the heaviest element by atomic mass from *elements*, or
+    None."""
+    try:
+        return _default_reference_element(elements)
+    except ValueError:
+        return None
+
+
 def _reference_element_center_details(
     coordinates: np.ndarray,
     elements: tuple[str, ...],
@@ -162,9 +272,13 @@ def _reference_element_center_details(
         dtype=bool,
     )
     if not np.any(element_mask):
-        raise ValueError(
-            "Reference element "
-            f"{resolved_reference_element!r} is not present in the structure."
+        # Requested element absent in this structure — fall back to the heaviest
+        # element available rather than raising, so per-cluster reference-element
+        # mismatches are handled gracefully.
+        resolved_reference_element = _default_reference_element(elements)
+        element_mask = np.asarray(
+            [element == resolved_reference_element for element in elements],
+            dtype=bool,
         )
     reference_coordinates = coordinate_array[element_mask]
     reference_geometric_center = _geometric_center(reference_coordinates)
@@ -198,23 +312,154 @@ def _gaussian_smooth_profile(
     *,
     sigma_a: float,
 ) -> np.ndarray:
-    centers = np.asarray(radial_centers, dtype=float)
+    kernel = _gaussian_smoothing_kernel(
+        radial_centers,
+        sigma_a=sigma_a,
+    )
     profile = np.asarray(values, dtype=float)
-    sigma_value = max(float(sigma_a), 0.0)
-    if profile.size <= 1 or sigma_value <= 0.0:
+    if profile.size <= 1 or kernel.size == 0:
         return profile.copy()
+    return np.asarray(kernel @ profile, dtype=float)
+
+
+def _gaussian_smoothing_kernel(
+    radial_centers: np.ndarray,
+    *,
+    sigma_a: float,
+) -> np.ndarray:
+    centers = np.asarray(radial_centers, dtype=float)
+    sigma_value = max(float(sigma_a), 0.0)
+    if centers.size <= 1 or sigma_value <= 0.0:
+        return np.eye(int(centers.size), dtype=float)
     distance_matrix = centers[:, np.newaxis] - centers[np.newaxis, :]
     kernel = np.exp(
         -0.5 * np.square(distance_matrix / max(sigma_value, 1.0e-12))
     )
     normalizers = np.sum(kernel, axis=1, keepdims=True)
-    kernel = np.divide(
+    return np.divide(
         kernel,
         normalizers,
         out=np.zeros_like(kernel, dtype=float),
         where=normalizers > 0.0,
     )
-    return np.asarray(kernel @ profile, dtype=float)
+
+
+def _legacy_exact_count_conserving_gaussian_transfer_kernel(
+    radial_centers: np.ndarray,
+    shell_volumes: np.ndarray,
+    *,
+    sigma_a: float,
+) -> np.ndarray:
+    centers = np.asarray(radial_centers, dtype=float)
+    volumes = np.asarray(shell_volumes, dtype=float)
+    sigma_value = max(float(sigma_a), 0.0)
+    if centers.size <= 1 or sigma_value <= 0.0 or volumes.size <= 1:
+        return np.eye(int(centers.size), dtype=float)
+    total_volume = float(np.sum(volumes))
+    if total_volume <= 0.0:
+        return np.eye(int(centers.size), dtype=float)
+    distance_matrix = centers[:, np.newaxis] - centers[np.newaxis, :]
+    affinity = np.exp(
+        -0.5 * np.square(distance_matrix / max(sigma_value, 1.0e-12))
+    )
+    # Balance the Gaussian affinity to the shell-volume measure so a flat
+    # density remains flat, the integrated electron count is preserved, and
+    # each smeared shell stays a convex combination of the raw densities.
+    target = volumes / total_volume
+    left_scale = np.ones_like(target, dtype=float)
+    right_scale = np.ones_like(target, dtype=float)
+    for _ in range(512):
+        affinity_right = affinity @ right_scale
+        next_left = np.divide(
+            target,
+            affinity_right,
+            out=np.zeros_like(left_scale, dtype=float),
+            where=affinity_right > 0.0,
+        )
+        affinity_left = affinity.T @ next_left
+        next_right = np.divide(
+            target,
+            affinity_left,
+            out=np.zeros_like(right_scale, dtype=float),
+            where=affinity_left > 0.0,
+        )
+        delta = max(
+            float(np.max(np.abs(next_left - left_scale))),
+            float(np.max(np.abs(next_right - right_scale))),
+        )
+        left_scale = next_left
+        right_scale = next_right
+        if delta <= 1.0e-12:
+            break
+    balanced_transport = (
+        left_scale[:, np.newaxis] * affinity * right_scale[np.newaxis, :]
+    )
+    normalizers = np.sum(
+        balanced_transport,
+        axis=1,
+        keepdims=True,
+    )
+    return np.divide(
+        balanced_transport,
+        normalizers,
+        out=np.zeros_like(balanced_transport, dtype=float),
+        where=normalizers > 0.0,
+    )
+
+
+def _count_conserving_gaussian_transfer_kernel(
+    radial_centers: np.ndarray,
+    shell_volumes: np.ndarray,
+    *,
+    sigma_a: float,
+) -> np.ndarray:
+    # Preserve the exact balanced transport kernel for legacy comparisons while
+    # letting the active smearing path apply a non-amplifying clamp after the
+    # matrix multiply.
+    return _legacy_exact_count_conserving_gaussian_transfer_kernel(
+        radial_centers,
+        shell_volumes,
+        sigma_a=sigma_a,
+    )
+
+
+def _cap_smeared_density_stack_to_input_totals(
+    density_stack: np.ndarray,
+    smeared_density_stack: np.ndarray,
+    shell_volumes: np.ndarray,
+) -> np.ndarray:
+    raw_density_stack = np.asarray(density_stack, dtype=float)
+    raw_smeared_density_stack = np.asarray(
+        smeared_density_stack,
+        dtype=float,
+    )
+    volumes = np.asarray(shell_volumes, dtype=float)
+    if (
+        raw_density_stack.ndim != 2
+        or raw_smeared_density_stack.ndim != 2
+        or raw_density_stack.shape != raw_smeared_density_stack.shape
+        or volumes.ndim != 1
+        or volumes.size != raw_density_stack.shape[1]
+    ):
+        raise ValueError(
+            "Smearing totals can only be capped for aligned density/profile "
+            "arrays with one shell-volume entry per shell."
+        )
+    input_totals = raw_density_stack @ volumes
+    smeared_totals = raw_smeared_density_stack @ volumes
+    scale_factors = np.ones_like(input_totals, dtype=float)
+    overshoot_mask = smeared_totals > (input_totals + 1.0e-12)
+    if np.any(overshoot_mask):
+        scale_factors[overshoot_mask] = np.divide(
+            input_totals[overshoot_mask],
+            smeared_totals[overshoot_mask],
+            out=np.zeros_like(input_totals[overshoot_mask], dtype=float),
+            where=smeared_totals[overshoot_mask] > 0.0,
+        )
+    return np.asarray(
+        raw_smeared_density_stack * scale_factors[:, np.newaxis],
+        dtype=float,
+    )
 
 
 def _trapezoid_integral(
@@ -243,6 +488,27 @@ def _normalized_transform_window_name(value: object) -> str:
     return normalized
 
 
+def _normalized_transform_domain_mode(value: object) -> str:
+    normalized = str(value or "").strip().lower().replace("-", "_")
+    if normalized in {
+        "mirror",
+        "mirrored",
+        "symmetric",
+        "symmetric_about_zero",
+        "reflected",
+    }:
+        return "mirrored"
+    if normalized in {
+        "",
+        "legacy",
+        "positive",
+        "positive_only",
+        "rmin_rmax",
+    }:
+        return "legacy"
+    return normalized
+
+
 def _extend_profile_to_origin(
     radial_values: np.ndarray,
     density_values: np.ndarray,
@@ -262,6 +528,30 @@ def _extend_profile_to_origin(
     )
 
 
+def _mirror_profile_about_zero(
+    radial_values: np.ndarray,
+    density_values: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    radii = np.asarray(radial_values, dtype=float)
+    densities = np.asarray(density_values, dtype=float)
+    if radii.size == 0 or densities.size == 0:
+        return radii.copy(), densities.copy()
+    if radii.size != densities.size:
+        raise ValueError(
+            "Radial and density arrays must have matching lengths when mirroring the Fourier source profile."
+        )
+    if abs(float(radii[0])) > 1.0e-12:
+        radii, densities = _extend_profile_to_origin(radii, densities)
+    if radii.size <= 1:
+        return radii.copy(), densities.copy()
+    mirrored_radii = np.concatenate((-radii[:0:-1], radii))
+    mirrored_densities = np.concatenate((densities[:0:-1], densities))
+    return (
+        np.asarray(mirrored_radii, dtype=float),
+        np.asarray(mirrored_densities, dtype=float),
+    )
+
+
 def _emit_progress(
     callback: ElectronDensityProgressCallback | None,
     current: int,
@@ -271,6 +561,15 @@ def _emit_progress(
     if callback is None:
         return
     callback(int(current), int(total), str(message))
+
+
+def _raise_if_canceled(
+    cancel_callback: ElectronDensityCancelCallback | None,
+) -> None:
+    if cancel_callback is not None and bool(cancel_callback()):
+        raise ElectronDensityCalculationCanceled(
+            "Electron-density calculation was stopped by the user."
+        )
 
 
 def _validate_supported_structure_path(path: str | Path) -> Path:
@@ -291,12 +590,16 @@ class ElectronDensityMeshSettings:
     theta_divisions: int = 120
     phi_divisions: int = 60
     rmax: float = 8.0
+    pin_contiguous_geometric_tracking: bool = True
 
     def normalized(self) -> "ElectronDensityMeshSettings":
         rstep = float(self.rstep)
         theta_divisions = int(self.theta_divisions)
         phi_divisions = int(self.phi_divisions)
         rmax = float(self.rmax)
+        pin_contiguous_geometric_tracking = bool(
+            self.pin_contiguous_geometric_tracking
+        )
         if rstep <= 0.0:
             raise ValueError("rstep must be greater than zero.")
         if theta_divisions < 2:
@@ -310,6 +613,7 @@ class ElectronDensityMeshSettings:
             theta_divisions=theta_divisions,
             phi_divisions=phi_divisions,
             rmax=rmax,
+            pin_contiguous_geometric_tracking=pin_contiguous_geometric_tracking,
         )
 
     def to_dict(self) -> dict[str, object]:
@@ -319,28 +623,202 @@ class ElectronDensityMeshSettings:
             "theta_divisions": int(normalized.theta_divisions),
             "phi_divisions": int(normalized.phi_divisions),
             "rmax_a": float(normalized.rmax),
+            "pin_contiguous_geometric_tracking": bool(
+                normalized.pin_contiguous_geometric_tracking
+            ),
         }
+
+
+@dataclass(slots=True, frozen=True)
+class ElectronDensityDebyeWallerPairTerm:
+    scope: str
+    type_definition: str
+    pair_label_a: str
+    pair_label_b: str
+    pair_label: str
+    mean_distance_a: float
+    sigma_a: float
+    sigma_std_a: float
+    sigma_squared_a2: float
+    sigma_squared_std_a2: float
+    b_factor_a2: float
+    b_factor_std_a2: float
+
+    @property
+    def key(self) -> tuple[str, str]:
+        normalized = self.normalized()
+        return (
+            str(normalized.scope),
+            str(normalized.pair_label),
+        )
+
+    def normalized(self) -> "ElectronDensityDebyeWallerPairTerm":
+        return ElectronDensityDebyeWallerPairTerm(
+            scope=str(self.scope or "").strip(),
+            type_definition=str(self.type_definition or "").strip(),
+            pair_label_a=str(self.pair_label_a or "").strip(),
+            pair_label_b=str(self.pair_label_b or "").strip(),
+            pair_label=str(self.pair_label or "").strip(),
+            mean_distance_a=max(float(self.mean_distance_a), 0.0),
+            sigma_a=max(float(self.sigma_a), 0.0),
+            sigma_std_a=max(float(self.sigma_std_a), 0.0),
+            sigma_squared_a2=max(float(self.sigma_squared_a2), 0.0),
+            sigma_squared_std_a2=max(float(self.sigma_squared_std_a2), 0.0),
+            b_factor_a2=max(float(self.b_factor_a2), 0.0),
+            b_factor_std_a2=max(float(self.b_factor_std_a2), 0.0),
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        normalized = self.normalized()
+        return {
+            "scope": str(normalized.scope),
+            "type_definition": str(normalized.type_definition),
+            "pair_label_a": str(normalized.pair_label_a),
+            "pair_label_b": str(normalized.pair_label_b),
+            "pair_label": str(normalized.pair_label),
+            "mean_distance_a": float(normalized.mean_distance_a),
+            "sigma_a": float(normalized.sigma_a),
+            "sigma_std_a": float(normalized.sigma_std_a),
+            "sigma_squared_a2": float(normalized.sigma_squared_a2),
+            "sigma_squared_std_a2": float(normalized.sigma_squared_std_a2),
+            "b_factor_a2": float(normalized.b_factor_a2),
+            "b_factor_std_a2": float(normalized.b_factor_std_a2),
+        }
+
+
+def _debye_waller_pair_term_sort_key(
+    term: ElectronDensityDebyeWallerPairTerm,
+) -> tuple[str, str, str, str]:
+    normalized = term.normalized()
+    return (
+        str(normalized.scope).lower(),
+        str(normalized.pair_label).lower(),
+        str(normalized.pair_label_a).lower(),
+        str(normalized.pair_label_b).lower(),
+    )
 
 
 @dataclass(slots=True, frozen=True)
 class ElectronDensitySmearingSettings:
     debye_waller_factor: float = 0.006
+    debye_waller_mode: str = _DEBYE_WALLER_MODE_UNIVERSAL
+    pair_specific_terms: tuple[ElectronDensityDebyeWallerPairTerm, ...] = ()
+    imported_pair_specific_terms: tuple[
+        ElectronDensityDebyeWallerPairTerm, ...
+    ] = ()
 
     def normalized(self) -> "ElectronDensitySmearingSettings":
         factor = max(float(self.debye_waller_factor), 0.0)
+        pair_specific_terms = tuple(
+            sorted(
+                (term.normalized() for term in self.pair_specific_terms),
+                key=_debye_waller_pair_term_sort_key,
+            )
+        )
+        imported_pair_specific_terms = tuple(
+            sorted(
+                (
+                    term.normalized()
+                    for term in self.imported_pair_specific_terms
+                ),
+                key=_debye_waller_pair_term_sort_key,
+            )
+        )
+        if not imported_pair_specific_terms and pair_specific_terms:
+            imported_pair_specific_terms = pair_specific_terms
+        if not pair_specific_terms and imported_pair_specific_terms:
+            pair_specific_terms = imported_pair_specific_terms
+        debye_waller_mode = str(self.debye_waller_mode or "").strip().lower()
+        if debye_waller_mode not in _SUPPORTED_DEBYE_WALLER_MODES:
+            debye_waller_mode = (
+                _DEBYE_WALLER_MODE_PAIR_SPECIFIC
+                if pair_specific_terms
+                else _DEBYE_WALLER_MODE_UNIVERSAL
+            )
+        if (
+            debye_waller_mode == _DEBYE_WALLER_MODE_PAIR_SPECIFIC
+            and not pair_specific_terms
+        ):
+            debye_waller_mode = _DEBYE_WALLER_MODE_UNIVERSAL
         return ElectronDensitySmearingSettings(
             debye_waller_factor=factor,
+            debye_waller_mode=debye_waller_mode,
+            pair_specific_terms=pair_specific_terms,
+            imported_pair_specific_terms=imported_pair_specific_terms,
         )
 
     @property
     def gaussian_sigma_a(self) -> float:
+        # TODO: When pair-specific Debye-Waller smearing is implemented,
+        # derive the active broadening from the imported pair terms instead of
+        # always falling back to the universal Gaussian factor.
         return float(np.sqrt(self.normalized().debye_waller_factor))
 
-    def to_dict(self) -> dict[str, float]:
+    @property
+    def has_pair_specific_terms(self) -> bool:
+        return bool(self.normalized().pair_specific_terms)
+
+    @property
+    def uses_pair_specific_terms(self) -> bool:
+        normalized = self.normalized()
+        return (
+            normalized.debye_waller_mode == _DEBYE_WALLER_MODE_PAIR_SPECIFIC
+            and bool(normalized.pair_specific_terms)
+        )
+
+    def with_pair_specific_terms(
+        self,
+        terms: (
+            tuple[ElectronDensityDebyeWallerPairTerm, ...]
+            | list[ElectronDensityDebyeWallerPairTerm]
+        ),
+        *,
+        imported_terms: (
+            tuple[ElectronDensityDebyeWallerPairTerm, ...]
+            | list[ElectronDensityDebyeWallerPairTerm]
+            | None
+        ) = None,
+        prefer_pair_specific: bool = True,
+    ) -> "ElectronDensitySmearingSettings":
+        return ElectronDensitySmearingSettings(
+            debye_waller_factor=float(self.debye_waller_factor),
+            debye_waller_mode=(
+                _DEBYE_WALLER_MODE_PAIR_SPECIFIC
+                if prefer_pair_specific and terms
+                else _DEBYE_WALLER_MODE_UNIVERSAL
+            ),
+            pair_specific_terms=tuple(terms),
+            imported_pair_specific_terms=(
+                tuple(terms)
+                if imported_terms is None
+                else tuple(imported_terms)
+            ),
+        ).normalized()
+
+    def reset_pair_specific_terms(self) -> "ElectronDensitySmearingSettings":
+        normalized = self.normalized()
+        return ElectronDensitySmearingSettings(
+            debye_waller_factor=float(normalized.debye_waller_factor),
+            debye_waller_mode=str(normalized.debye_waller_mode),
+            pair_specific_terms=tuple(normalized.imported_pair_specific_terms),
+            imported_pair_specific_terms=tuple(
+                normalized.imported_pair_specific_terms
+            ),
+        ).normalized()
+
+    def to_dict(self) -> dict[str, object]:
         normalized = self.normalized()
         return {
             "debye_waller_factor_a2": float(normalized.debye_waller_factor),
             "gaussian_sigma_a": float(normalized.gaussian_sigma_a),
+            "debye_waller_mode": str(normalized.debye_waller_mode),
+            "pair_specific_terms": [
+                term.to_dict() for term in normalized.pair_specific_terms
+            ],
+            "imported_pair_specific_terms": [
+                term.to_dict()
+                for term in normalized.imported_pair_specific_terms
+            ],
         }
 
 
@@ -348,18 +826,20 @@ class ElectronDensitySmearingSettings:
 class ElectronDensityFourierTransformSettings:
     r_min: float = 0.0
     r_max: float = 1.0
+    domain_mode: str = "mirrored"
     window_function: str = "none"
-    resampling_points: int = 1024
+    resampling_points: int = 2048
     q_min: float = 0.02
-    q_max: float = 10.0
-    q_step: float = 0.02
+    q_max: float = 1.2
+    q_step: float = 0.01
     use_solvent_subtracted_profile: bool = True
     log_q_axis: bool = True
     log_intensity_axis: bool = True
 
     def normalized(self) -> "ElectronDensityFourierTransformSettings":
-        r_min = max(float(self.r_min), 0.0)
-        r_max = float(self.r_max)
+        domain_mode = (
+            _normalized_transform_domain_mode(self.domain_mode) or "legacy"
+        )
         resampling_points = int(self.resampling_points)
         q_min = max(float(self.q_min), 0.0)
         q_max = float(self.q_max)
@@ -367,8 +847,27 @@ class ElectronDensityFourierTransformSettings:
         window_function = (
             _normalized_transform_window_name(self.window_function) or "none"
         )
-        if r_max <= r_min:
-            raise ValueError("Transform rmax must be greater than r min.")
+        if domain_mode not in _SUPPORTED_TRANSFORM_DOMAIN_MODES:
+            raise ValueError(
+                "Unsupported Fourier-transform domain mode. Choose from: "
+                + ", ".join(sorted(_SUPPORTED_TRANSFORM_DOMAIN_MODES))
+                + "."
+            )
+        if domain_mode == "mirrored":
+            r_max = max(
+                abs(float(self.r_max)),
+                abs(float(self.r_min)),
+            )
+            r_min = -r_max
+            if r_max <= 0.0:
+                raise ValueError(
+                    "Transform rmax must be greater than zero in mirrored mode."
+                )
+        else:
+            r_min = max(float(self.r_min), 0.0)
+            r_max = float(self.r_max)
+            if r_max <= r_min:
+                raise ValueError("Transform rmax must be greater than r min.")
         if resampling_points < 8:
             raise ValueError(
                 "Fourier-transform resampling points must be at least 8."
@@ -386,6 +885,7 @@ class ElectronDensityFourierTransformSettings:
         return ElectronDensityFourierTransformSettings(
             r_min=r_min,
             r_max=r_max,
+            domain_mode=domain_mode,
             window_function=window_function,
             resampling_points=resampling_points,
             q_min=q_min,
@@ -403,6 +903,7 @@ class ElectronDensityFourierTransformSettings:
         return {
             "r_min_a": float(normalized.r_min),
             "r_max_a": float(normalized.r_max),
+            "domain_mode": str(normalized.domain_mode),
             "window_function": str(normalized.window_function),
             "resampling_points": int(normalized.resampling_points),
             "q_min_a_inverse": float(normalized.q_min),
@@ -520,6 +1021,34 @@ class ElectronDensityMemberSummary:
 
 
 @dataclass(slots=True, frozen=True)
+class ElectronDensityContiguousFrameSetSummary:
+    series_label: str
+    frame_ids: tuple[int, ...]
+    frame_labels: tuple[str, ...]
+    file_paths: tuple[Path, ...]
+
+    @property
+    def frame_count(self) -> int:
+        return int(len(self.frame_ids))
+
+    @property
+    def frame_range_label(self) -> str:
+        if not self.frame_labels:
+            return "Unavailable"
+        if len(self.frame_labels) == 1:
+            return self.frame_labels[0]
+        return f"{self.frame_labels[0]}-{self.frame_labels[-1]}"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "series_label": str(self.series_label),
+            "frame_ids": [int(value) for value in self.frame_ids],
+            "frame_labels": [str(value) for value in self.frame_labels],
+            "file_paths": [str(path) for path in self.file_paths],
+        }
+
+
+@dataclass(slots=True, frozen=True)
 class ElectronDensityProfileResult:
     structure: ElectronDensityStructure
     input_mode: str
@@ -541,6 +1070,15 @@ class ElectronDensityProfileResult:
     shell_volumes: np.ndarray
     excluded_atom_count: int
     excluded_electron_count: float
+    averaging_mode: str = "complete_average"
+    contiguous_frame_mode_requested: bool = False
+    contiguous_frame_mode_applied: bool = False
+    pinned_geometric_tracking_requested: bool = False
+    pinned_geometric_tracking_applied: bool = False
+    averaging_notes: tuple[str, ...] = ()
+    contiguous_frame_sets: tuple[
+        ElectronDensityContiguousFrameSetSummary, ...
+    ] = ()
     solvent_contrast: "ElectronDensitySolventContrastResult | None" = None
 
 
@@ -605,6 +1143,7 @@ class ElectronDensityFourierTransformPreview:
     q_grid_is_oversampled: bool
     q_max_was_clamped: bool
     notes: tuple[str, ...]
+    source_mode: str = "density_fourier"
 
 
 @dataclass(slots=True, frozen=True)
@@ -613,6 +1152,18 @@ class ElectronDensityScatteringTransformResult:
     q_values: np.ndarray
     scattering_amplitude: np.ndarray
     intensity: np.ndarray
+
+
+@dataclass(slots=True, frozen=True)
+class ElectronDensityDebyeScatteringAverageResult:
+    q_values: np.ndarray
+    mean_intensity: np.ndarray
+    std_intensity: np.ndarray
+    se_intensity: np.ndarray
+    source_files: tuple[Path, ...]
+    source_structure_count: int
+    unique_elements: tuple[str, ...]
+    notes: tuple[str, ...] = ()
 
 
 @dataclass(slots=True, frozen=True)
@@ -949,6 +1500,8 @@ def load_electron_density_structure(
     *,
     center_mode: str = "center_of_mass",
     reference_element: str | None = None,
+    include_bonds: bool = True,
+    include_comment: bool = True,
 ) -> ElectronDensityStructure:
     resolved = _validate_supported_structure_path(file_path)
     coordinates, raw_elements = load_structure_file(resolved)
@@ -1021,15 +1574,19 @@ def load_electron_density_structure(
         active_center,
     )
 
-    preview_atoms = tuple(
-        PreviewAtomRecord(
-            element=element,
-            position=tuple(float(value) for value in coordinates_array[index]),
+    bonds: tuple[tuple[int, int], ...] = ()
+    if include_bonds:
+        preview_atoms = tuple(
+            PreviewAtomRecord(
+                element=element,
+                position=tuple(
+                    float(value) for value in coordinates_array[index]
+                ),
+            )
+            for index, element in enumerate(elements)
         )
-        for index, element in enumerate(elements)
-    )
-    bonds = detect_bonds_records(preview_atoms)
-    comment = read_structure_comment(resolved)
+        bonds = detect_bonds_records(preview_atoms)
+    comment = read_structure_comment(resolved) if include_comment else ""
     display_label = comment.strip() or resolved.name
     return ElectronDensityStructure(
         file_path=resolved,
@@ -1112,6 +1669,38 @@ def recenter_electron_density_structure(
     )
 
 
+def _prepared_reference_structure_for_run(
+    reference_structure: ElectronDensityStructure | None,
+    *,
+    reference_file: Path,
+    center_mode: str,
+    reference_element: str | None = None,
+) -> ElectronDensityStructure | None:
+    if reference_structure is None:
+        return None
+    resolved_reference = Path(reference_file).expanduser().resolve()
+    if reference_structure.file_path != resolved_reference:
+        return None
+    requested_reference_element = _normalized_element_symbol(
+        reference_element or reference_structure.reference_element
+    )
+    needs_recenter = reference_structure.center_mode != center_mode
+    if (
+        center_mode == "reference_element"
+        and requested_reference_element
+        and requested_reference_element
+        != reference_structure.reference_element
+    ):
+        needs_recenter = True
+    if not needs_recenter:
+        return reference_structure
+    return recenter_electron_density_structure(
+        reference_structure,
+        center_mode=center_mode,
+        reference_element=requested_reference_element or None,
+    )
+
+
 def build_electron_density_mesh(
     structure: ElectronDensityStructure,
     settings: ElectronDensityMeshSettings,
@@ -1150,6 +1739,123 @@ def build_electron_density_mesh(
     )
 
 
+def _tag_atoms_by_radial_shell(
+    radial_distances: np.ndarray,
+    radial_edges: np.ndarray,
+    *,
+    domain_max_radius: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    distances = np.asarray(radial_distances, dtype=float)
+    edges = np.asarray(radial_edges, dtype=float)
+    shell_count = int(max(len(edges) - 1, 0))
+    in_domain_mask = distances <= (float(domain_max_radius) + 1.0e-12)
+    shell_tags = np.full(distances.shape, -1, dtype=np.intp)
+    if shell_count <= 0 or not np.any(in_domain_mask):
+        return in_domain_mask, shell_tags
+
+    # Assign exactly one shell tag per in-domain atom, then sum by tag. This
+    # keeps origin-centered atoms in the first shell instead of letting them
+    # inflate every angular bin that touches r = 0.
+    candidate_shell_indices = (
+        np.searchsorted(edges, distances[in_domain_mask], side="right") - 1
+    )
+    shell_tags[in_domain_mask] = np.clip(
+        candidate_shell_indices,
+        0,
+        shell_count - 1,
+    )
+    return in_domain_mask, shell_tags
+
+
+def _sphere_overlap_volume(
+    sphere_radius: float,
+    radial_limits: np.ndarray,
+    *,
+    center_distance: float,
+) -> np.ndarray:
+    finite_radius = max(float(sphere_radius), 0.0)
+    radial_array = np.clip(np.asarray(radial_limits, dtype=float), 0.0, None)
+    if finite_radius <= 0.0 or radial_array.size == 0:
+        return np.zeros_like(radial_array, dtype=float)
+
+    separation = abs(float(center_distance))
+    volume = np.zeros_like(radial_array, dtype=float)
+    sphere_volume = (4.0 * np.pi / 3.0) * finite_radius**3
+
+    contains_mask = separation <= np.abs(radial_array - finite_radius)
+    if np.any(contains_mask):
+        min_radii = np.minimum(radial_array[contains_mask], finite_radius)
+        volume[contains_mask] = 4.0 * np.pi / 3.0 * np.power(min_radii, 3.0)
+
+    partial_mask = (
+        ~contains_mask
+        & (separation < (radial_array + finite_radius))
+        & (radial_array > 0.0)
+    )
+    if np.any(partial_mask):
+        radial_subset = radial_array[partial_mask]
+        numerator = (
+            np.pi
+            * np.square(radial_subset + finite_radius - separation)
+            * (
+                separation**2
+                + (2.0 * separation * (radial_subset + finite_radius))
+                - 3.0 * np.square(radial_subset - finite_radius)
+            )
+        )
+        denominator = max(12.0 * separation, 1.0e-12)
+        volume[partial_mask] = np.clip(
+            numerator / denominator,
+            0.0,
+            sphere_volume,
+        )
+
+    return np.clip(volume, 0.0, sphere_volume)
+
+
+def _finite_radius_shell_overlap_counts(
+    radial_edges: np.ndarray,
+    *,
+    atom_distance: float,
+    electron_count: float,
+    overlap_radius: float,
+) -> np.ndarray:
+    edge_array = np.asarray(radial_edges, dtype=float)
+    shell_count = int(max(len(edge_array) - 1, 0))
+    if shell_count <= 0 or electron_count <= 0.0:
+        return np.asarray([], dtype=float)
+    cumulative_overlap = _sphere_overlap_volume(
+        overlap_radius,
+        edge_array,
+        center_distance=atom_distance,
+    )
+    shell_overlap = np.diff(cumulative_overlap)
+    shell_overlap = np.clip(shell_overlap, 0.0, None)
+    overlap_total = float(np.sum(shell_overlap))
+    if overlap_total <= 0.0:
+        return np.zeros(shell_count, dtype=float)
+    return np.asarray(shell_overlap, dtype=float) * (
+        float(electron_count) / overlap_total
+    )
+
+
+def _resolve_electron_density_worker_count(
+    structure_count: int,
+) -> int:
+    if structure_count <= 1:
+        return 1
+    available_cpus = os.cpu_count() or 1
+    conservative_cpu_budget = max(1, (available_cpus + 1) // 2)
+    return max(
+        1,
+        min(
+            int(structure_count),
+            int(conservative_cpu_budget),
+            4,
+        ),
+    )
+
+
 def _member_summary_from_profile_result(
     result: ElectronDensityProfileResult,
 ) -> ElectronDensityMemberSummary:
@@ -1179,9 +1885,239 @@ def _member_summary_from_profile_result(
     )
 
 
+@dataclass(slots=True, frozen=True)
+class _ContiguousFrameRecord:
+    file_path: Path
+    frame_id: int
+    frame_label: str
+    series_key: str
+    series_label: str
+
+
+def _frame_series_label(prefix: str, suffix: str) -> str:
+    parts = [part for part in (prefix.strip("_"), suffix.strip("_")) if part]
+    if not parts:
+        return "default"
+    return " ".join(parts)
+
+
+def _parse_contiguous_frame_record(
+    file_path: str | Path,
+) -> _ContiguousFrameRecord | None:
+    resolved = Path(file_path).expanduser().resolve()
+    stem = str(resolved.stem)
+    match = _FRAME_ID_PATTERN.search(stem)
+    if match is None:
+        return None
+    frame_label = str(match.group(1))
+    prefix = stem[: match.start()]
+    suffix = stem[match.end() :]
+    return _ContiguousFrameRecord(
+        file_path=resolved,
+        frame_id=int(frame_label),
+        frame_label=frame_label,
+        series_key=f"{prefix}::{suffix}",
+        series_label=_frame_series_label(prefix, suffix),
+    )
+
+
+def _detect_contiguous_frame_sets(
+    structure_files: tuple[Path, ...],
+) -> tuple[tuple[ElectronDensityContiguousFrameSetSummary, ...], str | None]:
+    if not structure_files:
+        return tuple(), None
+    records: list[_ContiguousFrameRecord] = []
+    for file_path in structure_files:
+        parsed = _parse_contiguous_frame_record(file_path)
+        if parsed is None:
+            return (
+                tuple(),
+                "Contiguous-frame averaging requires every input file to "
+                "contain a frame_<NNNN> identifier. Falling back to complete averaging.",
+            )
+        records.append(parsed)
+
+    series_map: dict[str, list[_ContiguousFrameRecord]] = {}
+    for record in sorted(
+        records,
+        key=lambda item: (item.series_key, item.frame_id, item.file_path.name),
+    ):
+        series_map.setdefault(record.series_key, []).append(record)
+
+    contiguous_sets: list[ElectronDensityContiguousFrameSetSummary] = []
+    for series_records in series_map.values():
+        current_records: list[_ContiguousFrameRecord] = []
+        for record in series_records:
+            if (
+                current_records
+                and record.frame_id != current_records[-1].frame_id + 1
+            ):
+                contiguous_sets.append(
+                    ElectronDensityContiguousFrameSetSummary(
+                        series_label=str(current_records[0].series_label),
+                        frame_ids=tuple(
+                            int(entry.frame_id) for entry in current_records
+                        ),
+                        frame_labels=tuple(
+                            str(entry.frame_label) for entry in current_records
+                        ),
+                        file_paths=tuple(
+                            entry.file_path for entry in current_records
+                        ),
+                    )
+                )
+                current_records = []
+            current_records.append(record)
+        if current_records:
+            contiguous_sets.append(
+                ElectronDensityContiguousFrameSetSummary(
+                    series_label=str(current_records[0].series_label),
+                    frame_ids=tuple(
+                        int(entry.frame_id) for entry in current_records
+                    ),
+                    frame_labels=tuple(
+                        str(entry.frame_label) for entry in current_records
+                    ),
+                    file_paths=tuple(
+                        entry.file_path for entry in current_records
+                    ),
+                )
+            )
+    return tuple(contiguous_sets), None
+
+
+def _heaviest_element_geometric_center(
+    structure: ElectronDensityStructure,
+) -> np.ndarray:
+    (
+        _resolved_reference_element,
+        _geometric_center,
+        reference_element_geometric_center,
+        _reference_element_offset,
+    ) = _reference_element_center_details(
+        structure.coordinates,
+        structure.elements,
+        reference_element=None,
+    )
+    return np.asarray(reference_element_geometric_center, dtype=float)
+
+
+def _structure_with_active_center(
+    structure: ElectronDensityStructure,
+    active_center: np.ndarray,
+) -> ElectronDensityStructure:
+    active_center_array = np.asarray(active_center, dtype=float)
+    centered_coordinates, rmax = _centered_coordinates_from_origin(
+        structure.coordinates,
+        active_center_array,
+    )
+    return replace(
+        structure,
+        centered_coordinates=np.asarray(centered_coordinates, dtype=float),
+        active_center=active_center_array,
+        rmax=float(rmax),
+    )
+
+
+def _apply_contiguous_frame_center_lock(
+    structures: tuple[ElectronDensityStructure, ...],
+    contiguous_frame_sets: tuple[
+        ElectronDensityContiguousFrameSetSummary, ...
+    ],
+) -> tuple[ElectronDensityStructure, ...]:
+    if not structures or not contiguous_frame_sets:
+        return structures
+    structure_map = {
+        structure.file_path: structure for structure in structures
+    }
+    locked_structures: dict[Path, ElectronDensityStructure] = {}
+    for frame_set in contiguous_frame_sets:
+        set_structures = [
+            structure_map[path]
+            for path in frame_set.file_paths
+            if path in structure_map
+        ]
+        if not set_structures:
+            continue
+        anchor_centers = [
+            _heaviest_element_geometric_center(structure)
+            for structure in set_structures
+        ]
+        average_offset = np.mean(
+            np.vstack(
+                [
+                    np.asarray(structure.active_center, dtype=float) - anchor
+                    for structure, anchor in zip(
+                        set_structures,
+                        anchor_centers,
+                    )
+                ]
+            ),
+            axis=0,
+        )
+        for structure, anchor_center in zip(set_structures, anchor_centers):
+            locked_structures[structure.file_path] = (
+                _structure_with_active_center(
+                    structure,
+                    np.asarray(anchor_center, dtype=float) + average_offset,
+                )
+            )
+    return tuple(
+        locked_structures.get(structure.file_path, structure)
+        for structure in structures
+    )
+
+
+def _structure_files_are_pdb_only(
+    structure_files: tuple[Path, ...],
+) -> bool:
+    return bool(structure_files) and all(
+        Path(file_path).suffix.lower() == ".pdb"
+        for file_path in structure_files
+    )
+
+
+def _apply_pinned_geometric_tracking_to_frame_sets(
+    structures: tuple[ElectronDensityStructure, ...],
+    contiguous_frame_sets: tuple[
+        ElectronDensityContiguousFrameSetSummary, ...
+    ],
+) -> tuple[ElectronDensityStructure, ...]:
+    if not structures or not contiguous_frame_sets:
+        return structures
+    structure_map = {
+        structure.file_path: structure for structure in structures
+    }
+    locked_structures: dict[Path, ElectronDensityStructure] = {}
+    for frame_set in contiguous_frame_sets:
+        set_structures = [
+            structure_map[path]
+            for path in frame_set.file_paths
+            if path in structure_map
+        ]
+        if not set_structures:
+            continue
+        pinned_center = np.asarray(
+            set_structures[0].active_center,
+            dtype=float,
+        )
+        for structure in set_structures:
+            locked_structures[structure.file_path] = (
+                _structure_with_active_center(
+                    structure,
+                    pinned_center,
+                )
+            )
+    return tuple(
+        locked_structures.get(structure.file_path, structure)
+        for structure in structures
+    )
+
+
 def _compute_smeared_profile_statistics(
     radial_centers: np.ndarray,
-    member_profiles: tuple[np.ndarray, ...],
+    shell_volumes: np.ndarray,
+    member_density_profiles: tuple[np.ndarray, ...],
     *,
     smearing_settings: ElectronDensitySmearingSettings | None = None,
 ) -> tuple[
@@ -1195,26 +2131,41 @@ def _compute_smeared_profile_statistics(
         if smearing_settings is None
         else smearing_settings
     ).normalized()
-    profile_members = tuple(
-        np.asarray(profile, dtype=float).copy() for profile in member_profiles
+    density_members = tuple(
+        np.asarray(profile, dtype=float).copy()
+        for profile in member_density_profiles
     )
-    if not profile_members:
+    if not density_members:
         raise ValueError(
             "At least one member profile is required for smearing."
         )
-    smeared_stack = np.vstack(
-        [
-            _gaussian_smooth_profile(
-                radial_centers,
-                profile,
-                sigma_a=active_smearing.gaussian_sigma_a,
-            )
-            for profile in profile_members
-        ]
-    )
-    smeared_mean = np.mean(smeared_stack, axis=0)
-    if len(profile_members) > 1:
-        smeared_variance = np.var(smeared_stack, axis=0)
+    density_stack = np.vstack(density_members)
+    if density_stack.shape[1] <= 1 or active_smearing.gaussian_sigma_a <= 0.0:
+        smeared_density_stack = np.asarray(
+            density_stack,
+            dtype=float,
+        ).copy()
+    else:
+        kernel = _count_conserving_gaussian_transfer_kernel(
+            radial_centers,
+            shell_volumes,
+            sigma_a=active_smearing.gaussian_sigma_a,
+        )
+        smeared_density_stack = np.asarray(
+            density_stack @ kernel.T,
+            dtype=float,
+        )
+        # Keep the finite-precision balanced transport from ever increasing the
+        # integrated electron density. Small losses remain acceptable if a
+        # future smearing kernel intentionally leaks density outside the domain.
+        smeared_density_stack = _cap_smeared_density_stack_to_input_totals(
+            density_stack,
+            smeared_density_stack,
+            shell_volumes,
+        )
+    smeared_mean = np.mean(smeared_density_stack, axis=0)
+    if len(density_members) > 1:
+        smeared_variance = np.var(smeared_density_stack, axis=0)
     else:
         smeared_variance = np.zeros_like(smeared_mean, dtype=float)
     return (
@@ -1229,6 +2180,9 @@ def apply_smearing_to_profile_result(
     result: ElectronDensityProfileResult,
     smearing_settings: ElectronDensitySmearingSettings | None = None,
 ) -> ElectronDensityProfileResult:
+    # TODO: Apply pair-specific Debye-Waller terms to the electron-density
+    # smearing path once the pair-aware broadening model is implemented.
+    # For now this continues to use the universal Gaussian factor only.
     member_profiles = result.member_orientation_average_densities or (
         np.asarray(result.orientation_average_density, dtype=float).copy(),
     )
@@ -1239,7 +2193,11 @@ def apply_smearing_to_profile_result(
         smeared_orientation_density_stddev,
     ) = _compute_smeared_profile_statistics(
         np.asarray(result.radial_centers, dtype=float),
-        member_profiles,
+        np.asarray(result.shell_volumes, dtype=float),
+        tuple(
+            np.asarray(profile, dtype=float).copy()
+            for profile in member_profiles
+        ),
         smearing_settings=smearing_settings,
     )
     updated_result = replace(
@@ -1282,8 +2240,13 @@ def _transform_window_values(
         1.0,
     )
     absolute_centered = np.abs(normalized_centered)
+    symmetric_about_zero = bool(
+        float(r_min) < 0.0 < float(r_max)
+        and np.isclose(float(r_min), -float(r_max), atol=1.0e-12)
+    )
     if normalized_window == "lorch":
-        return np.asarray(np.sinc(position), dtype=float)
+        argument = normalized_centered if symmetric_about_zero else position
+        return np.asarray(np.sinc(argument), dtype=float)
     if normalized_window == "cosine":
         return np.asarray(
             np.cos(0.5 * np.pi * normalized_centered),
@@ -1326,6 +2289,94 @@ def _transform_window_values(
     )
 
 
+def _q_values_from_transform_settings(
+    settings: ElectronDensityFourierTransformSettings,
+) -> np.ndarray:
+    normalized = settings.normalized()
+    q_values = np.arange(
+        float(normalized.q_min),
+        float(normalized.q_max) + float(normalized.q_step) * 0.5,
+        float(normalized.q_step),
+        dtype=float,
+    )
+    if q_values.size > 0 and q_values[-1] > float(normalized.q_max) + 1.0e-12:
+        q_values = q_values[:-1]
+    return np.asarray(q_values, dtype=float)
+
+
+def _validated_debye_q_values(
+    *,
+    settings: ElectronDensityFourierTransformSettings | None,
+    q_values: np.ndarray | list[float] | tuple[float, ...] | None,
+) -> np.ndarray:
+    if q_values is None:
+        if settings is None:
+            raise ValueError(
+                "Provide Fourier settings or an explicit q grid for the Debye scattering calculation."
+            )
+        return _q_values_from_transform_settings(settings)
+    q_grid = np.asarray(q_values, dtype=float)
+    if q_grid.ndim != 1 or q_grid.size == 0:
+        raise ValueError(
+            "Debye scattering q-values must be a non-empty 1D grid."
+        )
+    if not np.all(np.isfinite(q_grid)):
+        raise ValueError("Debye scattering q-values must be finite.")
+    if q_grid.size > 1 and np.any(np.diff(q_grid) <= 0.0):
+        raise ValueError(
+            "Debye scattering q-values must be strictly increasing."
+        )
+    return np.asarray(q_grid, dtype=float)
+
+
+def _all_single_atom_structures_are_equivalent(
+    structures: list[tuple[np.ndarray, tuple[str, ...]]],
+) -> bool:
+    if not structures:
+        return False
+    atom_signatures: set[tuple[str, ...]] = set()
+    for coordinates, elements in structures:
+        coordinate_array = np.asarray(coordinates, dtype=float)
+        if (
+            coordinate_array.ndim != 2
+            or coordinate_array.shape[0] != 1
+            or coordinate_array.shape[1] != 3
+            or len(elements) != 1
+        ):
+            return False
+        atom_signatures.add(tuple(str(element) for element in elements))
+    return len(atom_signatures) == 1
+
+
+def prepare_single_atom_debye_scattering_preview(
+    settings: ElectronDensityFourierTransformSettings,
+) -> ElectronDensityFourierTransformPreview:
+    normalized = settings.normalized()
+    return ElectronDensityFourierTransformPreview(
+        settings=normalized,
+        source_profile_label="Single-atom Debye scattering",
+        source_radial_values=np.asarray([], dtype=float),
+        source_density_values=np.asarray([], dtype=float),
+        resampled_r_values=np.asarray([], dtype=float),
+        resampled_density_values=np.asarray([], dtype=float),
+        window_values=np.asarray([], dtype=float),
+        windowed_density_values=np.asarray([], dtype=float),
+        available_r_min=0.0,
+        available_r_max=0.0,
+        resampling_step_a=0.0,
+        nyquist_q_max_a_inverse=0.0,
+        independent_q_step_a_inverse=0.0,
+        q_grid_is_oversampled=False,
+        q_max_was_clamped=False,
+        notes=(
+            "Single-atom cluster bins use direct Debye scattering. "
+            "Electron-density, solvent-contrast, and Fourier-profile "
+            "preparation are skipped; only the q-grid controls apply.",
+        ),
+        source_mode="single_atom_debye",
+    )
+
+
 def prepare_electron_density_fourier_transform(
     result: ElectronDensityProfileResult,
     settings: ElectronDensityFourierTransformSettings,
@@ -1362,6 +2413,14 @@ def prepare_electron_density_fourier_transform(
     )
     available_r_min = 0.0
     available_r_max = float(source_radial_values[-1])
+    if normalized.domain_mode == "mirrored":
+        source_radial_values, source_density_values = (
+            _mirror_profile_about_zero(
+                source_radial_values,
+                source_density_values,
+            )
+        )
+        available_r_min = -available_r_max
     effective_r_min = max(float(normalized.r_min), available_r_min)
     effective_r_max = min(float(normalized.r_max), available_r_max)
     if effective_r_min > float(normalized.r_min) + 1.0e-12:
@@ -1381,7 +2440,7 @@ def prepare_electron_density_fourier_transform(
         normalized,
         r_min=effective_r_min,
         r_max=effective_r_max,
-    )
+    ).normalized()
     resampled_r_values = np.linspace(
         effective_r_min,
         effective_r_max,
@@ -1456,6 +2515,7 @@ def prepare_electron_density_fourier_transform(
         q_grid_is_oversampled=q_grid_is_oversampled,
         q_max_was_clamped=q_max_was_clamped,
         notes=tuple(notes),
+        source_mode="density_fourier",
     )
 
 
@@ -1465,13 +2525,7 @@ def compute_electron_density_scattering_profile(
 ) -> ElectronDensityScatteringTransformResult:
     preview = prepare_electron_density_fourier_transform(result, settings)
     effective_settings = preview.settings
-    q_values = np.arange(
-        float(effective_settings.q_min),
-        float(effective_settings.q_max)
-        + float(effective_settings.q_step) * 0.5,
-        float(effective_settings.q_step),
-        dtype=float,
-    )
+    q_values = _q_values_from_transform_settings(effective_settings)
     radial_values = np.asarray(preview.resampled_r_values, dtype=float)
     windowed_density = np.asarray(preview.windowed_density_values, dtype=float)
     radial_square = np.square(radial_values)
@@ -1506,6 +2560,241 @@ def compute_electron_density_scattering_profile(
     )
 
 
+def compute_average_debye_scattering_profile_for_input(
+    selection: ElectronDensityInputInspection | str | Path,
+    settings: ElectronDensityFourierTransformSettings | None = None,
+    *,
+    q_values: np.ndarray | list[float] | tuple[float, ...] | None = None,
+    progress_callback: ElectronDensityProgressCallback | None = None,
+    cancel_callback: ElectronDensityCancelCallback | None = None,
+) -> ElectronDensityDebyeScatteringAverageResult:
+    inspection = (
+        selection
+        if isinstance(selection, ElectronDensityInputInspection)
+        else inspect_structure_input(selection)
+    )
+    structure_files = tuple(inspection.structure_files)
+    if not structure_files:
+        raise ValueError("No structure files were available for calculation.")
+
+    q_grid = _validated_debye_q_values(settings=settings, q_values=q_values)
+    total_steps = len(structure_files) * 2 + 2
+    _raise_if_canceled(cancel_callback)
+    _emit_progress(
+        progress_callback,
+        0,
+        total_steps,
+        "Preparing Debye scattering average calculation.",
+    )
+
+    loaded_structures: list[tuple[np.ndarray, tuple[str, ...]]] = []
+    unique_elements: set[str] = set()
+    for file_index, file_path in enumerate(structure_files, start=1):
+        _raise_if_canceled(cancel_callback)
+        _emit_progress(
+            progress_callback,
+            file_index,
+            total_steps,
+            "Loading structure "
+            f"{file_index}/{len(structure_files)} for Debye scattering: "
+            f"{file_path.name}",
+        )
+        coordinates, raw_elements = load_structure_file(file_path)
+        coordinate_array = np.asarray(coordinates, dtype=float)
+        elements = tuple(
+            _normalized_element_symbol(element) for element in raw_elements
+        )
+        if (
+            coordinate_array.ndim != 2
+            or coordinate_array.shape[0] != len(elements)
+            or coordinate_array.shape[1] != 3
+        ):
+            raise ValueError(
+                f"Structure {file_path.name} could not be parsed into a valid coordinate array."
+            )
+        loaded_structures.append((coordinate_array, elements))
+        unique_elements.update(
+            element for element in elements if str(element).strip()
+        )
+
+    if not loaded_structures:
+        raise ValueError(
+            "No valid structures were available for Debye scattering."
+        )
+
+    _raise_if_canceled(cancel_callback)
+    _emit_progress(
+        progress_callback,
+        len(structure_files) + 1,
+        total_steps,
+        "Building atomic form factors for "
+        f"{len(unique_elements)} unique element"
+        f"{'' if len(unique_elements) == 1 else 's'}.",
+    )
+    f0_dictionary = build_f0_dictionary(
+        sorted(unique_elements),
+        q_grid,
+    )
+
+    traces: list[np.ndarray] = []
+    notes: list[str] = []
+    if _all_single_atom_structures_are_equivalent(loaded_structures):
+        coordinates, elements = loaded_structures[0]
+        trace = compute_debye_intensity(
+            coordinates,
+            list(elements),
+            q_grid,
+            f0_dictionary=f0_dictionary,
+        )
+        traces = [np.asarray(trace, dtype=float)] * len(loaded_structures)
+        notes.append(
+            "All source structures contained the same single-atom type, so the Debye trace was evaluated once and reused across the average."
+        )
+        _emit_progress(
+            progress_callback,
+            total_steps - 1,
+            total_steps,
+            "Reused a single equivalent single-atom Debye trace across the average.",
+        )
+    else:
+        for structure_index, (coordinates, elements) in enumerate(
+            loaded_structures,
+            start=1,
+        ):
+            _raise_if_canceled(cancel_callback)
+            _emit_progress(
+                progress_callback,
+                len(structure_files) + 1 + structure_index,
+                total_steps,
+                "Computing Debye trace "
+                f"{structure_index}/{len(loaded_structures)}.",
+            )
+            traces.append(
+                np.asarray(
+                    compute_debye_intensity(
+                        coordinates,
+                        list(elements),
+                        q_grid,
+                        f0_dictionary=f0_dictionary,
+                    ),
+                    dtype=float,
+                )
+            )
+
+    stacked = np.asarray(traces, dtype=float)
+    mean_trace = np.asarray(np.mean(stacked, axis=0), dtype=float)
+    std_trace = np.asarray(np.std(stacked, axis=0), dtype=float)
+    se_trace = np.asarray(
+        std_trace / np.sqrt(float(max(stacked.shape[0], 1))),
+        dtype=float,
+    )
+    _emit_progress(
+        progress_callback,
+        total_steps,
+        total_steps,
+        "Debye scattering average profile ready.",
+    )
+    return ElectronDensityDebyeScatteringAverageResult(
+        q_values=np.asarray(q_grid, dtype=float),
+        mean_intensity=mean_trace,
+        std_intensity=std_trace,
+        se_intensity=se_trace,
+        source_files=structure_files,
+        source_structure_count=len(structure_files),
+        unique_elements=tuple(sorted(unique_elements)),
+        notes=tuple(notes),
+    )
+
+
+def compute_single_atom_debye_scattering_profile_for_input(
+    selection: ElectronDensityInputInspection | str | Path,
+    settings: ElectronDensityFourierTransformSettings,
+    *,
+    progress_callback: ElectronDensityProgressCallback | None = None,
+    cancel_callback: ElectronDensityCancelCallback | None = None,
+) -> ElectronDensityScatteringTransformResult:
+    inspection = (
+        selection
+        if isinstance(selection, ElectronDensityInputInspection)
+        else inspect_structure_input(selection)
+    )
+    structure_files = tuple(inspection.structure_files)
+    if not structure_files:
+        raise ValueError("No structure files were available for calculation.")
+
+    _raise_if_canceled(cancel_callback)
+    total_steps = len(structure_files) + 2
+    _emit_progress(
+        progress_callback,
+        0,
+        total_steps,
+        "Preparing single-atom Debye scattering calculation.",
+    )
+    preview = prepare_single_atom_debye_scattering_preview(settings)
+    q_values = _q_values_from_transform_settings(preview.settings)
+    element_counts: Counter[str] = Counter()
+
+    for file_index, file_path in enumerate(structure_files, start=1):
+        _raise_if_canceled(cancel_callback)
+        _emit_progress(
+            progress_callback,
+            file_index,
+            total_steps,
+            "Validating single-atom structure "
+            f"{file_index}/{len(structure_files)}: {file_path.name}",
+        )
+        coordinates, raw_elements = load_structure_file(file_path)
+        coordinate_array = np.asarray(coordinates, dtype=float)
+        elements = tuple(
+            _normalized_element_symbol(element) for element in raw_elements
+        )
+        if (
+            coordinate_array.ndim != 2
+            or coordinate_array.shape[0] != 1
+            or coordinate_array.shape[1] != 3
+            or len(elements) != 1
+        ):
+            raise ValueError(
+                "Single-atom Debye scattering requires exactly one atom in "
+                f"every structure file; {file_path.name} did not match that requirement."
+            )
+        element_counts[str(elements[0])] += 1
+
+    _raise_if_canceled(cancel_callback)
+    _emit_progress(
+        progress_callback,
+        total_steps - 1,
+        total_steps,
+        "Computing single-atom Debye scattering from "
+        f"{len(element_counts)} unique atom type"
+        f"{'' if len(element_counts) == 1 else 's'}.",
+    )
+    weighted_intensity = np.zeros_like(q_values, dtype=float)
+    total_structure_count = sum(
+        int(count) for count in element_counts.values()
+    )
+    for element, count in sorted(element_counts.items()):
+        _raise_if_canceled(cancel_callback)
+        form_factor = atomic_form_factor(element, q_values)
+        weighted_intensity += float(count) * np.square(
+            np.asarray(form_factor, dtype=float)
+        )
+    intensity = weighted_intensity / float(max(total_structure_count, 1))
+    amplitude = np.sqrt(np.clip(np.asarray(intensity, dtype=float), 0.0, None))
+    _emit_progress(
+        progress_callback,
+        total_steps,
+        total_steps,
+        "Single-atom Debye scattering profile ready.",
+    )
+    return ElectronDensityScatteringTransformResult(
+        preview=preview,
+        q_values=np.asarray(q_values, dtype=float),
+        scattering_amplitude=np.asarray(amplitude, dtype=float),
+        intensity=np.asarray(intensity, dtype=float),
+    )
+
+
 def compute_electron_density_profile(
     structure: ElectronDensityStructure,
     mesh_settings: ElectronDensityMeshSettings,
@@ -1518,111 +2807,81 @@ def compute_electron_density_profile(
     )
     radial_distances = np.linalg.norm(centered_coordinates, axis=1)
 
-    theta_values = np.zeros_like(radial_distances, dtype=float)
-    nonzero_mask = radial_distances > 0.0
-    theta_values[nonzero_mask] = np.arccos(
-        np.clip(
-            centered_coordinates[nonzero_mask, 2]
-            / radial_distances[nonzero_mask],
-            -1.0,
-            1.0,
-        )
-    )
-    phi_values = np.mod(
-        np.arctan2(centered_coordinates[:, 1], centered_coordinates[:, 0]),
-        2.0 * np.pi,
-    )
-
     radial_edges = np.asarray(mesh_geometry.radial_edges, dtype=float)
-    theta_edges = np.asarray(mesh_geometry.theta_edges, dtype=float)
-    phi_edges = np.asarray(mesh_geometry.phi_edges, dtype=float)
     shell_count = int(len(radial_edges) - 1)
-    theta_count = int(len(theta_edges) - 1)
-    phi_count = int(len(phi_edges) - 1)
     domain_max_radius = float(mesh_geometry.domain_max_radius)
 
-    in_domain_mask = radial_distances <= (domain_max_radius + 1.0e-12)
+    in_domain_mask, shell_tags = _tag_atoms_by_radial_shell(
+        radial_distances,
+        radial_edges,
+        domain_max_radius=domain_max_radius,
+    )
     excluded_atom_count = int(np.count_nonzero(~in_domain_mask))
     excluded_electron_count = float(
         np.sum(
             np.asarray(structure.atomic_numbers, dtype=float)[~in_domain_mask]
         )
     )
-    radial_distances = radial_distances[in_domain_mask]
-    theta_values = theta_values[in_domain_mask]
-    phi_values = phi_values[in_domain_mask]
     atomic_numbers = np.asarray(structure.atomic_numbers, dtype=float)[
         in_domain_mask
     ]
+    tagged_shells = np.asarray(shell_tags[in_domain_mask], dtype=np.intp)
 
-    radial_indices = (
-        np.searchsorted(radial_edges, radial_distances, side="right") - 1
-    )
-    radial_indices = np.clip(radial_indices, 0, shell_count - 1)
-    theta_indices = (
-        np.searchsorted(theta_edges, theta_values, side="right") - 1
-    )
-    theta_indices = np.clip(theta_indices, 0, theta_count - 1)
-    phi_indices = np.searchsorted(phi_edges, phi_values, side="right") - 1
-    phi_indices = np.clip(phi_indices, 0, phi_count - 1)
+    if shell_count > 0:
+        shell_electron_counts = np.bincount(
+            tagged_shells,
+            weights=atomic_numbers,
+            minlength=shell_count,
+        ).astype(float, copy=False)
+    else:
+        shell_electron_counts = np.asarray([], dtype=float)
 
-    flat_indices = (
-        radial_indices * theta_count * phi_count
-        + theta_indices * phi_count
-        + phi_indices
-    )
-    cell_electron_counts = np.zeros(
-        shell_count * theta_count * phi_count,
-        dtype=float,
-    )
-    np.add.at(
-        cell_electron_counts,
-        flat_indices,
-        atomic_numbers,
-    )
-    cell_electron_counts = cell_electron_counts.reshape(
-        shell_count,
-        theta_count,
-        phi_count,
-    )
-
-    radial_shell_factors = (
+    shell_volumes = (4.0 * np.pi / 3.0) * (
         np.power(radial_edges[1:], 3.0) - np.power(radial_edges[:-1], 3.0)
-    ) / 3.0
-    theta_factors = (np.cos(theta_edges[:-1]) - np.cos(theta_edges[1:]))[
-        :, np.newaxis
-    ]
-    phi_widths = np.diff(phi_edges)[np.newaxis, :]
-    angular_factors = theta_factors * phi_widths
-    cell_volumes = (
-        radial_shell_factors[:, np.newaxis, np.newaxis]
-        * angular_factors[np.newaxis, :, :]
     )
-    cell_densities = np.divide(
-        cell_electron_counts,
-        cell_volumes,
-        out=np.zeros_like(cell_electron_counts, dtype=float),
-        where=cell_volumes > 0.0,
-    )
-
-    shell_electron_counts = np.sum(cell_electron_counts, axis=(1, 2))
-    shell_volumes = np.sum(cell_volumes, axis=(1, 2))
     shell_volume_average_density = np.divide(
         shell_electron_counts,
         shell_volumes,
         out=np.zeros_like(shell_electron_counts, dtype=float),
         where=shell_volumes > 0.0,
     )
-    angular_weight_sum = float(np.sum(angular_factors))
-    solid_angle_weights = np.divide(
-        angular_factors,
-        angular_weight_sum,
-        out=np.zeros_like(angular_factors, dtype=float),
-        where=angular_weight_sum > 0.0,
+    finite_radius_shell_electron_counts = np.zeros_like(
+        shell_electron_counts,
+        dtype=float,
     )
-    orientation_average_density = np.sum(
-        cell_densities * solid_angle_weights[np.newaxis, :, :],
-        axis=(1, 2),
+    in_domain_elements = structure.elements
+    if np.any(in_domain_mask):
+        in_domain_elements = tuple(
+            structure.elements[index]
+            for index, included in enumerate(in_domain_mask)
+            if included
+        )
+    for atom_distance, atom_electrons, atom_element in zip(
+        radial_distances[in_domain_mask],
+        atomic_numbers,
+        in_domain_elements,
+        strict=False,
+    ):
+        overlap_radius = _effective_atomic_overlap_radius(str(atom_element))
+        finite_radius_shell_electron_counts += (
+            _finite_radius_shell_overlap_counts(
+                radial_edges,
+                atom_distance=float(atom_distance),
+                electron_count=float(atom_electrons),
+                overlap_radius=overlap_radius,
+            )
+        )
+
+    orientation_average_density = np.asarray(
+        np.divide(
+            finite_radius_shell_electron_counts,
+            shell_volumes,
+            out=np.zeros_like(
+                finite_radius_shell_electron_counts, dtype=float
+            ),
+            where=shell_volumes > 0.0,
+        ),
+        dtype=float,
     )
     radial_centers = (radial_edges[:-1] + radial_edges[1:]) * 0.5
     active_smearing = (
@@ -1648,6 +2907,7 @@ def compute_electron_density_profile(
         smeared_orientation_density_stddev,
     ) = _compute_smeared_profile_statistics(
         radial_centers,
+        shell_volumes,
         member_orientation_average_densities,
         smearing_settings=active_smearing,
     )
@@ -1684,10 +2944,14 @@ def compute_electron_density_profile_for_input(
     mesh_settings: ElectronDensityMeshSettings,
     *,
     smearing_settings: ElectronDensitySmearingSettings | None = None,
+    reference_structure: ElectronDensityStructure | None = None,
     center_mode: str = "center_of_mass",
     reference_element: str | None = None,
+    use_contiguous_frame_mode: bool = False,
     progress_callback: ElectronDensityProgressCallback | None = None,
+    cancel_callback: ElectronDensityCancelCallback | None = None,
 ) -> ElectronDensityProfileResult:
+    normalized_mesh_settings = mesh_settings.normalized()
     inspection = (
         selection
         if isinstance(selection, ElectronDensityInputInspection)
@@ -1697,53 +2961,290 @@ def compute_electron_density_profile_for_input(
     if not structure_files:
         raise ValueError("No structure files were available for calculation.")
 
-    total_steps = len(structure_files) * 2 + 2
+    should_try_contiguous_mode = bool(
+        use_contiguous_frame_mode
+        and inspection.input_mode == "folder"
+        and len(structure_files) > 1
+    )
+    contiguous_frame_sets: tuple[
+        ElectronDensityContiguousFrameSetSummary, ...
+    ] = ()
+    averaging_mode = "complete_average"
+    contiguous_frame_mode_applied = False
+    pinned_geometric_tracking_requested = bool(
+        should_try_contiguous_mode
+        and center_mode == "center_of_mass"
+        and normalized_mesh_settings.pin_contiguous_geometric_tracking
+    )
+    pinned_geometric_tracking_applied = False
+    averaging_notes: list[str] = []
+    total_steps = (
+        len(structure_files) * 2 + 2 + (1 if should_try_contiguous_mode else 0)
+    )
     step_index = 0
+    _raise_if_canceled(cancel_callback)
     if inspection.input_mode == "folder":
         _emit_progress(
             progress_callback,
             step_index,
             total_steps,
-            f"Preparing ensemble electron-density calculation for {len(structure_files)} structures.",
+            "Preparing ensemble electron-density calculation for "
+            f"{len(structure_files)} structures using "
+            f"{_progress_center_mode_label(center_mode, reference_element=reference_element)}"
+            + (
+                " with contiguous-frame evaluation enabled."
+                if should_try_contiguous_mode
+                else "."
+            ),
         )
     else:
         _emit_progress(
             progress_callback,
             step_index,
             total_steps,
-            "Preparing electron-density calculation.",
+            "Preparing electron-density calculation for "
+            f"{structure_files[0].name} using "
+            f"{_progress_center_mode_label(center_mode, reference_element=reference_element)}.",
         )
+
+    if should_try_contiguous_mode:
+        step_index += 1
+        _raise_if_canceled(cancel_callback)
+        contiguous_frame_sets, fallback_reason = _detect_contiguous_frame_sets(
+            structure_files
+        )
+        if fallback_reason is None:
+            contiguous_frame_mode_applied = True
+            averaging_mode = "contiguous_frame_sets"
+            if pinned_geometric_tracking_requested:
+                if _structure_files_are_pdb_only(structure_files):
+                    pinned_geometric_tracking_applied = True
+                    averaging_notes.append(
+                        "Pinned each contiguous PDB frame set to the first "
+                        "frame's geometric mass center coordinates."
+                    )
+                else:
+                    averaging_notes.append(
+                        "Pinned geometric tracking requires contiguous PDB "
+                        "frame sets. Reused the standard shared-center "
+                        "contiguous evaluation instead."
+                    )
+            if not pinned_geometric_tracking_applied:
+                averaging_notes.append(
+                    "Locked each contiguous frame set to a shared active-center "
+                    "offset relative to the heaviest-element geometric center."
+                )
+            contiguous_structure_count = sum(
+                frame_set.frame_count for frame_set in contiguous_frame_sets
+            )
+            frame_set_count = len(contiguous_frame_sets)
+            mode_message = (
+                "pinning each set to its first frame's geometric mass center."
+                if pinned_geometric_tracking_applied
+                else "locking active centers within each set."
+            )
+            _emit_progress(
+                progress_callback,
+                step_index,
+                total_steps,
+                "Detected "
+                f"{frame_set_count} contiguous frame set"
+                f"{'' if frame_set_count == 1 else 's'} across "
+                f"{contiguous_structure_count} structure"
+                f"{'' if contiguous_structure_count == 1 else 's'}; "
+                + mode_message,
+            )
+        else:
+            averaging_notes.append(fallback_reason)
+            _emit_progress(
+                progress_callback,
+                step_index,
+                total_steps,
+                fallback_reason,
+            )
+
+    worker_count = _resolve_electron_density_worker_count(len(structure_files))
+    prepared_reference_structure = _prepared_reference_structure_for_run(
+        reference_structure,
+        reference_file=inspection.reference_file,
+        center_mode=center_mode,
+        reference_element=reference_element,
+    )
+    loaded_structures: list[ElectronDensityStructure] = []
+    if worker_count <= 1:
+        for file_index, file_path in enumerate(structure_files, start=1):
+            step_index += 1
+            _raise_if_canceled(cancel_callback)
+            _emit_progress(
+                progress_callback,
+                step_index,
+                total_steps,
+                f"Loading structure {file_index}/{len(structure_files)}: {file_path.name}",
+            )
+            if file_index == 1 and prepared_reference_structure is not None:
+                structure = prepared_reference_structure
+            else:
+                structure = load_electron_density_structure(
+                    file_path,
+                    center_mode=center_mode,
+                    reference_element=reference_element,
+                    include_bonds=file_index == 1,
+                    include_comment=file_index == 1,
+                )
+            loaded_structures.append(structure)
+    else:
+        ordered_structures: list[ElectronDensityStructure | None] = [
+            None
+        ] * len(structure_files)
+        with ThreadPoolExecutor(
+            max_workers=worker_count,
+            thread_name_prefix="electron-density-load",
+        ) as executor:
+            pending_futures = {}
+            next_index = 0
+            completed_count = 0
+            if prepared_reference_structure is not None:
+                ordered_structures[0] = prepared_reference_structure
+                completed_count = 1
+                step_index += 1
+                _emit_progress(
+                    progress_callback,
+                    step_index,
+                    total_steps,
+                    "Loading structure "
+                    f"1/{len(structure_files)}: {structure_files[0].name}",
+                )
+                next_index = 1
+            while completed_count < len(structure_files):
+                _raise_if_canceled(cancel_callback)
+                while (
+                    next_index < len(structure_files)
+                    and len(pending_futures) < worker_count
+                ):
+                    file_path = structure_files[next_index]
+                    _emit_progress(
+                        progress_callback,
+                        step_index,
+                        total_steps,
+                        "Loading structure "
+                        f"{next_index + 1}/{len(structure_files)}: {file_path.name}",
+                    )
+                    future = executor.submit(
+                        load_electron_density_structure,
+                        file_path,
+                        center_mode=center_mode,
+                        reference_element=reference_element,
+                        include_bonds=next_index == 0,
+                        include_comment=next_index == 0,
+                    )
+                    pending_futures[future] = next_index
+                    next_index += 1
+                done_futures, _pending = wait(
+                    tuple(pending_futures),
+                    return_when=FIRST_COMPLETED,
+                )
+                for future in done_futures:
+                    member_index = pending_futures.pop(future)
+                    ordered_structures[member_index] = future.result()
+                    completed_count += 1
+                    step_index += 1
+                    _emit_progress(
+                        progress_callback,
+                        step_index,
+                        total_steps,
+                        "Loaded structure "
+                        f"{completed_count}/{len(structure_files)}: "
+                        f"{structure_files[member_index].name}",
+                    )
+        loaded_structures = [
+            structure
+            for structure in ordered_structures
+            if structure is not None
+        ]
+    structure_members = tuple(loaded_structures)
+    if contiguous_frame_mode_applied:
+        _raise_if_canceled(cancel_callback)
+        if pinned_geometric_tracking_applied:
+            structure_members = _apply_pinned_geometric_tracking_to_frame_sets(
+                structure_members,
+                contiguous_frame_sets,
+            )
+        else:
+            structure_members = _apply_contiguous_frame_center_lock(
+                structure_members,
+                contiguous_frame_sets,
+            )
 
     member_results: list[ElectronDensityProfileResult] = []
-    for file_index, file_path in enumerate(structure_files, start=1):
-        step_index += 1
-        _emit_progress(
-            progress_callback,
-            step_index,
-            total_steps,
-            f"Loading structure {file_index}/{len(structure_files)}: {file_path.name}",
-        )
-        structure = load_electron_density_structure(
-            file_path,
-            center_mode=center_mode,
-            reference_element=reference_element,
-        )
-        step_index += 1
-        _emit_progress(
-            progress_callback,
-            step_index,
-            total_steps,
-            f"Computing electron density {file_index}/{len(structure_files)}: {file_path.name}",
-        )
-        member_results.append(
-            compute_electron_density_profile(
-                structure,
-                mesh_settings,
-                smearing_settings=smearing_settings,
+    member_compute_smearing = ElectronDensitySmearingSettings(
+        debye_waller_factor=0.0
+    )
+    if worker_count <= 1:
+        for file_index, structure in enumerate(structure_members, start=1):
+            step_index += 1
+            _raise_if_canceled(cancel_callback)
+            _emit_progress(
+                progress_callback,
+                step_index,
+                total_steps,
+                "Computing electron density "
+                f"{file_index}/{len(structure_files)}: {structure.file_path.name}",
             )
-        )
+            member_results.append(
+                compute_electron_density_profile(
+                    structure,
+                    normalized_mesh_settings,
+                    smearing_settings=member_compute_smearing,
+                )
+            )
+    else:
+        ordered_results: list[ElectronDensityProfileResult | None] = [
+            None
+        ] * len(structure_members)
+        with ThreadPoolExecutor(
+            max_workers=worker_count,
+            thread_name_prefix="electron-density",
+        ) as executor:
+            pending_futures = {}
+            next_index = 0
+            completed_count = 0
+            while completed_count < len(structure_members):
+                _raise_if_canceled(cancel_callback)
+                while (
+                    next_index < len(structure_members)
+                    and len(pending_futures) < worker_count
+                ):
+                    future = executor.submit(
+                        compute_electron_density_profile,
+                        structure_members[next_index],
+                        normalized_mesh_settings,
+                        smearing_settings=member_compute_smearing,
+                    )
+                    pending_futures[future] = next_index
+                    next_index += 1
+                done_futures, _pending = wait(
+                    tuple(pending_futures),
+                    return_when=FIRST_COMPLETED,
+                )
+                for future in done_futures:
+                    member_index = pending_futures.pop(future)
+                    ordered_results[member_index] = future.result()
+                    completed_count += 1
+                    step_index += 1
+                    _emit_progress(
+                        progress_callback,
+                        step_index,
+                        total_steps,
+                        "Computing electron density "
+                        f"{completed_count}/{len(structure_files)}: "
+                        f"{structure_members[member_index].file_path.name}",
+                    )
+        member_results = [
+            result for result in ordered_results if result is not None
+        ]
 
     step_index += 1
+    _raise_if_canceled(cancel_callback)
     _emit_progress(
         progress_callback,
         step_index,
@@ -1776,6 +3277,7 @@ def compute_electron_density_profile_for_input(
         smeared_orientation_density_stddev,
     ) = _compute_smeared_profile_statistics(
         np.asarray(reference_result.radial_centers, dtype=float),
+        np.asarray(reference_result.shell_volumes, dtype=float),
         member_orientation_average_densities,
         smearing_settings=smearing_settings,
     )
@@ -1810,8 +3312,20 @@ def compute_electron_density_profile_for_input(
         excluded_electron_count=float(
             sum(result.excluded_electron_count for result in member_results)
         ),
+        averaging_mode=str(averaging_mode),
+        contiguous_frame_mode_requested=bool(should_try_contiguous_mode),
+        contiguous_frame_mode_applied=bool(contiguous_frame_mode_applied),
+        pinned_geometric_tracking_requested=bool(
+            pinned_geometric_tracking_requested
+        ),
+        pinned_geometric_tracking_applied=bool(
+            pinned_geometric_tracking_applied
+        ),
+        averaging_notes=tuple(str(note) for note in averaging_notes),
+        contiguous_frame_sets=tuple(contiguous_frame_sets),
     )
     step_index += 1
+    _raise_if_canceled(cancel_callback)
     _emit_progress(
         progress_callback,
         step_index,
@@ -1900,6 +3414,23 @@ def write_electron_density_profile_outputs(
         "source_file": str(result.structure.file_path),
         "source_files": [str(path) for path in result.source_files],
         "source_structure_count": int(result.source_structure_count),
+        "averaging_mode": str(result.averaging_mode),
+        "contiguous_frame_mode_requested": bool(
+            result.contiguous_frame_mode_requested
+        ),
+        "contiguous_frame_mode_applied": bool(
+            result.contiguous_frame_mode_applied
+        ),
+        "pinned_geometric_tracking_requested": bool(
+            result.pinned_geometric_tracking_requested
+        ),
+        "pinned_geometric_tracking_applied": bool(
+            result.pinned_geometric_tracking_applied
+        ),
+        "averaging_notes": [str(note) for note in result.averaging_notes],
+        "contiguous_frame_sets": [
+            entry.to_dict() for entry in result.contiguous_frame_sets
+        ],
         "display_label": result.structure.display_label,
         "structure_comment": result.structure.structure_comment,
         "atom_count": int(result.structure.atom_count),
@@ -1934,6 +3465,26 @@ def write_electron_density_profile_outputs(
         "shell_count": int(result.mesh_geometry.shell_count),
         "excluded_atom_count": int(result.excluded_atom_count),
         "excluded_electron_count": float(result.excluded_electron_count),
+        "density_profile_metadata": {
+            "displayed_raw_density_method": "finite_radius_shell_overlap",
+            "displayed_raw_density_field": (
+                "orientation_average_density_e_per_a3"
+            ),
+            "shell_electron_count_field": "electrons_in_shell",
+            "shell_electron_count_role": "point_tag_bookkeeping",
+            "fourier_transform_density_source": (
+                "smeared_orientation_average_density_e_per_a3 "
+                "(or solvent-subtracted smeared density when enabled)"
+            ),
+            "interpretation_note": (
+                "Displayed raw density is derived from finite-radius shell "
+                "overlap using element-specific effective atomic radii, "
+                "while shell electron counts remain point-tag bookkeeping "
+                "and Gaussian smearing applies a shell-volume-balanced "
+                "broadening kernel. Fourier/scattering outputs are built "
+                "from the smeared profile."
+            ),
+        },
         "member_summaries": [
             {
                 "file_path": str(entry.file_path),
@@ -2016,6 +3567,10 @@ def write_electron_density_profile_outputs(
 
 
 __all__ = [
+    "ElectronDensityCalculationCanceled",
+    "ElectronDensityContiguousFrameSetSummary",
+    "ElectronDensityDebyeScatteringAverageResult",
+    "ElectronDensityDebyeWallerPairTerm",
     "ElectronDensityFourierTransformPreview",
     "ElectronDensityFourierTransformSettings",
     "ElectronDensityInputInspection",
@@ -2031,11 +3586,15 @@ __all__ = [
     "apply_solvent_contrast_to_profile_result",
     "apply_smearing_to_profile_result",
     "build_electron_density_mesh",
+    "heaviest_reference_element",
+    "compute_average_debye_scattering_profile_for_input",
     "compute_electron_density_profile",
     "compute_electron_density_profile_for_input",
     "compute_electron_density_scattering_profile",
+    "compute_single_atom_debye_scattering_profile_for_input",
     "inspect_structure_input",
     "load_electron_density_structure",
+    "prepare_single_atom_debye_scattering_preview",
     "prepare_electron_density_fourier_transform",
     "recenter_electron_density_structure",
     "suggest_output_basename",

--- a/src/saxshell/saxs/prefit/workflow.py
+++ b/src/saxshell/saxs/prefit/workflow.py
@@ -2269,7 +2269,7 @@ class SAXSPrefitWorkflow:
                 raise FileNotFoundError(
                     "Predicted Structures mode is enabled, but the "
                     "predicted-structure prior weights have not been "
-                    "generated for this project. Generate Prior Weights in "
+                    "generated for this project. Create Computed Distribution in "
                     "Project Setup with Use Predicted Structure Weights enabled."
                 )
             raise FileNotFoundError(

--- a/src/saxshell/saxs/project_manager/prior_plot.py
+++ b/src/saxshell/saxs/project_manager/prior_plot.py
@@ -116,6 +116,7 @@ def build_prior_histogram_export_payload(
     mode: str = "structure_fraction",
     value_mode: str = "percent",
     secondary_element: str | None = None,
+    custom_label_order: list[tuple[str, str]] | None = None,
 ) -> dict[str, object]:
     payload = _load_prior_payload(json_path)
     normalized_mode = _normalize_prior_mode(mode)
@@ -124,6 +125,20 @@ def build_prior_histogram_export_payload(
         plot_mode=normalized_mode,
     )
     labels = sort_stoich_labels(structures)
+    if custom_label_order is not None:
+        available = set(structures.keys())
+        ordered = [raw for raw, _ in custom_label_order if raw in available]
+        remaining = [
+            lbl
+            for lbl in labels
+            if lbl not in {r for r, _ in custom_label_order}
+        ]
+        labels = ordered + remaining
+    _custom_display: dict[str, str] = (
+        {raw: display for raw, display in custom_label_order}
+        if custom_label_order is not None
+        else {}
+    )
     if normalized_mode not in {
         "structure_fraction",
         "atom_fraction",
@@ -225,7 +240,10 @@ def build_prior_histogram_export_payload(
         "plot_mode": normalized_mode,
         "value_mode": value_mode,
         "labels": labels,
-        "axis_labels": [format_stoich_for_axis(label) for label in labels],
+        "axis_labels": [
+            _custom_display.get(label, format_stoich_for_axis(label))
+            for label in labels
+        ],
         "segments": [str(segment) for segment in segments],
         "segment_labels": segment_labels,
         "secondary_element": secondary_element,
@@ -320,6 +338,7 @@ def plot_md_prior_histogram(
     cmap: str = "summer",
     structure_motif_colors: dict[str, str] | None = None,
     show_percent: bool = True,
+    custom_label_order: list[tuple[str, str]] | None = None,
     ax=None,
 ):
     small_total_threshold = 1.0
@@ -328,8 +347,10 @@ def plot_md_prior_histogram(
         mode=mode,
         value_mode="percent",
         secondary_element=secondary_element,
+        custom_label_order=custom_label_order,
     )
     labels = [str(label) for label in export_payload["labels"]]
+    axis_labels = [str(label) for label in export_payload["axis_labels"]]
     segments = [str(segment) for segment in export_payload["segments"]]
     segment_labels = [str(label) for label in export_payload["segment_labels"]]
     plot_mode = str(export_payload["plot_mode"])
@@ -413,7 +434,7 @@ def plot_md_prior_histogram(
     ax.set_title(_prior_plot_title(plot_mode, secondary_element))
     ax.set_xticks(range(len(labels)))
     ax.set_xticklabels(
-        [format_stoich_for_axis(label) for label in labels],
+        axis_labels,
         rotation=45,
         ha="right",
     )

--- a/src/saxshell/saxs/project_manager/project.py
+++ b/src/saxshell/saxs/project_manager/project.py
@@ -565,6 +565,7 @@ class ProjectSettings:
     powerpoint_export_settings: PowerPointExportSettings = field(
         default_factory=PowerPointExportSettings
     )
+    prior_histogram_x_axis_order: list[list[str]] = field(default_factory=list)
 
     @property
     def resolved_project_dir(self) -> Path:
@@ -850,7 +851,20 @@ class ProjectSettings:
             powerpoint_export_settings=PowerPointExportSettings.from_dict(
                 payload.get("powerpoint_export_settings", {})
             ),
+            prior_histogram_x_axis_order=_normalized_prior_x_axis_order(
+                payload.get("prior_histogram_x_axis_order", [])
+            ),
         )
+
+
+def _normalized_prior_x_axis_order(raw: object) -> list[list[str]]:
+    if not isinstance(raw, list):
+        return []
+    result: list[list[str]] = []
+    for entry in raw:
+        if isinstance(entry, (list, tuple)) and len(entry) >= 2:
+            result.append([str(entry[0]), str(entry[1])])
+    return result
 
 
 def _distribution_id_for_settings(

--- a/src/saxshell/saxs/structure_viewer/__init__.py
+++ b/src/saxshell/saxs/structure_viewer/__init__.py
@@ -1,0 +1,11 @@
+from .ui import (
+    StructureViewerMainWindow,
+    StructureViewerWidget,
+    launch_structure_viewer_ui,
+)
+
+__all__ = [
+    "StructureViewerMainWindow",
+    "StructureViewerWidget",
+    "launch_structure_viewer_ui",
+]

--- a/src/saxshell/saxs/structure_viewer/__main__.py
+++ b/src/saxshell/saxs/structure_viewer/__main__.py
@@ -1,0 +1,11 @@
+from saxshell.saxs.structure_viewer.ui.main_window import (
+    launch_structure_viewer_ui,
+)
+
+if __name__ == "__main__":
+    from PySide6.QtWidgets import QApplication
+
+    window = launch_structure_viewer_ui()
+    window.show()
+    app = QApplication.instance()
+    raise SystemExit(app.exec() if app is not None else 0)

--- a/src/saxshell/saxs/structure_viewer/cli.py
+++ b/src/saxshell/saxs/structure_viewer/cli.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from .ui.main_window import main
+
+__all__ = ["main"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/saxshell/saxs/structure_viewer/ui/__init__.py
+++ b/src/saxshell/saxs/structure_viewer/ui/__init__.py
@@ -1,0 +1,8 @@
+from .main_window import StructureViewerMainWindow, launch_structure_viewer_ui
+from .widget import StructureViewerWidget
+
+__all__ = [
+    "StructureViewerMainWindow",
+    "StructureViewerWidget",
+    "launch_structure_viewer_ui",
+]

--- a/src/saxshell/saxs/structure_viewer/ui/main_window.py
+++ b/src/saxshell/saxs/structure_viewer/ui/main_window.py
@@ -1,0 +1,757 @@
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+import numpy as np
+from PySide6.QtCore import Qt, Slot
+from PySide6.QtGui import QAction
+from PySide6.QtWidgets import (
+    QApplication,
+    QButtonGroup,
+    QComboBox,
+    QDoubleSpinBox,
+    QFileDialog,
+    QFormLayout,
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMainWindow,
+    QMessageBox,
+    QPushButton,
+    QScrollArea,
+    QSpinBox,
+    QSplitter,
+    QVBoxLayout,
+    QWidget,
+)
+
+from saxshell.saxs.electron_density_mapping.workflow import (
+    ElectronDensityMeshGeometry,
+    ElectronDensityMeshSettings,
+    ElectronDensityStructure,
+    build_electron_density_mesh,
+    load_electron_density_structure,
+    recenter_electron_density_structure,
+)
+from saxshell.saxs.ui.branding import (
+    configure_saxshell_application,
+    load_saxshell_icon,
+    prepare_saxshell_application_identity,
+)
+
+from .widget import StructureViewerWidget
+
+_OPEN_WINDOWS: list["StructureViewerMainWindow"] = []
+
+
+class StructureViewerMainWindow(QMainWindow):
+    """Standalone harness for the reusable structure-viewer widget."""
+
+    def __init__(
+        self,
+        *,
+        initial_input_path: str | Path | None = None,
+    ) -> None:
+        super().__init__()
+        self._structure: ElectronDensityStructure | None = None
+        self._active_mesh_settings = ElectronDensityMeshSettings(rstep=0.05)
+        self._active_mesh_geometry: ElectronDensityMeshGeometry | None = None
+
+        self.setWindowTitle("Structure Viewer")
+        self.setWindowIcon(load_saxshell_icon())
+        self.resize(1380, 900)
+        self._build_menu_bar()
+        self._build_ui()
+
+        if initial_input_path is not None:
+            self.input_path_edit.setText(
+                str(Path(initial_input_path).expanduser().resolve())
+            )
+            self._load_input_from_edit()
+
+    def _build_menu_bar(self) -> None:
+        file_menu = self.menuBar().addMenu("File")
+
+        self.open_structure_action = QAction("Open Structure...", self)
+        self.open_structure_action.triggered.connect(self._choose_input_file)
+        file_menu.addAction(self.open_structure_action)
+
+        self.reload_structure_action = QAction(
+            "Reload Current Structure", self
+        )
+        self.reload_structure_action.setEnabled(False)
+        self.reload_structure_action.triggered.connect(
+            self._reload_current_structure
+        )
+        file_menu.addAction(self.reload_structure_action)
+
+        file_menu.addSeparator()
+        close_action = QAction("Close", self)
+        close_action.triggered.connect(self.close)
+        file_menu.addAction(close_action)
+
+    def _build_ui(self) -> None:
+        central = QWidget(self)
+        root_layout = QVBoxLayout(central)
+        root_layout.setContentsMargins(8, 8, 8, 8)
+        root_layout.setSpacing(8)
+        self.setCentralWidget(central)
+
+        self._pane_splitter = QSplitter(Qt.Orientation.Horizontal, central)
+        root_layout.addWidget(self._pane_splitter, stretch=1)
+
+        self._left_scroll_area = QScrollArea(self)
+        self._left_scroll_area.setWidgetResizable(True)
+        self._left_scroll_area.setHorizontalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAsNeeded
+        )
+        self._left_scroll_area.setVerticalScrollBarPolicy(
+            Qt.ScrollBarPolicy.ScrollBarAsNeeded
+        )
+        left_container = QWidget()
+        left_layout = QVBoxLayout(left_container)
+        left_layout.setContentsMargins(10, 10, 10, 10)
+        left_layout.setSpacing(10)
+        left_layout.addWidget(self._build_input_group())
+        left_layout.addWidget(self._build_mesh_group())
+        left_layout.addStretch(1)
+        self._left_scroll_area.setWidget(left_container)
+        self._pane_splitter.addWidget(self._left_scroll_area)
+
+        right_container = QWidget(self)
+        right_layout = QVBoxLayout(right_container)
+        right_layout.setContentsMargins(10, 10, 10, 10)
+        right_layout.setSpacing(8)
+
+        self.viewer_status_label = QLabel(
+            "Load a single XYZ or PDB structure to exercise the isolated "
+            "Structure Viewer widget."
+        )
+        self.viewer_status_label.setWordWrap(True)
+        right_layout.addWidget(self.viewer_status_label)
+
+        self.structure_viewer = StructureViewerWidget(right_container)
+        right_layout.addWidget(self.structure_viewer, stretch=1)
+
+        self._pane_splitter.addWidget(right_container)
+        self._pane_splitter.setStretchFactor(0, 0)
+        self._pane_splitter.setStretchFactor(1, 1)
+        self._pane_splitter.setSizes([420, 960])
+
+    def _build_input_group(self) -> QWidget:
+        group = QGroupBox("Input")
+        layout = QVBoxLayout(group)
+
+        path_row = QHBoxLayout()
+        self.input_path_edit = QLineEdit()
+        self.input_path_edit.setPlaceholderText(
+            "Choose one XYZ or PDB structure file"
+        )
+        self.input_path_edit.returnPressed.connect(self._load_input_from_edit)
+        path_row.addWidget(self.input_path_edit, stretch=1)
+
+        browse_button = QPushButton("Choose File")
+        browse_button.clicked.connect(self._choose_input_file)
+        path_row.addWidget(browse_button)
+        layout.addLayout(path_row)
+
+        self.load_input_button = QPushButton("Load Structure")
+        self.load_input_button.clicked.connect(self._load_input_from_edit)
+        layout.addWidget(self.load_input_button)
+
+        form = QFormLayout()
+        form.addRow(QLabel("Input mode:"))
+        self.input_mode_value = QLabel("No structure loaded")
+        self.input_mode_value.setWordWrap(True)
+        form.addRow(self.input_mode_value)
+
+        form.addRow(QLabel("Source file:"))
+        self.reference_file_value = QLabel("Unavailable")
+        self.reference_file_value.setWordWrap(True)
+        form.addRow(self.reference_file_value)
+
+        form.addRow(QLabel("Structure summary:"))
+        self.structure_summary_value = QLabel(
+            "Load a structure to populate atoms, element counts, center of "
+            "mass, active center, and rmax."
+        )
+        self.structure_summary_value.setWordWrap(True)
+        form.addRow(self.structure_summary_value)
+        layout.addLayout(form)
+        return group
+
+    def _build_mesh_group(self) -> QWidget:
+        group = QGroupBox("Mesh and Origin")
+        layout = QFormLayout(group)
+
+        self.rstep_spin = QDoubleSpinBox()
+        self.rstep_spin.setRange(0.01, 1000.0)
+        self.rstep_spin.setDecimals(4)
+        self.rstep_spin.setSingleStep(0.01)
+        self.rstep_spin.setValue(self._active_mesh_settings.rstep)
+        self.rstep_spin.valueChanged.connect(self._refresh_mesh_notice)
+        layout.addRow("rstep (A)", self.rstep_spin)
+
+        self.theta_divisions_spin = QSpinBox()
+        self.theta_divisions_spin.setRange(2, 720)
+        self.theta_divisions_spin.setValue(
+            self._active_mesh_settings.theta_divisions
+        )
+        self.theta_divisions_spin.valueChanged.connect(
+            self._refresh_mesh_notice
+        )
+        layout.addRow("Theta divisions", self.theta_divisions_spin)
+
+        self.phi_divisions_spin = QSpinBox()
+        self.phi_divisions_spin.setRange(2, 720)
+        self.phi_divisions_spin.setValue(
+            self._active_mesh_settings.phi_divisions
+        )
+        self.phi_divisions_spin.valueChanged.connect(self._refresh_mesh_notice)
+        layout.addRow("Phi divisions", self.phi_divisions_spin)
+
+        self.rmax_spin = QDoubleSpinBox()
+        self.rmax_spin.setRange(0.01, 100000.0)
+        self.rmax_spin.setDecimals(4)
+        self.rmax_spin.setSingleStep(0.1)
+        self.rmax_spin.setValue(self._active_mesh_settings.rmax)
+        self.rmax_spin.valueChanged.connect(self._refresh_mesh_notice)
+        layout.addRow("rmax (A)", self.rmax_spin)
+
+        layout.addRow(QLabel("Center mode:"))
+        self.center_mode_value = QLabel("Mass-weighted center of mass")
+        self.center_mode_value.setWordWrap(True)
+        layout.addRow(self.center_mode_value)
+
+        layout.addRow(QLabel("Calculated center:"))
+        self.calculated_center_value = QLabel("Unavailable")
+        self.calculated_center_value.setWordWrap(True)
+        layout.addRow(self.calculated_center_value)
+
+        layout.addRow(QLabel("Active center:"))
+        self.active_center_value = QLabel("Unavailable")
+        self.active_center_value.setWordWrap(True)
+        layout.addRow(self.active_center_value)
+
+        layout.addRow(QLabel("Nearest atom:"))
+        self.nearest_atom_value = QLabel("Unavailable")
+        self.nearest_atom_value.setWordWrap(True)
+        layout.addRow(self.nearest_atom_value)
+
+        self.reference_element_combo = QComboBox()
+        self.reference_element_combo.setEnabled(False)
+        self.reference_element_combo.currentIndexChanged.connect(
+            self._handle_reference_element_changed
+        )
+        layout.addRow("Reference element", self.reference_element_combo)
+
+        layout.addRow(QLabel("Total-atom geometric center:"))
+        self.geometric_center_value = QLabel("Unavailable")
+        self.geometric_center_value.setWordWrap(True)
+        layout.addRow(self.geometric_center_value)
+
+        layout.addRow(QLabel("Reference-element geometric center:"))
+        self.reference_element_center_value = QLabel("Unavailable")
+        self.reference_element_center_value.setWordWrap(True)
+        layout.addRow(self.reference_element_center_value)
+
+        layout.addRow(QLabel("Reference-center offset:"))
+        self.reference_element_offset_value = QLabel("Unavailable")
+        self.reference_element_offset_value.setWordWrap(True)
+        layout.addRow(self.reference_element_offset_value)
+
+        layout.addRow(QLabel("Snap center:"))
+        center_button_row = QWidget(group)
+        center_button_grid = QGridLayout(center_button_row)
+        center_button_grid.setContentsMargins(0, 0, 0, 0)
+        center_button_grid.setSpacing(4)
+
+        self.reset_center_button = QPushButton("Calculated Center")
+        self.reset_center_button.setCheckable(True)
+        self.reset_center_button.clicked.connect(
+            lambda _checked=False: self._apply_center_mode("center_of_mass")
+        )
+        center_button_grid.addWidget(self.reset_center_button, 0, 0)
+
+        self.snap_center_button = QPushButton("Nearest Atom")
+        self.snap_center_button.setCheckable(True)
+        self.snap_center_button.clicked.connect(
+            lambda _checked=False: self._apply_center_mode("nearest_atom")
+        )
+        center_button_grid.addWidget(self.snap_center_button, 0, 1)
+
+        self.snap_reference_center_button = QPushButton("Reference Element")
+        self.snap_reference_center_button.setCheckable(True)
+        self.snap_reference_center_button.clicked.connect(
+            lambda _checked=False: self._apply_center_mode("reference_element")
+        )
+        center_button_grid.addWidget(self.snap_reference_center_button, 1, 0)
+
+        self._center_snap_button_group = QButtonGroup(group)
+        self._center_snap_button_group.setExclusive(True)
+        self._center_snap_button_group.addButton(self.reset_center_button)
+        self._center_snap_button_group.addButton(self.snap_center_button)
+        self._center_snap_button_group.addButton(
+            self.snap_reference_center_button
+        )
+        self.reset_center_button.setChecked(True)
+        layout.addRow(center_button_row)
+
+        self.update_mesh_button = QPushButton("Update Mesh Settings")
+        self.update_mesh_button.clicked.connect(self._apply_mesh_from_controls)
+        layout.addRow(self.update_mesh_button)
+
+        layout.addRow(QLabel("Active mesh:"))
+        self.active_mesh_value = QLabel(
+            "Load a structure to render a spherical mesh overlay."
+        )
+        self.active_mesh_value.setWordWrap(True)
+        layout.addRow(self.active_mesh_value)
+
+        layout.addRow(QLabel("Pending fields:"))
+        self.pending_mesh_value = QLabel(
+            "Pending field values match the rendered mesh."
+        )
+        self.pending_mesh_value.setWordWrap(True)
+        layout.addRow(self.pending_mesh_value)
+        return group
+
+    @Slot()
+    def _choose_input_file(self) -> None:
+        start_dir = str(self._suggest_input_dir())
+        selected_path, _selected_filter = QFileDialog.getOpenFileName(
+            self,
+            "Choose Structure File",
+            start_dir,
+            "Structure Files (*.xyz *.pdb)",
+        )
+        if not selected_path:
+            return
+        self.input_path_edit.setText(selected_path)
+        self._load_input_from_edit()
+
+    def _suggest_input_dir(self) -> Path:
+        current_text = self.input_path_edit.text().strip()
+        if current_text:
+            candidate = Path(current_text).expanduser()
+            if candidate.is_file():
+                return candidate.parent
+            if candidate.is_dir():
+                return candidate
+        return Path.cwd()
+
+    @Slot()
+    def _load_input_from_edit(self) -> None:
+        raw_text = self.input_path_edit.text().strip()
+        if not raw_text:
+            self._show_error(
+                "No Structure Selected",
+                "Choose an XYZ or PDB file before loading the viewer.",
+            )
+            return
+        self._load_structure_path(Path(raw_text))
+
+    @Slot()
+    def _reload_current_structure(self) -> None:
+        if self._structure is None:
+            self._show_error(
+                "No Structure Loaded",
+                "Load a structure before reloading it.",
+            )
+            return
+        self._load_structure_path(self._structure.file_path)
+
+    def _load_structure_path(self, path: Path) -> None:
+        try:
+            structure = load_electron_density_structure(path)
+        except Exception as exc:
+            self._show_error("Structure Load Error", str(exc))
+            return
+
+        self._structure = structure
+        self.input_path_edit.setText(str(structure.file_path))
+        self.input_mode_value.setText("Single structure file")
+        self.reference_file_value.setText(str(structure.file_path))
+        self.reload_structure_action.setEnabled(True)
+        self._sync_controls_to_structure()
+        self._apply_mesh_settings(self._mesh_settings_from_controls())
+        self.structure_viewer.set_structure(
+            self._structure,
+            mesh_geometry=self._active_mesh_geometry,
+            reset_view=True,
+        )
+        self.viewer_status_label.setText(
+            f"Previewing {structure.display_label} from {structure.file_path.name}."
+        )
+        self.statusBar().showMessage(f"Loaded {structure.file_path.name}")
+
+    @staticmethod
+    def _format_point(values: np.ndarray) -> str:
+        array = np.asarray(values, dtype=float)
+        return f"({array[0]:.3f}, {array[1]:.3f}, {array[2]:.3f}) A"
+
+    @staticmethod
+    def _format_mesh_settings_summary(
+        settings: ElectronDensityMeshSettings,
+    ) -> str:
+        normalized = settings.normalized()
+        return (
+            f"rstep={normalized.rstep:.3f} A, "
+            f"theta={normalized.theta_divisions}, "
+            f"phi={normalized.phi_divisions}, "
+            f"rmax={normalized.rmax:.3f} A"
+        )
+
+    @staticmethod
+    def _center_mode_label_for_structure(
+        structure: ElectronDensityStructure | None,
+    ) -> str:
+        if structure is None:
+            return "Unavailable"
+        if structure.center_mode == "center_of_mass":
+            return "Mass-weighted center of mass"
+        if structure.center_mode == "nearest_atom":
+            return "Nearest atom to calculated center"
+        return (
+            f"{structure.reference_element} reference-element "
+            "geometric center"
+        )
+
+    def _mesh_settings_from_controls(self) -> ElectronDensityMeshSettings:
+        return ElectronDensityMeshSettings(
+            rstep=float(self.rstep_spin.value()),
+            theta_divisions=int(self.theta_divisions_spin.value()),
+            phi_divisions=int(self.phi_divisions_spin.value()),
+            rmax=float(self.rmax_spin.value()),
+        ).normalized()
+
+    def _selected_reference_element(self) -> str | None:
+        selected = (
+            self.reference_element_combo.currentData()
+            or self.reference_element_combo.currentText()
+        )
+        text = str(selected or "").strip()
+        return text or None
+
+    def _sync_reference_element_controls(self) -> None:
+        combo = self.reference_element_combo
+        combo.blockSignals(True)
+        combo.clear()
+        if self._structure is None:
+            combo.setEnabled(False)
+            combo.blockSignals(False)
+            return
+        for element in sorted(self._structure.element_counts):
+            count = int(self._structure.element_counts[element])
+            combo.addItem(f"{element} ({count})", element)
+        combo.setCurrentIndex(
+            max(combo.findData(self._structure.reference_element), 0)
+        )
+        combo.setEnabled(combo.count() > 0)
+        combo.blockSignals(False)
+
+    def _sync_controls_to_structure(self) -> None:
+        if self._structure is None:
+            return
+        self.rmax_spin.blockSignals(True)
+        try:
+            self.rmax_spin.setValue(max(float(self._structure.rmax), 0.01))
+        finally:
+            self.rmax_spin.blockSignals(False)
+        self._sync_reference_element_controls()
+        self._refresh_center_display()
+        self._refresh_structure_summary()
+        self._refresh_active_mesh_display()
+        self._refresh_mesh_notice()
+
+    def _refresh_structure_summary(self) -> None:
+        if self._structure is None:
+            self.structure_summary_value.setText(
+                "Load a structure to populate atoms, element counts, center "
+                "of mass, reference-element center, current center, and rmax."
+            )
+            return
+        structure = self._structure
+        self.structure_summary_value.setText(
+            f"{structure.atom_count} atoms, "
+            + ", ".join(
+                f"{element} x{count}"
+                for element, count in structure.element_counts.items()
+            )
+            + "; calculated center="
+            + self._format_point(structure.center_of_mass)
+            + f"; {structure.reference_element} geometric center="
+            + self._format_point(structure.reference_element_geometric_center)
+            + "; active center="
+            + self._format_point(structure.active_center)
+            + f"; rmax={structure.rmax:.3f} A"
+        )
+
+    def _refresh_center_display(self) -> None:
+        if self._structure is None:
+            self.center_mode_value.setText("Mass-weighted center of mass")
+            self.calculated_center_value.setText("Unavailable")
+            self.active_center_value.setText("Unavailable")
+            self.nearest_atom_value.setText("Unavailable")
+            self.geometric_center_value.setText("Unavailable")
+            self.reference_element_center_value.setText("Unavailable")
+            self.reference_element_offset_value.setText("Unavailable")
+            self.reference_element_combo.setEnabled(False)
+            self.reset_center_button.setChecked(True)
+            self.snap_center_button.setChecked(False)
+            self.snap_reference_center_button.setChecked(False)
+            return
+        structure = self._structure
+        self.center_mode_value.setText(
+            self._center_mode_label_for_structure(structure)
+        )
+        self.reset_center_button.setChecked(
+            structure.center_mode == "center_of_mass"
+        )
+        self.snap_center_button.setChecked(
+            structure.center_mode == "nearest_atom"
+        )
+        self.snap_reference_center_button.setChecked(
+            structure.center_mode == "reference_element"
+        )
+        self.calculated_center_value.setText(
+            self._format_point(structure.center_of_mass)
+        )
+        self.geometric_center_value.setText(
+            self._format_point(structure.geometric_center)
+        )
+        self.reference_element_center_value.setText(
+            f"{structure.reference_element}: "
+            f"{self._format_point(structure.reference_element_geometric_center)}"
+        )
+        self.reference_element_offset_value.setText(
+            f"{structure.reference_element_offset_from_geometric_center:.3f} A "
+            "from the total-atom geometric center"
+        )
+        self.active_center_value.setText(
+            self._format_point(structure.active_center)
+        )
+        self.nearest_atom_value.setText(
+            f"#{structure.nearest_atom_index + 1} "
+            f"{structure.nearest_atom_element} at "
+            f"{self._format_point(structure.nearest_atom_coordinates)}; "
+            f"{structure.nearest_atom_distance:.3f} A from the calculated center"
+        )
+
+    def _refresh_active_mesh_display(self) -> None:
+        center_label = self._center_mode_label_for_structure(self._structure)
+        center_text = (
+            self._format_point(self._structure.active_center)
+            if self._structure is not None
+            else "Unavailable"
+        )
+        if self._active_mesh_geometry is None:
+            self.active_mesh_value.setText(
+                "No active mesh is rendered yet. The current settings are "
+                f"{self._format_mesh_settings_summary(self._active_mesh_settings)}, "
+                f"center mode={center_label}, center={center_text}."
+            )
+            return
+        geometry = self._active_mesh_geometry
+        self.active_mesh_value.setText(
+            f"{self._format_mesh_settings_summary(geometry.settings)}, "
+            f"shells={geometry.shell_count}, "
+            f"domain=0 to {geometry.domain_max_radius:.3f} A, "
+            f"center mode={center_label}, center={center_text}"
+        )
+
+    @Slot()
+    def _refresh_mesh_notice(self) -> None:
+        if self._structure is None:
+            self.pending_mesh_value.setText(
+                "Load a structure to compare pending mesh fields to the "
+                "rendered mesh."
+            )
+            self.pending_mesh_value.setStyleSheet("color: #475569;")
+            return
+        pending = self._mesh_settings_from_controls()
+        if pending != self._active_mesh_settings:
+            self.pending_mesh_value.setText(
+                "Pending field values differ from the rendered mesh. Press "
+                "Update Mesh Settings to redraw the spherical overlay."
+            )
+            self.pending_mesh_value.setStyleSheet("color: #92400e;")
+            return
+        self.pending_mesh_value.setText(
+            "Pending field values match the rendered mesh."
+        )
+        self.pending_mesh_value.setStyleSheet("color: #166534;")
+
+    @Slot()
+    def _apply_mesh_from_controls(self) -> None:
+        if self._structure is None:
+            self._show_error(
+                "No Structure Loaded",
+                "Load a structure before updating the mesh overlay.",
+            )
+            return
+        self._apply_mesh_settings(self._mesh_settings_from_controls())
+        self.statusBar().showMessage("Updated mesh settings")
+
+    def _apply_mesh_settings(
+        self,
+        settings: ElectronDensityMeshSettings,
+        *,
+        preserve_viewer_display: bool = False,
+    ) -> None:
+        self._active_mesh_settings = settings.normalized()
+        self._active_mesh_geometry = None
+        if self._structure is not None:
+            self._active_mesh_geometry = build_electron_density_mesh(
+                self._structure,
+                self._active_mesh_settings,
+            )
+        self._refresh_active_mesh_display()
+        self._refresh_mesh_notice()
+        if self._structure is None:
+            return
+        if preserve_viewer_display:
+            self.structure_viewer.set_structure_preserving_display(
+                self._structure,
+                mesh_geometry=self._active_mesh_geometry,
+            )
+            return
+        self.structure_viewer.set_structure(
+            self._structure,
+            mesh_geometry=self._active_mesh_geometry,
+            reset_view=False,
+        )
+
+    def _apply_center_mode(self, center_mode: str) -> None:
+        if self._structure is None:
+            self._show_error(
+                "No Structure Loaded",
+                "Load a structure before changing the active center.",
+            )
+            return
+        try:
+            self._structure = recenter_electron_density_structure(
+                self._structure,
+                center_mode=center_mode,
+                reference_element=self._selected_reference_element(),
+            )
+        except Exception as exc:
+            self._show_error("Center Update Error", str(exc))
+            return
+        self._sync_controls_to_structure()
+        self._apply_mesh_settings(
+            self._mesh_settings_from_controls(),
+            preserve_viewer_display=True,
+        )
+        self.statusBar().showMessage("Updated active center")
+
+    @Slot()
+    def _handle_reference_element_changed(self) -> None:
+        if self._structure is None:
+            return
+        reference_element = self._selected_reference_element()
+        if (
+            reference_element is None
+            or reference_element == self._structure.reference_element
+        ):
+            return
+        previous_structure = self._structure
+        try:
+            self._structure = recenter_electron_density_structure(
+                self._structure,
+                center_mode=self._structure.center_mode,
+                reference_element=reference_element,
+            )
+        except Exception as exc:
+            self._show_error("Reference Element Error", str(exc))
+            self._sync_reference_element_controls()
+            return
+        active_center_changed = not np.allclose(
+            previous_structure.active_center,
+            self._structure.active_center,
+        ) or not np.isclose(previous_structure.rmax, self._structure.rmax)
+        self._sync_controls_to_structure()
+        if active_center_changed:
+            self._apply_mesh_settings(
+                self._mesh_settings_from_controls(),
+                preserve_viewer_display=True,
+            )
+            self.statusBar().showMessage("Updated reference-element center")
+            return
+        self.statusBar().showMessage("Updated reference element")
+
+    def _show_error(self, title: str, message: str) -> None:
+        QMessageBox.critical(self, title, message)
+
+
+def _forget_open_window(window: StructureViewerMainWindow) -> None:
+    if window in _OPEN_WINDOWS:
+        _OPEN_WINDOWS.remove(window)
+
+
+def launch_structure_viewer_ui(
+    *,
+    initial_input_path: str | Path | None = None,
+) -> StructureViewerMainWindow:
+    app = QApplication.instance()
+    if app is None:
+        prepare_saxshell_application_identity()
+        app = QApplication(sys.argv)
+    configure_saxshell_application(app)
+    window = StructureViewerMainWindow(
+        initial_input_path=(
+            None
+            if initial_input_path is None
+            else Path(initial_input_path).expanduser().resolve()
+        )
+    )
+    window.show()
+    window.raise_()
+    _OPEN_WINDOWS.append(window)
+    window.destroyed.connect(
+        lambda _obj=None, win=window: _forget_open_window(win)
+    )
+    return window
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="structureviewer",
+        description=(
+            "Launch the standalone SAXSShell Structure Viewer widget harness."
+        ),
+    )
+    parser.add_argument(
+        "input_path",
+        nargs="?",
+        type=Path,
+        help="Optional XYZ or PDB file to prefill in the window.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    app = QApplication.instance()
+    created_app = app is None
+    if app is None:
+        prepare_saxshell_application_identity()
+        app = QApplication(sys.argv)
+    launch_structure_viewer_ui(initial_input_path=args.input_path)
+    if created_app:
+        assert app is not None
+        return int(app.exec())
+    return 0
+
+
+__all__ = [
+    "StructureViewerMainWindow",
+    "build_parser",
+    "launch_structure_viewer_ui",
+    "main",
+]

--- a/src/saxshell/saxs/structure_viewer/ui/widget.py
+++ b/src/saxshell/saxs/structure_viewer/ui/widget.py
@@ -1,0 +1,1204 @@
+from __future__ import annotations
+
+import numpy as np
+from matplotlib.backend_bases import MouseButton
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.figure import Figure
+from matplotlib.lines import Line2D
+from mpl_toolkits.mplot3d import Axes3D  # noqa: F401
+from PySide6.QtCore import Qt, QTimer
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QColorDialog,
+    QDoubleSpinBox,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from saxshell.saxs.electron_density_mapping.workflow import (
+    ElectronDensityMeshGeometry,
+    ElectronDensityStructure,
+)
+from saxshell.toolbox.blender.common import (
+    DEFAULT_ATOM_STYLE,
+    atom_style_defaults,
+    style_atom_color,
+    style_display_radius,
+    style_neutral_bond_color,
+    style_split_bond_color,
+)
+
+_BACKGROUND_COLOR = "#fdfbf8"
+_EDGE_COLOR = (0.16, 0.14, 0.20)
+_SHADOW_COLOR = (0.26, 0.17, 0.30)
+_AXIS_COLORS = (
+    ("x", "#d9534f"),
+    ("y", "#3aa655"),
+    ("z", "#3b7ddd"),
+)
+_DEFAULT_MESH_COLOR = "#2b8cbe"
+_DEFAULT_MESH_LINEWIDTH = 1.35
+_CAMERA_AZIM = -62.0
+_CAMERA_ELEV = 22.0
+_DEFAULT_ATOM_CONTRAST = 1.0
+_DEFAULT_MESH_CONTRAST = 0.60
+_ORIGIN_GUIDE_CUTOFF_A = 3.0
+_POINT_ATOM_SIZE = 26.0
+_ACTIVE_READOUT_COLOR = "#9ad8ff"
+_ACTIVE_READOUT_BACKGROUND = (0.05, 0.10, 0.17, 0.78)
+_VIEW_UPDATE_INTERVAL_MS = 16
+_DEFAULT_VIEW_RADIUS_REBASE = 0.5
+
+
+def _clamp_fraction(value: float) -> float:
+    return float(max(0.0, min(1.0, float(value))))
+
+
+def _rotation_matrix_from_axis_angle(
+    axis: np.ndarray,
+    angle_radians: float,
+) -> np.ndarray:
+    axis_vector = np.asarray(axis, dtype=float)
+    norm = float(np.linalg.norm(axis_vector))
+    if norm <= 1.0e-12 or abs(float(angle_radians)) <= 1.0e-12:
+        return np.eye(3, dtype=float)
+    axis_vector = axis_vector / norm
+    x_value, y_value, z_value = axis_vector
+    cosine = float(np.cos(angle_radians))
+    sine = float(np.sin(angle_radians))
+    one_minus_cosine = 1.0 - cosine
+    return np.asarray(
+        [
+            [
+                cosine + x_value * x_value * one_minus_cosine,
+                x_value * y_value * one_minus_cosine - z_value * sine,
+                x_value * z_value * one_minus_cosine + y_value * sine,
+            ],
+            [
+                y_value * x_value * one_minus_cosine + z_value * sine,
+                cosine + y_value * y_value * one_minus_cosine,
+                y_value * z_value * one_minus_cosine - x_value * sine,
+            ],
+            [
+                z_value * x_value * one_minus_cosine - y_value * sine,
+                z_value * y_value * one_minus_cosine + x_value * sine,
+                cosine + z_value * z_value * one_minus_cosine,
+            ],
+        ],
+        dtype=float,
+    )
+
+
+def _orthonormalize_rotation(matrix: np.ndarray) -> np.ndarray:
+    left, _singular_values, right = np.linalg.svd(
+        np.asarray(matrix, dtype=float)
+    )
+    rotation = left @ right
+    if float(np.linalg.det(rotation)) < 0.0:
+        left[:, -1] *= -1.0
+        rotation = left @ right
+    return np.asarray(rotation, dtype=float)
+
+
+def _sample_values(values: np.ndarray, *, max_count: int) -> np.ndarray:
+    array = np.asarray(values, dtype=float)
+    if array.size <= max_count:
+        return array
+    indices = np.linspace(
+        0,
+        array.size - 1,
+        max_count,
+        dtype=int,
+    )
+    return array[np.unique(indices)]
+
+
+class _PassiveWheelFigureCanvas(FigureCanvas):
+    def wheelEvent(self, event) -> None:  # noqa: N802 - Qt override
+        event.ignore()
+
+
+class StructureViewerWidget(QWidget):
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self.current_structure: ElectronDensityStructure | None = None
+        self.current_mesh_geometry: ElectronDensityMeshGeometry | None = None
+        self.figure = Figure(figsize=(8.4, 6.2))
+        self.canvas = _PassiveWheelFigureCanvas(self.figure)
+        self._axis = None
+        self._axis_reference = None
+        self._active_settings_artist = None
+        self._view_center = np.zeros(3, dtype=float)
+        self._view_radius = 1.0
+        self._interaction_mode = "rotate"
+        self._drag_mode: str | None = None
+        self._drag_start_xy = (0.0, 0.0)
+        self._drag_start_center = np.zeros(3, dtype=float)
+        self._drag_start_radius = 1.0
+        self._drag_start_rotation = np.eye(3, dtype=float)
+        self._scene_rotation = np.eye(3, dtype=float)
+        self._mesh_visible = True
+        self._atom_contrast = _DEFAULT_ATOM_CONTRAST
+        self._mesh_contrast = _DEFAULT_MESH_CONTRAST
+        self._mesh_linewidth = _DEFAULT_MESH_LINEWIDTH
+        self._mesh_color = _DEFAULT_MESH_COLOR
+        self._atom_render_mode = "points"
+        self._pending_view_update = False
+        self._pending_axis_reference_refresh = False
+        self._view_update_timer = QTimer(self)
+        self._view_update_timer.setSingleShot(True)
+        self._view_update_timer.setTimerType(Qt.TimerType.PreciseTimer)
+        self._view_update_timer.timeout.connect(self._flush_view_update)
+        self._build_ui()
+        self._connect_canvas_events()
+        self.draw_placeholder()
+
+    def _build_ui(self) -> None:
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+
+        toolbar_row = QHBoxLayout()
+        toolbar_row.setContentsMargins(0, 0, 0, 0)
+        toolbar_row.setSpacing(6)
+        self.rotate_button = QPushButton("Rotate")
+        self.rotate_button.setCheckable(True)
+        self.rotate_button.clicked.connect(
+            lambda _checked=False: self._set_interaction_mode("rotate")
+        )
+        toolbar_row.addWidget(self.rotate_button)
+
+        self.pan_button = QPushButton("Pan")
+        self.pan_button.setCheckable(True)
+        self.pan_button.clicked.connect(
+            lambda _checked=False: self._set_interaction_mode("pan")
+        )
+        toolbar_row.addWidget(self.pan_button)
+
+        self.zoom_button = QPushButton("Zoom")
+        self.zoom_button.setCheckable(True)
+        self.zoom_button.clicked.connect(
+            lambda _checked=False: self._set_interaction_mode("zoom")
+        )
+        toolbar_row.addWidget(self.zoom_button)
+
+        self.autoscale_button = QPushButton("Autoscale")
+        self.autoscale_button.clicked.connect(self.autoscale_view)
+        toolbar_row.addWidget(self.autoscale_button)
+
+        self.reset_view_button = QPushButton("Reset View")
+        self.reset_view_button.clicked.connect(self.reset_view)
+        toolbar_row.addWidget(self.reset_view_button)
+
+        self.show_mesh_checkbox = QCheckBox("Show Mesh Overlay")
+        self.show_mesh_checkbox.setChecked(True)
+        self.show_mesh_checkbox.toggled.connect(self._handle_mesh_toggle)
+        toolbar_row.addWidget(self.show_mesh_checkbox)
+        toolbar_row.addStretch(1)
+        layout.addLayout(toolbar_row)
+
+        contrast_row = QHBoxLayout()
+        contrast_row.setContentsMargins(0, 0, 0, 0)
+        contrast_row.setSpacing(6)
+        contrast_row.addWidget(QLabel("Atom Contrast"))
+        self.atom_contrast_spin = QDoubleSpinBox(self)
+        self.atom_contrast_spin.setRange(0.0, 100.0)
+        self.atom_contrast_spin.setDecimals(0)
+        self.atom_contrast_spin.setSingleStep(5.0)
+        self.atom_contrast_spin.setSuffix("%")
+        self.atom_contrast_spin.setKeyboardTracking(False)
+        self.atom_contrast_spin.setValue(self._atom_contrast * 100.0)
+        self.atom_contrast_spin.valueChanged.connect(
+            self._handle_atom_contrast_changed
+        )
+        contrast_row.addWidget(self.atom_contrast_spin)
+
+        contrast_row.addWidget(QLabel("Mesh Contrast"))
+        self.mesh_contrast_spin = QDoubleSpinBox(self)
+        self.mesh_contrast_spin.setRange(0.0, 100.0)
+        self.mesh_contrast_spin.setDecimals(0)
+        self.mesh_contrast_spin.setSingleStep(5.0)
+        self.mesh_contrast_spin.setSuffix("%")
+        self.mesh_contrast_spin.setKeyboardTracking(False)
+        self.mesh_contrast_spin.setValue(self._mesh_contrast * 100.0)
+        self.mesh_contrast_spin.valueChanged.connect(
+            self._handle_mesh_contrast_changed
+        )
+        contrast_row.addWidget(self.mesh_contrast_spin)
+
+        contrast_row.addWidget(QLabel("Mesh Width"))
+        self.mesh_linewidth_spin = QDoubleSpinBox(self)
+        self.mesh_linewidth_spin.setRange(0.2, 10.0)
+        self.mesh_linewidth_spin.setDecimals(2)
+        self.mesh_linewidth_spin.setSingleStep(0.1)
+        self.mesh_linewidth_spin.setSuffix(" px")
+        self.mesh_linewidth_spin.setKeyboardTracking(False)
+        self.mesh_linewidth_spin.setValue(self._mesh_linewidth)
+        self.mesh_linewidth_spin.valueChanged.connect(
+            self._handle_mesh_linewidth_changed
+        )
+        contrast_row.addWidget(self.mesh_linewidth_spin)
+
+        self.mesh_color_button = QPushButton("Mesh Color")
+        self.mesh_color_button.clicked.connect(self._choose_mesh_color)
+        contrast_row.addWidget(self.mesh_color_button)
+
+        self.point_atoms_checkbox = QCheckBox("Point Atoms")
+        self.point_atoms_checkbox.setChecked(True)
+        self.point_atoms_checkbox.toggled.connect(
+            self._handle_point_atoms_toggle
+        )
+        contrast_row.addWidget(self.point_atoms_checkbox)
+        contrast_row.addStretch(1)
+        layout.addLayout(contrast_row)
+        self._update_mesh_color_button_style()
+
+        self.canvas.setMinimumHeight(520)
+        layout.addWidget(self.canvas, stretch=1)
+        self.setMinimumHeight(self.minimumSizeHint().height())
+        self._set_interaction_mode("rotate")
+
+    def _connect_canvas_events(self) -> None:
+        self.canvas.mpl_connect("button_press_event", self._handle_press)
+        self.canvas.mpl_connect("button_release_event", self._handle_release)
+        self.canvas.mpl_connect("motion_notify_event", self._handle_motion)
+
+    def _set_interaction_mode(self, mode: str) -> None:
+        if mode not in {"rotate", "pan", "zoom"}:
+            return
+        self._interaction_mode = mode
+        self.rotate_button.setChecked(mode == "rotate")
+        self.pan_button.setChecked(mode == "pan")
+        self.zoom_button.setChecked(mode == "zoom")
+        self._update_canvas_cursor()
+
+    def _update_canvas_cursor(self, *, dragging: bool = False) -> None:
+        if dragging:
+            if self._drag_mode == "zoom":
+                cursor = Qt.CursorShape.SizeVerCursor
+            else:
+                cursor = Qt.CursorShape.ClosedHandCursor
+        elif self._interaction_mode == "zoom":
+            cursor = Qt.CursorShape.SizeVerCursor
+        else:
+            cursor = Qt.CursorShape.OpenHandCursor
+        self.canvas.setCursor(cursor)
+
+    def draw_placeholder(self) -> None:
+        self.current_structure = None
+        self._clear_pending_view_update()
+        self._active_settings_artist = None
+        self.figure.clear()
+        axis = self.figure.add_subplot(111)
+        axis.text(
+            0.5,
+            0.57,
+            "Load an XYZ or PDB structure to preview atoms, bonds, and the "
+            "active-origin mesh frame.",
+            ha="center",
+            va="center",
+            wrap=True,
+            transform=axis.transAxes,
+        )
+        axis.text(
+            0.5,
+            0.40,
+            "The viewer uses Blender-inspired atom colors and bond styling, "
+            "with mouse-driven rotate, pan, and zoom controls.",
+            ha="center",
+            va="center",
+            wrap=True,
+            alpha=0.78,
+            transform=axis.transAxes,
+        )
+        axis.set_axis_off()
+        self.canvas.draw_idle()
+
+    def set_structure(
+        self,
+        structure: ElectronDensityStructure | None,
+        *,
+        mesh_geometry: ElectronDensityMeshGeometry | None = None,
+        reset_view: bool = True,
+        preserve_zoom_percentage: float | None = None,
+    ) -> None:
+        if structure is None:
+            self.draw_placeholder()
+            return
+        self.current_structure = structure
+        self.current_mesh_geometry = mesh_geometry
+        self._draw_view(
+            reset_view=reset_view,
+            preserve_zoom_percentage=preserve_zoom_percentage,
+        )
+
+    def set_structure_preserving_display(
+        self,
+        structure: ElectronDensityStructure | None,
+        *,
+        mesh_geometry: ElectronDensityMeshGeometry | None = None,
+    ) -> None:
+        if structure is None:
+            self.draw_placeholder()
+            return
+        self.current_structure = structure
+        self.current_mesh_geometry = mesh_geometry
+        self._atom_contrast = _clamp_fraction(
+            float(self.atom_contrast_spin.value()) / 100.0
+        )
+        self._mesh_contrast = _clamp_fraction(
+            float(self.mesh_contrast_spin.value()) / 100.0
+        )
+        self._mesh_linewidth = max(
+            float(self.mesh_linewidth_spin.value()),
+            0.2,
+        )
+        self._atom_render_mode = (
+            "points" if self.point_atoms_checkbox.isChecked() else "balls"
+        )
+        self._draw_view(reset_view=False)
+
+    def set_mesh_geometry(
+        self,
+        mesh_geometry: ElectronDensityMeshGeometry | None,
+    ) -> None:
+        self.current_mesh_geometry = mesh_geometry
+        if self.current_structure is not None:
+            self._draw_view(reset_view=False)
+
+    def autoscale_view(self) -> None:
+        if self.current_structure is None:
+            return
+        self._view_center = np.zeros(3, dtype=float)
+        self._view_radius = self._default_view_radius(self.current_structure)
+        self._schedule_view_update(immediate=True)
+
+    def reset_view(self) -> None:
+        if self.current_structure is None:
+            return
+        self._draw_view(reset_view=True)
+
+    def _default_view_radius(
+        self,
+        structure: ElectronDensityStructure,
+    ) -> float:
+        legacy_radius = self._legacy_default_view_radius(structure)
+        return max(
+            legacy_radius * _DEFAULT_VIEW_RADIUS_REBASE,
+            0.2,
+        )
+
+    def _legacy_default_view_radius(
+        self,
+        structure: ElectronDensityStructure,
+    ) -> float:
+        max_structure_radius = float(
+            np.max(np.linalg.norm(structure.centered_coordinates, axis=1))
+        )
+        mesh_radius = (
+            0.0
+            if self.current_mesh_geometry is None
+            else float(self.current_mesh_geometry.domain_max_radius)
+        )
+        return max(
+            max_structure_radius * 1.55,
+            mesh_radius * 1.15,
+            1.2,
+        )
+
+    def _view_radius_for_zoom_percentage(
+        self,
+        structure: ElectronDensityStructure,
+        zoom_percentage: float | None,
+    ) -> float:
+        if zoom_percentage is None:
+            return self._default_view_radius(structure)
+        normalized_zoom = max(float(zoom_percentage) / 100.0, 1.0e-3)
+        return float(
+            np.clip(
+                self._default_view_radius(structure) / normalized_zoom,
+                0.2,
+                1.0e6,
+            )
+        )
+
+    def _draw_view(
+        self,
+        *,
+        reset_view: bool,
+        preserve_zoom_percentage: float | None = None,
+    ) -> None:
+        structure = self.current_structure
+        if structure is None:
+            self.draw_placeholder()
+            return
+
+        self._clear_pending_view_update()
+        self._active_settings_artist = None
+        self.figure.clear()
+        axis = self.figure.add_subplot(
+            111,
+            projection="3d",
+            computed_zorder=False,
+        )
+        axis_reference = self.figure.add_axes(
+            [0.05, 0.05, 0.14, 0.14],
+            projection="3d",
+            computed_zorder=False,
+        )
+        axis_reference.set_in_layout(False)
+        self._axis = axis
+        self._axis_reference = axis_reference
+        self.figure.set_facecolor(_BACKGROUND_COLOR)
+        axis.set_facecolor(_BACKGROUND_COLOR)
+        axis.grid(False)
+        axis.set_xticks([])
+        axis.set_yticks([])
+        axis.set_zticks([])
+        axis.set_xlabel("")
+        axis.set_ylabel("")
+        axis.set_zlabel("")
+        try:
+            axis.set_proj_type("ortho")
+        except Exception:
+            pass
+        try:
+            axis.set_box_aspect((1.0, 1.0, 1.0))
+        except Exception:
+            pass
+        for axis_obj in (axis.xaxis, axis.yaxis, axis.zaxis):
+            try:
+                axis_obj.line.set_alpha(0.0)
+                axis_obj.pane.set_alpha(0.0)
+            except Exception:
+                pass
+
+        self._draw_bonds(axis, structure)
+        self._draw_atoms(axis, structure)
+        if self._mesh_visible and self.current_mesh_geometry is not None:
+            self._draw_mesh_overlay(axis, self.current_mesh_geometry)
+        self._draw_origin_guides(axis, structure)
+        self._draw_origin_axes(axis, structure)
+        self._draw_active_settings_readout(axis)
+        self._draw_legend(axis, structure)
+
+        if reset_view:
+            self._scene_rotation = np.eye(3, dtype=float)
+            self._view_center = np.zeros(3, dtype=float)
+            self._view_radius = self._view_radius_for_zoom_percentage(
+                structure,
+                preserve_zoom_percentage,
+            )
+        self._apply_view_to_axes(refresh_axis_reference=True)
+        axis.set_title(structure.display_label)
+        axis.axis("off")
+        self.figure.subplots_adjust(
+            left=0.01,
+            right=0.86,
+            bottom=0.02,
+            top=0.94,
+        )
+        self.canvas.draw_idle()
+
+    def _clear_pending_view_update(self) -> None:
+        self._pending_view_update = False
+        self._pending_axis_reference_refresh = False
+        self._view_update_timer.stop()
+
+    def _draw_atoms(
+        self,
+        axis,
+        structure: ElectronDensityStructure,
+    ) -> None:
+        if self._atom_contrast <= 0.0:
+            return
+        coordinates = self._transform_coordinates(
+            np.asarray(structure.centered_coordinates, dtype=float)
+        )
+        y_values = coordinates[:, 1]
+        depth_min = float(np.min(y_values))
+        depth_span = max(float(np.max(y_values) - depth_min), 1.0e-6)
+        for atom_index in np.argsort(y_values):
+            element = structure.elements[int(atom_index)]
+            depth_factor = (
+                float(y_values[atom_index]) - depth_min
+            ) / depth_span
+            color = style_atom_color(element, atom_style=DEFAULT_ATOM_STYLE)
+            size = (
+                style_display_radius(
+                    element,
+                    atom_style=DEFAULT_ATOM_STYLE,
+                )
+                * 30.0
+            ) ** 2
+            point = coordinates[int(atom_index)]
+            if self._atom_render_mode == "points":
+                axis.scatter(
+                    [point[0]],
+                    [point[1]],
+                    [point[2]],
+                    s=_POINT_ATOM_SIZE * (0.90 + depth_factor * 0.22),
+                    c=[color],
+                    alpha=0.95 * self._atom_contrast,
+                    edgecolors="none",
+                    linewidths=0.0,
+                    zorder=4,
+                    depthshade=False,
+                )
+                continue
+            axis.scatter(
+                [point[0]],
+                [point[1]],
+                [point[2]],
+                s=size * (1.06 + depth_factor * 0.22),
+                c=[_SHADOW_COLOR],
+                alpha=0.10 * self._atom_contrast,
+                linewidths=0.0,
+                zorder=3,
+            )
+            axis.scatter(
+                [point[0]],
+                [point[1]],
+                [point[2]],
+                s=size * (0.84 + depth_factor * 0.34),
+                c=[color],
+                alpha=0.94 * self._atom_contrast,
+                edgecolors=[_EDGE_COLOR],
+                linewidths=1.0,
+                zorder=4,
+                depthshade=False,
+            )
+
+    def _draw_bonds(
+        self,
+        axis,
+        structure: ElectronDensityStructure,
+    ) -> None:
+        if self._atom_contrast <= 0.0:
+            return
+        coordinates = self._transform_coordinates(
+            np.asarray(structure.centered_coordinates, dtype=float)
+        )
+        if coordinates.size == 0:
+            return
+        style_defaults = atom_style_defaults(DEFAULT_ATOM_STYLE)
+        bond_width = max(2.4, 10.0 * float(style_defaults["bond_radius"]))
+        neutral_bond_color = style_neutral_bond_color(DEFAULT_ATOM_STYLE)
+        y_values = coordinates[:, 1]
+        depth_min = float(np.min(y_values))
+        depth_span = max(float(np.max(y_values) - depth_min), 1.0e-6)
+        for left_index, right_index in sorted(
+            structure.bonds,
+            key=lambda pair: float(y_values[pair[0]] + y_values[pair[1]]),
+        ):
+            start = coordinates[int(left_index)]
+            end = coordinates[int(right_index)]
+            midpoint = (start + end) * 0.5
+            depth_factor = (
+                float(y_values[left_index] + y_values[right_index]) * 0.5
+                - depth_min
+            ) / depth_span
+            axis.plot(
+                (start[0], end[0]),
+                (start[1], end[1]),
+                (start[2], end[2]),
+                color=neutral_bond_color,
+                linewidth=bond_width + 1.4,
+                alpha=(0.24 + depth_factor * 0.10) * self._atom_contrast,
+                solid_capstyle="round",
+                zorder=1,
+            )
+            left_color = style_split_bond_color(
+                structure.elements[int(left_index)],
+                atom_style=DEFAULT_ATOM_STYLE,
+            )
+            right_color = style_split_bond_color(
+                structure.elements[int(right_index)],
+                atom_style=DEFAULT_ATOM_STYLE,
+            )
+            axis.plot(
+                (start[0], midpoint[0]),
+                (start[1], midpoint[1]),
+                (start[2], midpoint[2]),
+                color=left_color,
+                linewidth=bond_width,
+                alpha=(0.74 + depth_factor * 0.12) * self._atom_contrast,
+                solid_capstyle="round",
+                zorder=2,
+            )
+            axis.plot(
+                (midpoint[0], end[0]),
+                (midpoint[1], end[1]),
+                (midpoint[2], end[2]),
+                color=right_color,
+                linewidth=bond_width,
+                alpha=(0.74 + depth_factor * 0.12) * self._atom_contrast,
+                solid_capstyle="round",
+                zorder=2,
+            )
+
+    def _draw_origin_axes(
+        self,
+        axis,
+        structure: ElectronDensityStructure,
+    ) -> None:
+        mesh_radius = (
+            0.0
+            if self.current_mesh_geometry is None
+            else float(self.current_mesh_geometry.domain_max_radius)
+        )
+        coordinates = np.asarray(structure.centered_coordinates, dtype=float)
+        atom_radius = float(np.max(np.linalg.norm(coordinates, axis=1)))
+        axis_length = max(mesh_radius * 0.32, atom_radius * 0.55, 1.0)
+        for vector, (label, color) in zip(
+            self._transform_coordinates(np.eye(3, dtype=float) * axis_length),
+            _AXIS_COLORS,
+            strict=False,
+        ):
+            axis.plot(
+                (-vector[0], vector[0]),
+                (-vector[1], vector[1]),
+                (-vector[2], vector[2]),
+                color=color,
+                linewidth=1.4,
+                alpha=0.90,
+                zorder=10,
+            )
+            axis.text(
+                vector[0] * 1.08,
+                vector[1] * 1.08,
+                vector[2] * 1.08,
+                label,
+                color=color,
+                fontsize=8,
+                zorder=11,
+            )
+        axis.scatter(
+            [0.0],
+            [0.0],
+            [0.0],
+            s=22,
+            c=["#111827"],
+            depthshade=False,
+            zorder=11,
+        )
+
+    def _draw_origin_guides(
+        self,
+        axis,
+        structure: ElectronDensityStructure,
+    ) -> None:
+        coordinates = np.asarray(structure.centered_coordinates, dtype=float)
+        if coordinates.size == 0:
+            return
+        distances = np.linalg.norm(coordinates, axis=1)
+        nearby_indices = np.flatnonzero(distances <= _ORIGIN_GUIDE_CUTOFF_A)
+        if nearby_indices.size == 0:
+            return
+        transformed = self._transform_coordinates(coordinates[nearby_indices])
+        for point in transformed:
+            (line,) = axis.plot(
+                (0.0, point[0]),
+                (0.0, point[1]),
+                (0.0, point[2]),
+                color="#0f172a",
+                linewidth=1.0,
+                alpha=0.58,
+                linestyle=(0, (4.0, 3.0)),
+                zorder=9,
+            )
+            line.set_gid("origin-guide")
+
+    def _draw_legend(
+        self,
+        axis,
+        structure: ElectronDensityStructure,
+    ) -> None:
+        legend_handles = [
+            Line2D(
+                [0],
+                [0],
+                marker="o",
+                linestyle="None",
+                markersize=5.0 if self._atom_render_mode == "points" else 7.5,
+                markerfacecolor=style_atom_color(
+                    element,
+                    atom_style=DEFAULT_ATOM_STYLE,
+                ),
+                markeredgecolor=_EDGE_COLOR,
+                markeredgewidth=(
+                    0.0 if self._atom_render_mode == "points" else 1.0
+                ),
+                label=f"{element} ({structure.element_counts[element]})",
+            )
+            for element in sorted(structure.element_counts)
+        ]
+        if np.any(
+            np.linalg.norm(
+                np.asarray(structure.centered_coordinates, dtype=float),
+                axis=1,
+            )
+            <= _ORIGIN_GUIDE_CUTOFF_A
+        ):
+            legend_handles.append(
+                Line2D(
+                    [0],
+                    [0],
+                    color="#0f172a",
+                    linewidth=1.0,
+                    alpha=0.58,
+                    linestyle=(0, (4.0, 3.0)),
+                    label="Origin guides (<= 3 A)",
+                )
+            )
+        if self._mesh_visible and self.current_mesh_geometry is not None:
+            legend_handles.append(
+                Line2D(
+                    [0],
+                    [0],
+                    color=self._mesh_color,
+                    linewidth=self._mesh_linewidth,
+                    alpha=self._mesh_contrast,
+                    label="Spherical mesh",
+                )
+            )
+        if legend_handles:
+            legend = axis.legend(
+                handles=legend_handles,
+                loc="upper left",
+                bbox_to_anchor=(1.01, 0.98),
+                frameon=True,
+                fancybox=True,
+                framealpha=0.94,
+                borderpad=0.5,
+                labelspacing=0.35,
+                handletextpad=0.5,
+                borderaxespad=0.0,
+                fontsize=8.2,
+            )
+            frame = legend.get_frame()
+            frame.set_facecolor(_BACKGROUND_COLOR)
+            frame.set_edgecolor("#c6ccd4")
+            frame.set_linewidth(0.8)
+
+    def _draw_mesh_overlay(
+        self,
+        axis,
+        mesh_geometry: ElectronDensityMeshGeometry,
+    ) -> None:
+        if self._mesh_contrast <= 0.0:
+            return
+        radii = _sample_values(
+            np.asarray(mesh_geometry.radial_edges[1:], dtype=float),
+            max_count=8,
+        )
+        theta_edges = _sample_values(
+            np.asarray(mesh_geometry.theta_edges[1:-1], dtype=float),
+            max_count=10,
+        )
+        phi_edges = _sample_values(
+            np.asarray(mesh_geometry.phi_edges[:-1], dtype=float),
+            max_count=12,
+        )
+        full_phi = np.linspace(0.0, 2.0 * np.pi, 150)
+        full_theta = np.linspace(0.0, np.pi, 120)
+        for radius in radii:
+            for theta in theta_edges:
+                sin_theta = float(np.sin(theta))
+                cos_theta = float(np.cos(theta))
+                x_values = radius * sin_theta * np.cos(full_phi)
+                y_values = radius * sin_theta * np.sin(full_phi)
+                z_values = np.full_like(full_phi, radius * cos_theta)
+                transformed = self._transform_coordinates(
+                    np.column_stack((x_values, y_values, z_values))
+                )
+                axis.plot(
+                    transformed[:, 0],
+                    transformed[:, 1],
+                    transformed[:, 2],
+                    color=self._mesh_color,
+                    linewidth=self._mesh_linewidth,
+                    alpha=0.26 * self._mesh_contrast,
+                    zorder=8,
+                )
+            for phi in phi_edges:
+                sin_theta = np.sin(full_theta)
+                x_values = radius * sin_theta * np.cos(phi)
+                y_values = radius * sin_theta * np.sin(phi)
+                z_values = radius * np.cos(full_theta)
+                transformed = self._transform_coordinates(
+                    np.column_stack((x_values, y_values, z_values))
+                )
+                axis.plot(
+                    transformed[:, 0],
+                    transformed[:, 1],
+                    transformed[:, 2],
+                    color=self._mesh_color,
+                    linewidth=self._mesh_linewidth,
+                    alpha=0.26 * self._mesh_contrast,
+                    zorder=8,
+                )
+
+        theta_centers = _sample_values(
+            (
+                np.asarray(mesh_geometry.theta_edges[:-1], dtype=float)
+                + np.asarray(mesh_geometry.theta_edges[1:], dtype=float)
+            )
+            * 0.5,
+            max_count=6,
+        )
+        phi_centers = _sample_values(
+            (
+                np.asarray(mesh_geometry.phi_edges[:-1], dtype=float)
+                + np.asarray(mesh_geometry.phi_edges[1:], dtype=float)
+            )
+            * 0.5,
+            max_count=8,
+        )
+        radial_values = np.linspace(
+            0.0,
+            float(mesh_geometry.domain_max_radius),
+            28,
+        )
+        for theta in theta_centers:
+            sin_theta = float(np.sin(theta))
+            cos_theta = float(np.cos(theta))
+            for phi in phi_centers:
+                x_values = radial_values * sin_theta * np.cos(phi)
+                y_values = radial_values * sin_theta * np.sin(phi)
+                z_values = radial_values * cos_theta
+                transformed = self._transform_coordinates(
+                    np.column_stack((x_values, y_values, z_values))
+                )
+                axis.plot(
+                    transformed[:, 0],
+                    transformed[:, 1],
+                    transformed[:, 2],
+                    color=self._mesh_color,
+                    linewidth=max(self._mesh_linewidth * 0.88, 0.2),
+                    alpha=0.22 * self._mesh_contrast,
+                    zorder=8,
+                )
+
+    def _draw_active_settings_readout(self, axis) -> None:
+        artist = axis.text2D(
+            0.02,
+            0.98,
+            self._active_settings_readout_text(),
+            transform=axis.transAxes,
+            ha="left",
+            va="top",
+            color=_ACTIVE_READOUT_COLOR,
+            fontsize=8.8,
+            fontfamily="DejaVu Sans Mono",
+            fontweight="bold",
+            bbox={
+                "facecolor": _ACTIVE_READOUT_BACKGROUND,
+                "edgecolor": "none",
+                "boxstyle": "round,pad=0.32",
+            },
+            zorder=14,
+        )
+        artist.set_gid("active-visual-settings")
+        self._active_settings_artist = artist
+
+    def _active_settings_readout_text(self) -> str:
+        zoom_percentage = self._current_zoom_percentage()
+        zoom_text = (
+            "--.-%" if zoom_percentage is None else f"{zoom_percentage:05.1f}%"
+        )
+        return "\n".join(
+            (
+                f"ZOOM {zoom_text}",
+                f"ATOM {self._atom_contrast * 100.0:05.1f}%",
+                f"MESH {self._mesh_contrast * 100.0:05.1f}%",
+                f"LINE {self._mesh_linewidth:04.2f}px",
+                f"COLOR {self._mesh_color.upper()}",
+            )
+        )
+
+    def _current_zoom_percentage(self) -> float | None:
+        structure = self.current_structure
+        if structure is None:
+            return None
+        reference_radius = max(self._default_view_radius(structure), 1.0e-6)
+        current_radius = max(float(self._view_radius), 1.0e-6)
+        return max(reference_radius / current_radius * 100.0, 0.1)
+
+    def _refresh_active_settings_readout(self) -> None:
+        if self._active_settings_artist is None:
+            return
+        self._active_settings_artist.set_text(
+            self._active_settings_readout_text()
+        )
+
+    def _update_mesh_color_button_style(self) -> None:
+        self.mesh_color_button.setStyleSheet(
+            "QPushButton {"
+            f"background-color: {self._mesh_color};"
+            "color: white;"
+            "border: 1px solid #475569;"
+            "padding: 4px 8px;"
+            "}"
+        )
+        self.mesh_color_button.setText(
+            f"Mesh Color {self._mesh_color.upper()}"
+        )
+
+    def _choose_mesh_color(self) -> None:
+        selected = QColorDialog.getColor(
+            QColor(self._mesh_color),
+            self,
+            "Select Mesh Color",
+        )
+        if not selected.isValid():
+            return
+        self._mesh_color = str(selected.name())
+        self._update_mesh_color_button_style()
+        if self.current_structure is not None:
+            self._draw_view(reset_view=False)
+
+    def _schedule_view_update(
+        self,
+        *,
+        refresh_axis_reference: bool = False,
+        immediate: bool = False,
+    ) -> None:
+        if self._axis is None:
+            return
+        self._pending_view_update = True
+        self._pending_axis_reference_refresh = (
+            self._pending_axis_reference_refresh
+            or bool(refresh_axis_reference)
+        )
+        if immediate:
+            self._view_update_timer.stop()
+            self._flush_view_update()
+            return
+        if not self._view_update_timer.isActive():
+            self._view_update_timer.start(_VIEW_UPDATE_INTERVAL_MS)
+
+    def _flush_view_update(self) -> None:
+        if self._axis is None or not self._pending_view_update:
+            return
+        refresh_axis_reference = self._pending_axis_reference_refresh
+        self._pending_view_update = False
+        self._pending_axis_reference_refresh = False
+        self._apply_view_to_axes(refresh_axis_reference=refresh_axis_reference)
+        self.canvas.draw_idle()
+
+    def _apply_view_to_axes(
+        self,
+        *,
+        refresh_axis_reference: bool = True,
+    ) -> None:
+        if self._axis is None:
+            return
+        self._axis.set_xlim(
+            self._view_center[0] - self._view_radius,
+            self._view_center[0] + self._view_radius,
+        )
+        self._axis.set_ylim(
+            self._view_center[1] - self._view_radius,
+            self._view_center[1] + self._view_radius,
+        )
+        self._axis.set_zlim(
+            self._view_center[2] - self._view_radius,
+            self._view_center[2] + self._view_radius,
+        )
+        self._axis.view_init(elev=_CAMERA_ELEV, azim=_CAMERA_AZIM)
+        self._refresh_active_settings_readout()
+        if refresh_axis_reference:
+            self._draw_axis_reference()
+
+    def _draw_axis_reference(self) -> None:
+        if self._axis_reference is None:
+            return
+        axis_ref = self._axis_reference
+        axis_ref.cla()
+        axis_ref.set_facecolor((1.0, 1.0, 1.0, 0.0))
+        axis_ref.patch.set_alpha(0.0)
+        try:
+            axis_ref.set_proj_type("ortho")
+        except Exception:
+            pass
+        axis_ref.grid(False)
+        axis_ref.set_xticks([])
+        axis_ref.set_yticks([])
+        axis_ref.set_zticks([])
+        try:
+            axis_ref.set_box_aspect((1.0, 1.0, 1.0))
+        except Exception:
+            pass
+        for axis_obj in (axis_ref.xaxis, axis_ref.yaxis, axis_ref.zaxis):
+            try:
+                axis_obj.line.set_alpha(0.0)
+                axis_obj.pane.set_alpha(0.0)
+            except Exception:
+                pass
+        axis_ref.view_init(elev=_CAMERA_ELEV, azim=_CAMERA_AZIM)
+        axis_length = 0.8
+        label_scale = 1.15
+        axis_vectors = self._transform_coordinates(
+            np.eye(3, dtype=float) * axis_length
+        )
+        for vector, (label, color) in zip(
+            axis_vectors,
+            _AXIS_COLORS,
+            strict=False,
+        ):
+            axis_ref.plot(
+                (0.0, float(vector[0])),
+                (0.0, float(vector[1])),
+                (0.0, float(vector[2])),
+                color=color,
+                linewidth=2.0,
+            )
+            axis_ref.text(
+                float(vector[0]) * label_scale,
+                float(vector[1]) * label_scale,
+                float(vector[2]) * label_scale,
+                label,
+                color=color,
+                fontsize=8,
+            )
+        axis_ref.scatter(
+            [0.0],
+            [0.0],
+            [0.0],
+            s=10,
+            c=["#6b7280"],
+            depthshade=False,
+        )
+        axis_ref.set_xlim(-1.0, 1.0)
+        axis_ref.set_ylim(-1.0, 1.0)
+        axis_ref.set_zlim(-1.0, 1.0)
+
+    def _transform_coordinates(self, coordinates: np.ndarray) -> np.ndarray:
+        array = np.asarray(coordinates, dtype=float)
+        if array.size == 0:
+            return array.reshape((-1, 3))
+        return np.asarray(array @ self._scene_rotation.T, dtype=float)
+
+    def _camera_basis_vectors(self) -> tuple[np.ndarray, np.ndarray]:
+        azimuth = np.radians(_CAMERA_AZIM)
+        elevation = np.radians(_CAMERA_ELEV)
+        forward = np.array(
+            [
+                np.cos(elevation) * np.cos(azimuth),
+                np.cos(elevation) * np.sin(azimuth),
+                np.sin(elevation),
+            ],
+            dtype=float,
+        )
+        world_up = np.array([0.0, 0.0, 1.0], dtype=float)
+        right = np.cross(forward, world_up)
+        right_norm = float(np.linalg.norm(right))
+        if right_norm < 1.0e-8:
+            right = np.array([1.0, 0.0, 0.0], dtype=float)
+        else:
+            right /= right_norm
+        up = np.cross(right, forward)
+        up_norm = float(np.linalg.norm(up))
+        if up_norm < 1.0e-8:
+            up = np.array([0.0, 1.0, 0.0], dtype=float)
+        else:
+            up /= up_norm
+        return right, up
+
+    def _handle_press(self, event) -> None:
+        if self._axis is None or event.inaxes not in {
+            self._axis,
+            self._axis_reference,
+        }:
+            return
+        if event.button is MouseButton.LEFT:
+            self._drag_mode = self._interaction_mode
+        elif event.button in (MouseButton.MIDDLE, MouseButton.RIGHT):
+            self._drag_mode = "pan"
+        else:
+            self._drag_mode = None
+            return
+        self._drag_start_xy = (float(event.x), float(event.y))
+        self._drag_start_center = self._view_center.copy()
+        self._drag_start_radius = self._view_radius
+        self._drag_start_rotation = self._scene_rotation.copy()
+        self._update_canvas_cursor(dragging=True)
+
+    def _handle_release(self, _event) -> None:
+        self._drag_mode = None
+        if self._view_update_timer.isActive():
+            self._view_update_timer.stop()
+            self._flush_view_update()
+        self._update_canvas_cursor()
+
+    def _handle_motion(self, event) -> None:
+        if self._axis is None or self._drag_mode is None:
+            return
+        delta_x = float(event.x) - self._drag_start_xy[0]
+        delta_y = float(event.y) - self._drag_start_xy[1]
+        width = max(float(self.canvas.width()), 1.0)
+        height = max(float(self.canvas.height()), 1.0)
+        if self._drag_mode == "rotate":
+            right, up = self._camera_basis_vectors()
+            horizontal_rotation = _rotation_matrix_from_axis_angle(
+                up,
+                -delta_x * np.pi / width,
+            )
+            vertical_rotation = _rotation_matrix_from_axis_angle(
+                right,
+                delta_y * np.pi / height,
+            )
+            self._scene_rotation = _orthonormalize_rotation(
+                horizontal_rotation
+                @ vertical_rotation
+                @ self._drag_start_rotation
+            )
+            self._draw_view(reset_view=False)
+            return
+        if self._drag_mode == "pan":
+            data_scale = (2.0 * self._view_radius) / max(width, height)
+            right, up = self._camera_basis_vectors()
+            self._view_center = (
+                self._drag_start_center
+                + right * (-delta_x * data_scale)
+                + up * (delta_y * data_scale)
+            )
+        elif self._drag_mode == "zoom":
+            zoom_factor = float(np.exp(delta_y / height * 2.0))
+            self._view_radius = float(
+                np.clip(self._drag_start_radius * zoom_factor, 0.2, 1.0e6)
+            )
+        self._schedule_view_update(refresh_axis_reference=False)
+
+    def _handle_mesh_toggle(self, checked: bool) -> None:
+        self._mesh_visible = bool(checked)
+        if self.current_structure is not None:
+            self._draw_view(reset_view=False)
+
+    def _handle_atom_contrast_changed(self, value: float) -> None:
+        self._atom_contrast = _clamp_fraction(float(value) / 100.0)
+        if self.current_structure is not None:
+            self._draw_view(reset_view=False)
+
+    def _handle_mesh_contrast_changed(self, value: float) -> None:
+        self._mesh_contrast = _clamp_fraction(float(value) / 100.0)
+        if self.current_structure is not None:
+            self._draw_view(reset_view=False)
+
+    def _handle_mesh_linewidth_changed(self, value: float) -> None:
+        self._mesh_linewidth = max(float(value), 0.2)
+        if self.current_structure is not None:
+            self._draw_view(reset_view=False)
+
+    def _handle_point_atoms_toggle(self, checked: bool) -> None:
+        self._atom_render_mode = "points" if checked else "balls"
+        if self.current_structure is not None:
+            self._draw_view(reset_view=False)
+
+
+__all__ = ["StructureViewerWidget"]

--- a/src/saxshell/saxs/ui/_pane_snap.py
+++ b/src/saxshell/saxs/ui/_pane_snap.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from PySide6.QtCore import QEvent, QObject, Qt
+from PySide6.QtWidgets import QApplication, QScrollArea, QSplitter, QWidget
+
+
+class PaneSnapFilter(QObject):
+    """Global event filter that focuses a horizontal QSplitter on
+    whichever pane the user clicks in.
+
+    Install one instance per splitter. Call ``set_enabled(True)`` to activate
+    and ``set_enabled(False)`` to restore normal splitter behaviour. The filter
+    returns False for every event so it never swallows normal interactions.
+    """
+
+    def __init__(
+        self,
+        splitter: QSplitter,
+        left_widget: QWidget,
+        right_widget: QWidget,
+        parent: QObject | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self._splitter = splitter
+        self._left_widget = left_widget
+        self._right_widget = right_widget
+        self._enabled = False
+
+    def set_enabled(self, enabled: bool) -> None:
+        enabled = bool(enabled)
+        if enabled == self._enabled:
+            return
+        self._enabled = enabled
+        app = QApplication.instance()
+        if app is None:
+            return
+        if enabled:
+            app.installEventFilter(self)
+        else:
+            app.removeEventFilter(self)
+
+    def is_enabled(self) -> bool:
+        return self._enabled
+
+    # ------------------------------------------------------------------
+    # QObject interface
+    # ------------------------------------------------------------------
+
+    def eventFilter(self, watched: QObject, event: QEvent) -> bool:
+        if (
+            not self._enabled
+            or self._splitter.orientation() != Qt.Orientation.Horizontal
+            or not self._splitter.isVisible()
+        ):
+            return False
+        if event.type() == QEvent.Type.MouseButtonPress:
+            if self._is_descendant(watched, self._left_widget):
+                self._snap_to(0)
+            elif self._is_descendant(watched, self._right_widget):
+                self._snap_to(1)
+        return False  # never consume events
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _is_descendant(widget: QObject, ancestor: QWidget) -> bool:
+        w: QObject | None = widget
+        while w is not None:
+            if w is ancestor:
+                return True
+            w = w.parent()
+        return False
+
+    def _snap_to(self, index: int) -> None:
+        if self._splitter.count() < 2:
+            return
+        sizes = self._splitter.sizes()
+        if len(sizes) < 2:
+            return
+        handle_w = self._splitter.handleWidth()
+        total = self._splitter.width() - handle_w
+        if total <= 0:
+            return
+        left_w = self._left_widget
+        right_w = self._right_widget
+        left_min = self._minimum_width(left_w)
+        right_min = self._minimum_width(right_w)
+        left_max = self._clamp_width(total - right_min, left_min, total)
+        right_max = self._clamp_width(total - left_min, right_min, total)
+        if index == 0:
+            right = self._unfocused_width(
+                widget=right_w,
+                current_width=sizes[1],
+                minimum_width=right_min,
+                maximum_width=right_max,
+            )
+            left = self._clamp_width(total - right, left_min, left_max)
+            self._splitter.setSizes(
+                [left, self._clamp_width(total - left, right_min, right_max)]
+            )
+        else:
+            left = self._unfocused_width(
+                widget=left_w,
+                current_width=sizes[0],
+                minimum_width=left_min,
+                maximum_width=left_max,
+            )
+            right = self._clamp_width(total - left, right_min, right_max)
+            self._splitter.setSizes(
+                [self._clamp_width(total - right, left_min, left_max), right]
+            )
+
+    def _unfocused_width(
+        self,
+        *,
+        widget: QWidget,
+        current_width: int,
+        minimum_width: int,
+        maximum_width: int,
+    ) -> int:
+        preferred_width = self._clamp_width(
+            self._preferred_width(widget),
+            minimum_width,
+            maximum_width,
+        )
+        current_width = self._clamp_width(
+            current_width,
+            minimum_width,
+            maximum_width,
+        )
+        # A pane click should only shrink the opposite pane, never expand it.
+        return min(current_width, preferred_width)
+
+    @staticmethod
+    def _clamp_width(
+        width: int, minimum_width: int, maximum_width: int
+    ) -> int:
+        maximum_width = max(int(maximum_width), int(minimum_width))
+        return max(int(minimum_width), min(int(width), maximum_width))
+
+    @staticmethod
+    def _minimum_width(widget: QWidget) -> int:
+        return max(widget.minimumSizeHint().width(), widget.minimumWidth(), 1)
+
+    @staticmethod
+    def _preferred_width(widget: QWidget) -> int:
+        if isinstance(widget, QScrollArea):
+            inner = widget.widget()
+            if inner is not None:
+                w = inner.sizeHint().width()
+                # account for the vertical scrollbar and frame border
+                sb = widget.verticalScrollBar()
+                if sb is not None:
+                    w += sb.sizeHint().width()
+                w += widget.frameWidth() * 2
+                return max(w, widget.minimumSizeHint().width())
+        hint = widget.sizeHint().width()
+        return hint if hint > 0 else widget.width()

--- a/src/saxshell/saxs/ui/dream_tab.py
+++ b/src/saxshell/saxs/ui/dream_tab.py
@@ -45,6 +45,7 @@ from saxshell.saxs.dream import (
     DreamSummary,
     DreamViolinPlotData,
 )
+from saxshell.saxs.ui._pane_snap import PaneSnapFilter
 
 DREAM_SEARCH_FILTER_PRESETS: dict[str, dict[str, object]] = {
     "less_aggressive": {
@@ -146,6 +147,7 @@ class DreamTab(QWidget):
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
+        self._auto_snap_enabled = True
         self._console_autoscroll_enabled = True
         self._summary_text = ""
         self._base_log_text = ""
@@ -217,6 +219,13 @@ class DreamTab(QWidget):
         self._top_splitter.setStretchFactor(0, 4)
         self._top_splitter.setStretchFactor(1, 7)
         self._top_splitter.setSizes([420, 760])
+        self._auto_snap_filter = PaneSnapFilter(
+            self._top_splitter,
+            self._settings_scroll_area,
+            self._plot_scroll_area,
+            parent=self,
+        )
+        self.set_auto_snap_enabled(self._auto_snap_enabled)
         content_layout.addWidget(self._top_splitter)
 
         self._outer_scroll_area.setWidget(content)
@@ -1823,6 +1832,10 @@ class DreamTab(QWidget):
         self._console_autoscroll_enabled = bool(enabled)
         if self._console_autoscroll_enabled:
             self._scroll_output_to_end()
+
+    def set_auto_snap_enabled(self, enabled: bool) -> None:
+        self._auto_snap_enabled = bool(enabled)
+        self._auto_snap_filter.set_enabled(self._auto_snap_enabled)
 
     def append_runtime_output(self, message: str) -> None:
         stripped = message.rstrip()

--- a/src/saxshell/saxs/ui/main_window.py
+++ b/src/saxshell/saxs/ui/main_window.py
@@ -75,6 +75,7 @@ from saxshell.saxs._model_templates import (
     load_template_spec,
 )
 from saxshell.saxs.contrast.settings import (
+    COMPONENT_BUILD_MODE_BORN_APPROXIMATION,
     COMPONENT_BUILD_MODE_CONTRAST,
     component_build_mode_label,
     normalize_component_build_mode,
@@ -165,6 +166,7 @@ GITHUB_REPOSITORY_URL = "https://github.com/kewh5868/SAXSShell"
 CONTACT_EMAIL = "keith.white@colorado.edu"
 RECENT_PROJECTS_KEY = "recent_project_dirs"
 CONSOLE_AUTOSCROLL_KEY = "console_autoscroll_enabled"
+AUTO_SNAP_PANES_KEY = "auto_snap_panes_enabled"
 MAX_RECENT_PROJECTS = 10
 PROJECT_LOAD_PREP_STEPS = 4
 PROJECT_LOAD_TOTAL_STEPS = 12
@@ -1105,6 +1107,7 @@ class SAXSMainWindow(QMainWindow):
         self._prefit_missing_components_warning_shown = False
         self._updating_deprecated_template_visibility = False
         self._show_deprecated_templates = False
+        self._auto_snap_panes_enabled = self._load_auto_snap_panes_setting()
         self._console_autoscroll_enabled = (
             self._load_console_autoscroll_setting()
         )
@@ -1175,12 +1178,17 @@ class SAXSMainWindow(QMainWindow):
         self.project_setup_tab.set_console_autoscroll_enabled(
             self._console_autoscroll_enabled
         )
+        self.project_setup_tab.set_auto_snap_enabled(
+            self._auto_snap_panes_enabled
+        )
         self.prefit_tab.set_console_autoscroll_enabled(
             self._console_autoscroll_enabled
         )
+        self.prefit_tab.set_auto_snap_enabled(self._auto_snap_panes_enabled)
         self.dream_tab.set_console_autoscroll_enabled(
             self._console_autoscroll_enabled
         )
+        self.dream_tab.set_auto_snap_enabled(self._auto_snap_panes_enabled)
         self.tabs.addTab(self.project_setup_tab, "Project Setup")
         self.tabs.addTab(self.prefit_tab, "SAXS Prefit")
         self.tabs.addTab(self.dream_tab, "SAXS DREAM Fit")
@@ -1204,6 +1212,12 @@ class SAXSMainWindow(QMainWindow):
         )
         self.project_setup_tab.open_cluster_requested.connect(
             self._open_cluster_tool
+        )
+        self.project_setup_tab.open_clusterdynamicsml_requested.connect(
+            self._open_clusterdynamicsml_tool
+        )
+        self.project_setup_tab.open_debye_waller_requested.connect(
+            self._open_debye_waller_analysis_tool
         )
         self.project_setup_tab.model_only_mode_changed.connect(
             self._on_model_only_mode_changed
@@ -1405,27 +1419,42 @@ class SAXSMainWindow(QMainWindow):
         self.file_menu.addAction(self.save_project_as_action)
 
         self.tools_menu = menu_bar.addMenu("Tools")
+        self.md_extraction_menu = self.tools_menu.addMenu("MD Extraction")
         self.mdtrajectory_action = QAction(
             "Open MD Trajectory Extraction", self
         )
         self.mdtrajectory_action.triggered.connect(
             self._open_mdtrajectory_tool
         )
-        self.tools_menu.addAction(self.mdtrajectory_action)
+        self.md_extraction_menu.addAction(self.mdtrajectory_action)
 
         self.xyz2pdb_action = QAction("Open XYZ -> PDB Conversion", self)
         self.xyz2pdb_action.triggered.connect(self._open_xyz2pdb_tool)
-        self.tools_menu.addAction(self.xyz2pdb_action)
+        self.md_extraction_menu.addAction(self.xyz2pdb_action)
 
         self.cluster_action = QAction("Open Cluster Extraction", self)
         self.cluster_action.triggered.connect(self._open_cluster_tool)
-        self.tools_menu.addAction(self.cluster_action)
+        self.md_extraction_menu.addAction(self.cluster_action)
 
+        self.structure_analysis_menu = self.tools_menu.addMenu(
+            "Structure Analysis"
+        )
         self.bondanalysis_action = QAction("Open Bond Analysis", self)
         self.bondanalysis_action.triggered.connect(
             self._open_bondanalysis_tool
         )
-        self.tools_menu.addAction(self.bondanalysis_action)
+        self.structure_analysis_menu.addAction(self.bondanalysis_action)
+
+        self.debye_waller_analysis_action = QAction(
+            "Open Debye-Waller Analysis",
+            self,
+        )
+        self.debye_waller_analysis_action.triggered.connect(
+            self._open_debye_waller_analysis_tool
+        )
+        self.structure_analysis_menu.addAction(
+            self.debye_waller_analysis_action
+        )
 
         self.cluster_dynamics_menu = self.tools_menu.addMenu(
             "Cluster Dynamics"
@@ -1457,46 +1486,68 @@ class SAXSMainWindow(QMainWindow):
         self.fullrmc_action.triggered.connect(self._open_fullrmc_tool)
         self.pdf_menu.addAction(self.fullrmc_action)
 
+        self.visualization_menu = self.tools_menu.addMenu("Visualization")
+        self.structure_viewer_action = QAction(
+            "Structure Viewer",
+            self,
+        )
+        self.structure_viewer_action.triggered.connect(
+            self._open_structure_viewer_tool
+        )
+        self.visualization_menu.addAction(self.structure_viewer_action)
+
         self.blenderxyz_action = QAction(
             "Open Blender XYZ Renderer",
             self,
         )
         self.blenderxyz_action.triggered.connect(self._open_blenderxyz_tool)
-        self.tools_menu.addAction(self.blenderxyz_action)
+        self.visualization_menu.addAction(self.blenderxyz_action)
 
+        self.component_calculation_preview_menu = self.tools_menu.addMenu(
+            "SAXS Calculation Preview"
+        )
         self.contrast_mode_action = QAction(
             "Open SAXS Contrast Mode",
             self,
         )
         self.contrast_mode_action.triggered.connect(
-            self._open_contrast_mode_tool
+            lambda _checked=False: self._open_contrast_mode_tool(
+                preview_mode=True
+            )
         )
-        self.tools_menu.addAction(self.contrast_mode_action)
+        self.component_calculation_preview_menu.addAction(
+            self.contrast_mode_action
+        )
 
         self.electron_density_mapping_action = QAction(
             "Open Electron Density Mapping",
             self,
         )
         self.electron_density_mapping_action.triggered.connect(
-            self._open_electron_density_mapping_tool
+            lambda _checked=False: self._open_electron_density_mapping_tool(
+                preview_mode=True
+            )
         )
-        self.tools_menu.addAction(self.electron_density_mapping_action)
+        self.component_calculation_preview_menu.addAction(
+            self.electron_density_mapping_action
+        )
 
-        self.estimation_menu = self.tools_menu.addMenu("Estimation")
+        self.xray_toolkit_menu = self.tools_menu.addMenu("X-ray Toolkit")
+        self.estimation_menu = self.xray_toolkit_menu
         self.volume_fraction_action = QAction(
             "Open Volume Fraction Estimate", self
         )
         self.volume_fraction_action.triggered.connect(
             self._open_solute_volume_fraction_tool
         )
-        self.estimation_menu.addAction(self.volume_fraction_action)
+        self.xray_toolkit_menu.addAction(self.volume_fraction_action)
         self.number_density_action = QAction(
             "Open Number Density Estimate", self
         )
         self.number_density_action.triggered.connect(
             self._open_number_density_tool
         )
-        self.estimation_menu.addAction(self.number_density_action)
+        self.xray_toolkit_menu.addAction(self.number_density_action)
         self.attenuation_estimate_action = QAction(
             "Open Attenuation Estimate",
             self,
@@ -1504,7 +1555,7 @@ class SAXSMainWindow(QMainWindow):
         self.attenuation_estimate_action.triggered.connect(
             self._open_attenuation_tool
         )
-        self.estimation_menu.addAction(self.attenuation_estimate_action)
+        self.xray_toolkit_menu.addAction(self.attenuation_estimate_action)
         self.fluorescence_estimate_action = QAction(
             "Open Fluorescence Estimate",
             self,
@@ -1512,7 +1563,7 @@ class SAXSMainWindow(QMainWindow):
         self.fluorescence_estimate_action.triggered.connect(
             self._open_fluorescence_tool
         )
-        self.estimation_menu.addAction(self.fluorescence_estimate_action)
+        self.xray_toolkit_menu.addAction(self.fluorescence_estimate_action)
         self.settings_menu = menu_bar.addMenu("Settings")
         self.console_autoscroll_action = QAction(
             "Autoscroll Console Output",
@@ -1526,6 +1577,15 @@ class SAXSMainWindow(QMainWindow):
             self._toggle_console_autoscroll
         )
         self.settings_menu.addAction(self.console_autoscroll_action)
+        self.auto_snap_panes_action = QAction("Auto-Snap Panes", self)
+        self.auto_snap_panes_action.setCheckable(True)
+        self.auto_snap_panes_action.setChecked(
+            bool(self._auto_snap_panes_enabled)
+        )
+        self.auto_snap_panes_action.triggered.connect(
+            self._toggle_auto_snap_panes
+        )
+        self.settings_menu.addAction(self.auto_snap_panes_action)
         self.main_ui_settings_action = QAction(
             "Main UI Settings...",
             self,
@@ -1767,6 +1827,24 @@ class SAXSMainWindow(QMainWindow):
         self.tabs.setCurrentWidget(self.project_setup_tab)
         self.create_project_from_tab()
 
+    def _preferred_project_browser_start_dir(self) -> str:
+        if self.current_settings is not None:
+            project_dir = (
+                Path(self.current_settings.project_dir).expanduser().resolve()
+            )
+            if project_dir.parent.exists():
+                return str(project_dir.parent)
+            return str(project_dir)
+        recent_paths = self._recent_project_paths()
+        if recent_paths:
+            recent_project_dir = Path(recent_paths[0]).expanduser()
+            if recent_project_dir.exists():
+                resolved_dir = recent_project_dir.resolve()
+                if resolved_dir.parent.exists():
+                    return str(resolved_dir.parent)
+                return str(resolved_dir)
+        return str(Path.home())
+
     def open_project_from_dialog(self) -> None:
         try:
             selected_path = self.project_setup_tab.open_project_dir()
@@ -1776,7 +1854,7 @@ class SAXSMainWindow(QMainWindow):
             selected = QFileDialog.getExistingDirectory(
                 self,
                 "Open SAXS project folder",
-                str(Path.home()),
+                self._preferred_project_browser_start_dir(),
             )
             if selected:
                 self.load_project(self._validated_project_dir(selected))
@@ -1785,15 +1863,10 @@ class SAXSMainWindow(QMainWindow):
 
     def _open_project_from_menu(self) -> None:
         try:
-            start_dir = (
-                self.current_settings.project_dir
-                if self.current_settings is not None
-                else str(Path.home())
-            )
             selected = QFileDialog.getExistingDirectory(
                 self,
                 "Open SAXS project folder",
-                start_dir,
+                self._preferred_project_browser_start_dir(),
             )
             if selected:
                 self.tabs.setCurrentWidget(self.project_setup_tab)
@@ -2152,18 +2225,41 @@ class SAXSMainWindow(QMainWindow):
                 )
                 self.current_settings = settings
                 self.project_setup_tab.append_summary(
-                    "Build SAXS Components requested in Contrast Mode.\n"
+                    "Build SAXS Components requested in Contrast (Debye).\n"
                     "Launching the separate contrast-mode workflow window "
-                    "with the current project context.\n"
+                    "with the current computed-distribution context.\n"
                     "Run the representative analysis, electron-density step, "
-                    "and contrast Debye build from that window when you are "
-                    "ready.\n"
-                    "Switch Component Build Mode back to No Contrast Mode to "
-                    "use the existing SAXS component builder."
+                    "and contrast Debye build from that window when you are ready."
                 )
-                self._open_contrast_mode_tool()
+                self._open_contrast_mode_tool(preview_mode=False)
                 self.statusBar().showMessage(
                     "Opened SAXS contrast-mode workflow"
+                )
+                return
+            if (
+                settings.component_build_mode
+                == COMPONENT_BUILD_MODE_BORN_APPROXIMATION
+            ):
+                self._save_settings(
+                    settings,
+                    status_message=(
+                        "Project auto-saved before launching the Born "
+                        "Approximation electron-density workflow"
+                    ),
+                )
+                self.current_settings = settings
+                self.project_setup_tab.append_summary(
+                    "Build SAXS Components requested in Born Approximation "
+                    "(Average).\n"
+                    "Launching the electron-density mapping workflow with the "
+                    "active computed-distribution context.\n"
+                    "Use that workspace to calculate per-stoichiometry "
+                    "electron-density profiles and Fourier-transformed Born "
+                    "Approximation traces."
+                )
+                self._open_electron_density_mapping_tool(preview_mode=False)
+                self.statusBar().showMessage(
+                    "Opened electron-density Born Approximation workflow"
                 )
                 return
             self._save_settings(
@@ -2266,7 +2362,10 @@ class SAXSMainWindow(QMainWindow):
             settings = self._settings_from_project_tab()
             self._save_settings(
                 settings,
-                status_message="Project auto-saved before generating prior weights",
+                status_message=(
+                    "Project auto-saved before creating the computed "
+                    "distribution"
+                ),
             )
             self.current_settings = settings
             self._start_project_task(
@@ -2278,11 +2377,11 @@ class SAXSMainWindow(QMainWindow):
                         progress_callback=progress,
                     ),
                 ),
-                start_message="Generating prior weights...",
+                start_message="Creating computed distribution...",
                 settings=settings,
             )
         except Exception as exc:
-            self._show_error("Generate prior weights failed", str(exc))
+            self._show_error("Create computed distribution failed", str(exc))
 
     def install_model_template(self) -> None:
         try:
@@ -2968,23 +3067,24 @@ class SAXSMainWindow(QMainWindow):
             )
             if build_result.used_predicted_structure_weights:
                 self.project_setup_tab.append_summary(
-                    "Generated observed + Predicted Structures prior weights.\n"
+                    "Created computed distribution with observed + Predicted "
+                    "Structures prior weights.\n"
                     f"Predicted Structures included: {build_result.predicted_component_count}\n"
                     f"Saved prior weights: {build_result.md_prior_weights_path}\n"
                     f"Saved prior plot data: {build_result.prior_plot_data_path}"
                 )
             else:
                 self.project_setup_tab.append_summary(
-                    "Generated prior weights for "
+                    "Created computed distribution and generated prior weights for "
                     f"{len(build_result.component_entries)} cluster bins.\n"
                     f"Saved prior weights: {build_result.md_prior_weights_path}\n"
                     f"Saved prior plot data: {build_result.prior_plot_data_path}"
                 )
             self._refresh_prior_plot()
             self.project_setup_tab.finish_activity_progress(
-                "Prior-weight generation complete."
+                "Computed-distribution creation complete."
             )
-            self.statusBar().showMessage("Prior weights generated")
+            self.statusBar().showMessage("Computed distribution created")
         self._close_progress_dialog()
 
     @Slot(str, str)
@@ -7866,12 +7966,15 @@ class SAXSMainWindow(QMainWindow):
         active_settings = settings or self.current_settings
         if active_settings is None:
             self.project_setup_tab.set_available_distributions([])
+            self.project_setup_tab.set_current_distribution_details(None)
             self._update_active_contrast_distribution_view_state(None)
             return 0
         records = self.project_manager.list_saved_distributions(
             active_settings.project_dir
         )
         labels = []
+        tooltips: dict[str, str] = {}
+        details: dict[str, str] = {}
         for record in records:
             readiness = []
             if record.component_artifacts_ready:
@@ -7889,6 +7992,12 @@ class SAXSMainWindow(QMainWindow):
                     record.distribution_id,
                 )
             )
+            tooltips[record.distribution_id] = (
+                self._distribution_tooltip_for_record(record)
+            )
+            details[record.distribution_id] = (
+                self._distribution_details_for_record(record)
+            )
         selected_id = None
         if labels:
             selected_id = project_artifact_paths(
@@ -7897,9 +8006,221 @@ class SAXSMainWindow(QMainWindow):
         self.project_setup_tab.set_available_distributions(
             labels,
             selected_distribution_id=selected_id,
+            distribution_tooltips=tooltips,
+            distribution_details=details,
+        )
+        self.project_setup_tab.set_current_distribution_details(
+            self._current_distribution_details_text(active_settings)
         )
         self._update_active_contrast_distribution_view_state(active_settings)
         return len(records)
+
+    @staticmethod
+    def _distribution_q_range_text(
+        q_min: float | None,
+        q_max: float | None,
+    ) -> str:
+        if q_min is None or q_max is None:
+            return "default experimental range"
+        return f"{float(q_min):.6g} to {float(q_max):.6g} A^-1"
+
+    @staticmethod
+    def _distribution_grid_text(
+        *,
+        use_experimental_grid: bool,
+        q_points: int | None,
+    ) -> str:
+        if use_experimental_grid:
+            return "experimental grid"
+        return f"resampled grid ({int(q_points or 0)} points)"
+
+    @staticmethod
+    def _distribution_time_text(value: str | None) -> str:
+        text = str(value or "").strip()
+        return text or "Unavailable"
+
+    @staticmethod
+    def _distribution_prefit_summary(
+        distribution_dir: Path,
+    ) -> tuple[int, str]:
+        prefit_dir = distribution_dir / "prefit"
+        if not prefit_dir.is_dir():
+            return 0, "Unavailable"
+        snapshot_dirs = sorted(
+            path
+            for path in prefit_dir.iterdir()
+            if path.is_dir() and (path / "prefit_state.json").is_file()
+        )
+        state_path = prefit_dir / "prefit_state.json"
+        best_r_squared = "Unavailable"
+        if state_path.is_file():
+            try:
+                payload = json.loads(state_path.read_text(encoding="utf-8"))
+            except Exception:
+                payload = {}
+            statistics = payload.get("statistics", {})
+            if isinstance(statistics, dict):
+                value = statistics.get("r_squared")
+                if isinstance(value, (int, float)):
+                    best_r_squared = f"{float(value):.6g}"
+        return len(snapshot_dirs), best_r_squared
+
+    @staticmethod
+    def _distribution_dream_run_count(distribution_dir: Path) -> int:
+        runtime_dir = distribution_dir / "dream" / "runtime_scripts"
+        if not runtime_dir.is_dir():
+            return 0
+        return len([path for path in runtime_dir.iterdir() if path.is_dir()])
+
+    @staticmethod
+    def _distribution_component_count(distribution_dir: Path) -> int:
+        for candidate in (
+            distribution_dir / "md_saxs_map_predicted_structures.json",
+            distribution_dir / "md_saxs_map.json",
+        ):
+            if not candidate.is_file():
+                continue
+            try:
+                payload = json.loads(candidate.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            saxs_map = payload.get("saxs_map", {})
+            if not isinstance(saxs_map, dict):
+                continue
+            return sum(
+                len(motif_map)
+                for motif_map in saxs_map.values()
+                if isinstance(motif_map, dict)
+            )
+        return 0
+
+    def _distribution_tooltip_for_record(self, record) -> str:
+        return "\n".join(
+            [
+                record.label,
+                f"Distribution ID: {record.distribution_id}",
+                "Build mode: "
+                + component_build_mode_label(record.component_build_mode),
+                "Template: " + str(record.template_name or "Unspecified"),
+                "q-range: "
+                + self._distribution_q_range_text(
+                    record.q_min,
+                    record.q_max,
+                ),
+                "Grid: "
+                + self._distribution_grid_text(
+                    use_experimental_grid=record.use_experimental_grid,
+                    q_points=record.q_points,
+                ),
+                "Updated: " + self._distribution_time_text(record.updated_at),
+            ]
+        )
+
+    def _distribution_details_for_record(self, record) -> str:
+        component_count = self._distribution_component_count(
+            record.distribution_dir
+        )
+        prefit_count, best_prefit_r_squared = (
+            self._distribution_prefit_summary(record.distribution_dir)
+        )
+        dream_count = self._distribution_dream_run_count(
+            record.distribution_dir
+        )
+        excluded_text = ", ".join(record.exclude_elements) or "None"
+        return "\n".join(
+            [
+                f"Distribution ID: {record.distribution_id}",
+                "Template: " + str(record.template_name or "Unspecified"),
+                "Build mode: "
+                + component_build_mode_label(record.component_build_mode),
+                "Structure weighting: "
+                + (
+                    "Observed + Predicted Structures"
+                    if record.use_predicted_structure_weights
+                    else "Observed Only"
+                ),
+                "Clusters folder: "
+                + str(record.clusters_dir or "Unavailable"),
+                "Excluded elements: " + excluded_text,
+                "q-range: "
+                + self._distribution_q_range_text(record.q_min, record.q_max),
+                "Grid: "
+                + self._distribution_grid_text(
+                    use_experimental_grid=record.use_experimental_grid,
+                    q_points=record.q_points,
+                ),
+                "Saved components: "
+                + (
+                    f"ready ({component_count} traces)"
+                    if record.component_artifacts_ready
+                    else "not built yet"
+                ),
+                "Saved prior weights: "
+                + (
+                    "ready"
+                    if record.prior_artifacts_ready
+                    else "not built yet"
+                ),
+                f"Saved prefits: {prefit_count}",
+                f"Best Prefit R^2: {best_prefit_r_squared}",
+                f"Saved DREAM runs: {dream_count}",
+                "Best DREAM R^2: Available after loading a DREAM run",
+                "Created: " + self._distribution_time_text(record.created_at),
+                "Updated: " + self._distribution_time_text(record.updated_at),
+                "Folder: " + str(record.distribution_dir),
+            ]
+        )
+
+    def _current_distribution_details_text(
+        self,
+        settings: ProjectSettings,
+    ) -> str:
+        artifact_paths = project_artifact_paths(
+            settings,
+            storage_mode="distribution",
+        )
+        excluded_text = (
+            ", ".join(sorted(set(settings.exclude_elements))) or "None"
+        )
+        return "\n".join(
+            [
+                "Current Project Setup Snapshot",
+                "This is the configuration that will be saved when you click "
+                "Create Computed Distribution.",
+                "",
+                "Pending distribution ID: "
+                + str(artifact_paths.distribution_id or "Unavailable"),
+                "Template: "
+                + str(settings.selected_model_template or "Unspecified"),
+                "Build mode: "
+                + component_build_mode_label(settings.component_build_mode),
+                "Structure weighting: "
+                + (
+                    "Observed + Predicted Structures"
+                    if settings.use_predicted_structure_weights
+                    else "Observed Only"
+                ),
+                "Clusters folder: "
+                + str(
+                    settings.resolved_clusters_dir
+                    if settings.resolved_clusters_dir is not None
+                    else "Unavailable"
+                ),
+                "Excluded elements: " + excluded_text,
+                "q-range: "
+                + self._distribution_q_range_text(
+                    settings.q_min,
+                    settings.q_max,
+                ),
+                "Grid: "
+                + self._distribution_grid_text(
+                    use_experimental_grid=settings.use_experimental_grid,
+                    q_points=settings.q_points,
+                ),
+                "Model only mode: "
+                + ("on" if settings.model_only_mode else "off"),
+            ]
+        )
 
     def _set_dream_tab_enabled(self, enabled: bool) -> None:
         dream_index = self.tabs.indexOf(self.dream_tab)
@@ -8100,6 +8421,9 @@ class SAXSMainWindow(QMainWindow):
         )
         base.component_build_mode = (
             self.project_setup_tab.component_build_mode()
+        )
+        base.prior_histogram_x_axis_order = (
+            self.project_setup_tab.prior_histogram_x_axis_order()
         )
         return base
 
@@ -8538,6 +8862,7 @@ class SAXSMainWindow(QMainWindow):
     ) -> str:
         active_settings = settings or self.current_settings
         if active_settings is None:
+            self.project_setup_tab.set_predicted_structure_availability(False)
             status_text = (
                 self.project_setup_tab._default_predicted_structure_status_text()
             )
@@ -8545,10 +8870,35 @@ class SAXSMainWindow(QMainWindow):
                 status_text
             )
             return status_text
+        predicted_state = self.project_manager.inspect_predicted_structures(
+            active_settings.project_dir
+        )
+        predicted_available = bool(
+            predicted_state.dataset_file is not None
+            and predicted_state.prediction_count > 0
+        )
+        self.project_setup_tab.set_predicted_structure_availability(
+            predicted_available,
+            prediction_count=predicted_state.prediction_count,
+        )
         if not active_settings.use_predicted_structure_weights:
-            status_text = (
-                self.project_setup_tab._default_predicted_structure_status_text()
-            )
+            if (
+                predicted_available
+                and predicted_state.dataset_file is not None
+            ):
+                status_text = (
+                    "Predicted Structures mode is off.\n"
+                    f"Found {predicted_state.prediction_count} predicted "
+                    "structure"
+                    f"{'' if predicted_state.prediction_count == 1 else 's'} "
+                    f"in {predicted_state.dataset_file.name}. Enable Use "
+                    "Predicted Structure Weights to bring them into Project "
+                    "Setup, Prefit, and DREAM."
+                )
+            else:
+                status_text = (
+                    self.project_setup_tab._default_predicted_structure_status_text()
+                )
             self.project_setup_tab.set_predicted_structure_status_text(
                 status_text
             )
@@ -8562,9 +8912,6 @@ class SAXSMainWindow(QMainWindow):
         prior_artifacts_ready = bool(
             artifact_paths.prior_weights_file.is_file()
         )
-        predicted_state = self.project_manager.inspect_predicted_structures(
-            active_settings.project_dir
-        )
         if component_artifacts_ready and prior_artifacts_ready:
             status_text = (
                 "Predicted Structures mode is on.\n"
@@ -8575,14 +8922,24 @@ class SAXSMainWindow(QMainWindow):
                 status_text
             )
             return status_text
-        if predicted_state.dataset_file is None:
-            status_text = (
-                "Predicted Structures mode is on, but no Cluster Dynamics ML "
-                "prediction bundle was found in this project.\n"
-                "Open Tools > Cluster Dynamics > Open Cluster Dynamics (ML), "
-                "run a prediction, "
-                "then rebuild SAXS components and prior weights."
-            )
+        if not predicted_available:
+            if predicted_state.dataset_file is None:
+                status_text = (
+                    "Predicted Structures mode is on, but no Cluster "
+                    "Dynamics ML prediction bundle was found in this project.\n"
+                    "Open Tools > Cluster Dynamics > Open Cluster Dynamics "
+                    "(ML), run a prediction, then rebuild SAXS components "
+                    "and prior weights."
+                )
+            else:
+                status_text = (
+                    "Predicted Structures mode is on, but the latest "
+                    "Cluster Dynamics ML result bundle does not contain any "
+                    "predicted structures.\n"
+                    "Open Tools > Cluster Dynamics > Open Cluster Dynamics "
+                    "(ML), run a prediction, then rebuild SAXS components "
+                    "and prior weights."
+                )
             self.project_setup_tab.set_predicted_structure_status_text(
                 status_text
             )
@@ -9064,8 +9421,26 @@ class SAXSMainWindow(QMainWindow):
             "off",
         }
 
+    def _load_auto_snap_panes_setting(self) -> bool:
+        raw_value = self._recent_projects_settings().value(
+            AUTO_SNAP_PANES_KEY,
+            True,
+        )
+        if isinstance(raw_value, bool):
+            return raw_value
+        return str(raw_value).strip().lower() not in {
+            "",
+            "0",
+            "false",
+            "no",
+            "off",
+        }
+
     def _toggle_console_autoscroll(self, enabled: bool) -> None:
         self._set_console_autoscroll_enabled(enabled, persist=True)
+
+    def _toggle_auto_snap_panes(self, enabled: bool) -> None:
+        self._set_auto_snap_panes_enabled(enabled, persist=True)
 
     def _set_console_autoscroll_enabled(
         self,
@@ -9104,6 +9479,39 @@ class SAXSMainWindow(QMainWindow):
                     if self._console_autoscroll_enabled
                     else "disabled"
                 )
+            )
+
+    def _set_auto_snap_panes_enabled(
+        self,
+        enabled: bool,
+        *,
+        persist: bool,
+    ) -> None:
+        self._auto_snap_panes_enabled = bool(enabled)
+        if hasattr(self, "auto_snap_panes_action"):
+            self.auto_snap_panes_action.blockSignals(True)
+            self.auto_snap_panes_action.setChecked(
+                self._auto_snap_panes_enabled
+            )
+            self.auto_snap_panes_action.blockSignals(False)
+        if hasattr(self, "project_setup_tab"):
+            self.project_setup_tab.set_auto_snap_enabled(
+                self._auto_snap_panes_enabled
+            )
+        if hasattr(self, "prefit_tab"):
+            self.prefit_tab.set_auto_snap_enabled(
+                self._auto_snap_panes_enabled
+            )
+        if hasattr(self, "dream_tab"):
+            self.dream_tab.set_auto_snap_enabled(self._auto_snap_panes_enabled)
+        if persist:
+            self._recent_projects_settings().setValue(
+                AUTO_SNAP_PANES_KEY,
+                self._auto_snap_panes_enabled,
+            )
+            self.statusBar().showMessage(
+                "Auto-snap panes "
+                + ("enabled" if self._auto_snap_panes_enabled else "disabled")
             )
 
     def _recent_projects_settings(self) -> QSettings:
@@ -9306,7 +9714,10 @@ class SAXSMainWindow(QMainWindow):
                 "contrast-mode representative outputs to reopen.",
             )
             return
-        self._open_contrast_mode_tool(load_saved_distribution_view=True)
+        self._open_contrast_mode_tool(
+            preview_mode=False,
+            load_saved_distribution_view=True,
+        )
 
     def _connect_project_path_updates(self, window: object) -> None:
         signal = getattr(window, "project_paths_registered", None)
@@ -9319,6 +9730,18 @@ class SAXSMainWindow(QMainWindow):
         if signal is None or not hasattr(signal, "connect"):
             return
         signal.connect(self._on_contrast_components_built)
+
+    def _connect_born_approximation_updates(self, window: object) -> None:
+        signal = getattr(window, "born_components_built", None)
+        if signal is None or not hasattr(signal, "connect"):
+            return
+        signal.connect(self._on_born_components_built)
+
+    def _connect_debye_waller_updates(self, window: object) -> None:
+        signal = getattr(window, "project_analysis_saved", None)
+        if signal is None or not hasattr(signal, "connect"):
+            return
+        signal.connect(self._on_debye_waller_project_saved)
 
     def _track_child_tool_window(self, window: object) -> None:
         if window in self._child_tool_windows:
@@ -9438,6 +9861,10 @@ class SAXSMainWindow(QMainWindow):
 
         if "clusters_dir" in payload:
             self.project_setup_tab.request_cluster_scan()
+            self.project_setup_tab.refresh_debye_waller_controls()
+            self.project_setup_tab.refresh_debye_waller_project_status(
+                project_dir
+            )
 
         if updated_labels:
             summary = ", ".join(updated_labels)
@@ -9447,6 +9874,27 @@ class SAXSMainWindow(QMainWindow):
             )
             self.statusBar().showMessage(
                 "Updated project folder references from linked tool"
+            )
+
+    @Slot(object)
+    def _on_debye_waller_project_saved(self, payload: object) -> None:
+        if self.current_settings is None or not isinstance(payload, dict):
+            return
+        project_dir_value = payload.get("project_dir")
+        if project_dir_value is None:
+            return
+        project_dir = Path(project_dir_value).expanduser().resolve()
+        active_project_dir = (
+            Path(self.current_settings.project_dir).expanduser().resolve()
+        )
+        if project_dir != active_project_dir:
+            return
+        ready = self.project_setup_tab.refresh_debye_waller_project_status(
+            project_dir
+        )
+        if ready:
+            self.statusBar().showMessage(
+                "Debye-Waller factors saved to active project"
             )
 
     def _open_mdtrajectory_tool(self) -> None:
@@ -9547,6 +9995,82 @@ class SAXSMainWindow(QMainWindow):
             )
         else:
             self.statusBar().showMessage("Opened bond analysis")
+
+    def _open_debye_waller_analysis_tool(self) -> None:
+        from saxshell.saxs.debye_waller.ui.main_window import (
+            DEBYE_WALLER_WINDOW_LOAD_TOTAL_STEPS,
+            launch_debye_waller_analysis_ui,
+        )
+
+        settings = self._active_project_launch_settings()
+        clusters_dir = None
+        project_dir = None
+        if settings is not None:
+            clusters_dir = settings.resolved_clusters_dir
+            project_dir = Path(settings.project_dir).resolve()
+        startup_progress_callback = None
+        startup_log_callback = None
+        if project_dir is not None:
+            start_message = (
+                f"Opening Debye-Waller analysis for {project_dir.name}..."
+            )
+            self._show_progress_dialog(
+                DEBYE_WALLER_WINDOW_LOAD_TOTAL_STEPS,
+                start_message,
+                unit_label="steps",
+                title="Opening Debye-Waller Analysis",
+            )
+            if self._progress_dialog is not None:
+                self._progress_dialog.append_output(
+                    f"Loading Debye-Waller analysis from {project_dir}"
+                )
+            self.statusBar().showMessage(start_message)
+            QApplication.processEvents()
+
+            def on_startup_progress(
+                processed: int,
+                total: int,
+                message: str,
+            ) -> None:
+                if self._progress_dialog is not None:
+                    self._progress_dialog.update_progress(
+                        processed,
+                        total,
+                        message,
+                        unit_label="steps",
+                    )
+                self.statusBar().showMessage(message)
+                QApplication.processEvents()
+
+            def on_startup_log(message: str) -> None:
+                stripped = str(message).strip()
+                if not stripped:
+                    return
+                if self._progress_dialog is not None:
+                    self._progress_dialog.append_output(stripped)
+                QApplication.processEvents()
+
+            startup_progress_callback = on_startup_progress
+            startup_log_callback = on_startup_log
+        try:
+            window = launch_debye_waller_analysis_ui(
+                initial_project_dir=project_dir,
+                initial_clusters_dir=clusters_dir,
+                startup_progress_callback=startup_progress_callback,
+                startup_log_callback=startup_log_callback,
+            )
+        finally:
+            if project_dir is not None:
+                self._close_progress_dialog()
+        self._connect_project_path_updates(window)
+        self._connect_debye_waller_updates(window)
+        self._track_child_tool_window(window)
+        if clusters_dir is not None:
+            self.statusBar().showMessage(
+                f"Opened Debye-Waller analysis for {clusters_dir}"
+            )
+        else:
+            self.statusBar().showMessage("Opened Debye-Waller analysis")
 
     def _open_clusterdynamics_tool(self) -> None:
         from saxshell.clusterdynamics.ui.main_window import (
@@ -9659,9 +10183,19 @@ class SAXSMainWindow(QMainWindow):
         self._track_child_tool_window(window)
         self.statusBar().showMessage("Opened Blender XYZ renderer")
 
+    def _open_structure_viewer_tool(self) -> None:
+        from saxshell.saxs.structure_viewer.ui.main_window import (
+            launch_structure_viewer_ui,
+        )
+
+        window = launch_structure_viewer_ui()
+        self._track_child_tool_window(window)
+        self.statusBar().showMessage("Opened Structure Viewer")
+
     def _open_contrast_mode_tool(
         self,
         *,
+        preview_mode: bool = True,
         load_saved_distribution_view: bool = False,
     ) -> None:
         existing_window = self._contrast_mode_tool_window
@@ -9700,10 +10234,16 @@ class SAXSMainWindow(QMainWindow):
                         contrast_artifact_dir=contrast_artifact_dir,
                     )
                 )
+            if hasattr(existing_window, "set_preview_mode"):
+                existing_window.set_preview_mode(preview_mode)
             existing_window.show()
             existing_window.raise_()
             existing_window.activateWindow()
-            self.statusBar().showMessage("Opened SAXS contrast-mode workflow")
+            self.statusBar().showMessage(
+                "Opened SAXS contrast-mode preview"
+                if preview_mode
+                else "Opened SAXS contrast-mode workflow"
+            )
             return
 
         from saxshell.saxs.contrast.ui.main_window import (
@@ -9745,6 +10285,7 @@ class SAXSMainWindow(QMainWindow):
             initial_distribution_id=distribution_id,
             initial_distribution_root_dir=distribution_root_dir,
             initial_contrast_artifact_dir=contrast_artifact_dir,
+            preview_mode=preview_mode,
         )
         self._connect_project_path_updates(window)
         self._connect_contrast_mode_updates(window)
@@ -9763,12 +10304,22 @@ class SAXSMainWindow(QMainWindow):
         self._track_child_tool_window(window)
         if project_dir is not None:
             self.statusBar().showMessage(
-                f"Opened SAXS contrast-mode workflow for {project_dir}"
+                ("Opened SAXS contrast-mode preview for " f"{project_dir}")
+                if preview_mode
+                else f"Opened SAXS contrast-mode workflow for {project_dir}"
             )
         else:
-            self.statusBar().showMessage("Opened SAXS contrast-mode workflow")
+            self.statusBar().showMessage(
+                "Opened SAXS contrast-mode preview"
+                if preview_mode
+                else "Opened SAXS contrast-mode workflow"
+            )
 
-    def _open_electron_density_mapping_tool(self) -> None:
+    def _open_electron_density_mapping_tool(
+        self,
+        *,
+        preview_mode: bool = True,
+    ) -> None:
         from saxshell.saxs.electron_density_mapping.ui.main_window import (
             launch_electron_density_mapping_ui,
         )
@@ -9776,30 +10327,86 @@ class SAXSMainWindow(QMainWindow):
         settings = self._active_project_launch_settings()
         project_dir = None
         input_path = None
+        output_dir = None
+        q_min = None
+        q_max = None
+        distribution_id = None
+        distribution_root_dir = None
+        use_predicted_structure_weights = False
         if settings is not None:
             project_dir = Path(settings.project_dir).resolve()
-            for candidate in (
-                settings.resolved_pdb_frames_dir,
-                settings.resolved_frames_dir,
-            ):
+            q_min = settings.q_min
+            q_max = settings.q_max
+            use_predicted_structure_weights = bool(
+                settings.use_predicted_structure_weights
+            )
+            candidate_paths = (
+                (
+                    settings.resolved_pdb_frames_dir,
+                    settings.resolved_frames_dir,
+                )
+                if preview_mode
+                else (
+                    settings.resolved_clusters_dir,
+                    settings.resolved_pdb_frames_dir,
+                    settings.resolved_frames_dir,
+                )
+            )
+            for candidate in candidate_paths:
                 if candidate is not None and candidate.exists():
                     input_path = candidate
                     break
+            if not preview_mode:
+                artifact_paths = project_artifact_paths(
+                    settings,
+                    storage_mode="distribution",
+                )
+                distribution_id = artifact_paths.distribution_id
+                distribution_root_dir = artifact_paths.root_dir
+                output_dir = (
+                    artifact_paths.root_dir / "electron_density_mapping"
+                )
         window = launch_electron_density_mapping_ui(
             initial_project_dir=project_dir,
             initial_input_path=input_path,
+            initial_output_dir=output_dir,
+            initial_project_q_min=q_min,
+            initial_project_q_max=q_max,
+            initial_distribution_id=distribution_id,
+            initial_distribution_root_dir=distribution_root_dir,
+            initial_use_predicted_structure_weights=(
+                use_predicted_structure_weights
+            ),
+            preview_mode=preview_mode,
         )
+        if hasattr(window, "set_auto_snap_enabled"):
+            window.set_auto_snap_enabled(self._auto_snap_panes_enabled)
+        self._connect_born_approximation_updates(window)
         self._track_child_tool_window(window)
         if input_path is not None:
             self.statusBar().showMessage(
-                f"Opened electron density mapping for {input_path}"
+                (
+                    "Opened electron density mapping preview for "
+                    f"{input_path}"
+                )
+                if preview_mode
+                else f"Opened electron density mapping for {input_path}"
             )
         elif project_dir is not None:
             self.statusBar().showMessage(
-                f"Opened electron density mapping for {project_dir}"
+                (
+                    "Opened electron density mapping preview for "
+                    f"{project_dir}"
+                )
+                if preview_mode
+                else f"Opened electron density mapping for {project_dir}"
             )
         else:
-            self.statusBar().showMessage("Opened electron density mapping")
+            self.statusBar().showMessage(
+                "Opened electron density mapping preview"
+                if preview_mode
+                else "Opened electron density mapping"
+            )
 
     @Slot(object)
     def _on_contrast_components_built(self, payload: object) -> None:
@@ -9818,6 +10425,25 @@ class SAXSMainWindow(QMainWindow):
         self._load_saved_distribution(distribution_id)
         self.statusBar().showMessage(
             "Contrast SAXS components built and loaded"
+        )
+
+    @Slot(object)
+    def _on_born_components_built(self, payload: object) -> None:
+        if self.current_settings is None or not isinstance(payload, dict):
+            return
+        distribution_id = str(payload.get("distribution_id") or "").strip()
+        project_dir_value = str(payload.get("project_dir") or "").strip()
+        if not distribution_id or not project_dir_value:
+            return
+        active_project_dir = (
+            Path(self.current_settings.project_dir).expanduser().resolve()
+        )
+        payload_project_dir = Path(project_dir_value).expanduser().resolve()
+        if payload_project_dir != active_project_dir:
+            return
+        self._load_saved_distribution(distribution_id)
+        self.statusBar().showMessage(
+            "Born-approximation components built and loaded"
         )
 
     def _open_solution_scattering_tool_window(
@@ -10121,6 +10747,9 @@ class SAXSMainWindow(QMainWindow):
             cmap=self.project_setup_tab.prior_cmap(),
             structure_motif_colors=(
                 self.project_setup_tab.prior_structure_motif_colors()
+            ),
+            custom_label_order=(
+                self.project_setup_tab._active_prior_x_axis_order()
             ),
             parent=None,
         )

--- a/src/saxshell/saxs/ui/prefit_tab.py
+++ b/src/saxshell/saxs/ui/prefit_tab.py
@@ -50,6 +50,7 @@ from saxshell.saxs.prefit.cluster_geometry import (
     STRUCTURE_FACTOR_RECOMMENDATIONS,
     synchronize_cluster_geometry_row,
 )
+from saxshell.saxs.ui._pane_snap import PaneSnapFilter
 from saxshell.saxs.ui.solute_volume_fraction_widget import (
     SOLUTE_VOLUME_FRACTION_HELP_TEXT as SOLUTE_VOLUME_FRACTION_HELP_MESSAGE,
 )
@@ -201,6 +202,7 @@ class PrefitTab(QWidget):
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
+        self._auto_snap_enabled = True
         self._console_autoscroll_enabled = True
         self._current_evaluation: PrefitEvaluation | None = None
         self._summary_text = ""
@@ -293,6 +295,13 @@ class PrefitTab(QWidget):
         self._main_splitter.setStretchFactor(0, 4)
         self._main_splitter.setStretchFactor(1, 2)
         self._main_splitter.setSizes([760, 260])
+        self._auto_snap_filter = PaneSnapFilter(
+            self._pane_splitter,
+            self._left_scroll_area,
+            self._plot_group,
+            parent=self,
+        )
+        self.set_auto_snap_enabled(self._auto_snap_enabled)
         content_layout.addWidget(self._main_splitter, stretch=1)
 
         self._scroll_area.setWidget(content)
@@ -1913,6 +1922,10 @@ class PrefitTab(QWidget):
         self._console_autoscroll_enabled = bool(enabled)
         if self._console_autoscroll_enabled:
             self._scroll_output_to_end()
+
+    def set_auto_snap_enabled(self, enabled: bool) -> None:
+        self._auto_snap_enabled = bool(enabled)
+        self._auto_snap_filter.set_enabled(self._auto_snap_enabled)
 
     def _item_text(self, row: int, column: int) -> str:
         item = self.parameter_table.item(row, column)

--- a/src/saxshell/saxs/ui/prior_histogram_window.py
+++ b/src/saxshell/saxs/ui/prior_histogram_window.py
@@ -36,6 +36,7 @@ class PriorHistogramWindow(QMainWindow):
         secondary_element: str | None = None,
         cmap: str = "summer",
         structure_motif_colors: dict[str, str] | None = None,
+        custom_label_order: list[tuple[str, str]] | None = None,
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent)
@@ -48,6 +49,7 @@ class PriorHistogramWindow(QMainWindow):
             if structure_motif_colors is not None
             else None
         )
+        self.custom_label_order = custom_label_order
         self.setAttribute(Qt.WidgetAttribute.WA_DeleteOnClose, True)
         self.setWindowFlag(Qt.WindowType.Window, True)
         self._build_ui()
@@ -92,6 +94,7 @@ class PriorHistogramWindow(QMainWindow):
             secondary_element=self.secondary_element,
             cmap=self.cmap,
             structure_motif_colors=self.structure_motif_colors,
+            custom_label_order=self.custom_label_order,
             ax=axis,
         )
         self.canvas.draw()

--- a/src/saxshell/saxs/ui/project_setup_tab.py
+++ b/src/saxshell/saxs/ui/project_setup_tab.py
@@ -13,13 +13,15 @@ from matplotlib.backends.backend_qtagg import (
 )
 from matplotlib.colors import to_hex
 from matplotlib.figure import Figure
-from PySide6.QtCore import Qt, QTimer, Signal
+from PySide6.QtCore import QSettings, Qt, QTimer, Signal
 from PySide6.QtGui import QColor, QTextCursor
 from PySide6.QtWidgets import (
     QAbstractItemView,
     QCheckBox,
     QColorDialog,
     QComboBox,
+    QDialog,
+    QDialogButtonBox,
     QFileDialog,
     QFormLayout,
     QGroupBox,
@@ -51,14 +53,21 @@ from saxshell.saxs.contrast.settings import (
     normalize_component_build_mode,
 )
 from saxshell.saxs.debye import discover_cluster_bins
+from saxshell.saxs.debye_waller.workflow import (
+    find_saved_project_debye_waller_analysis,
+    inspect_debye_waller_input,
+    load_debye_waller_analysis_result,
+)
 from saxshell.saxs.project_manager import (
     ExperimentalDataSummary,
     ProjectSettings,
+    build_prior_histogram_export_payload,
     build_project_paths,
     load_experimental_data_file,
     plot_md_prior_histogram,
 )
 from saxshell.saxs.stoichiometry import parse_stoich_label
+from saxshell.saxs.ui._pane_snap import PaneSnapFilter
 from saxshell.saxs.ui.experimental_data_loader import (
     ExperimentalDataHeaderDialog,
 )
@@ -66,6 +75,99 @@ from saxshell.saxs.ui.template_help import (
     TEMPLATE_HELP_TEXT,
     show_template_help,
 )
+
+
+class _XAxisOrderDialog(QDialog):
+    def __init__(
+        self,
+        entries: list[tuple[str, str]],
+        parent: QWidget | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Edit Custom X-Axis Order")
+        self.resize(520, 400)
+        self._build_ui(entries)
+
+    def _build_ui(self, entries: list[tuple[str, str]]) -> None:
+        layout = QVBoxLayout(self)
+        note = QLabel(
+            "Rearrange rows to set the x-axis order. Edit Display Text to "
+            "customise axis labels. Use $_{n}$ for subscript and $^{n}$ for "
+            "superscript (matplotlib mathtext)."
+        )
+        note.setWordWrap(True)
+        layout.addWidget(note)
+
+        content = QHBoxLayout()
+        self._table = QTableWidget(len(entries), 2)
+        self._table.setHorizontalHeaderLabels(["Structure", "Display Text"])
+        self._table.horizontalHeader().setStretchLastSection(True)
+        self._table.setSelectionBehavior(
+            QAbstractItemView.SelectionBehavior.SelectRows
+        )
+        self._table.setSelectionMode(
+            QAbstractItemView.SelectionMode.SingleSelection
+        )
+        for row, (raw, display) in enumerate(entries):
+            raw_item = QTableWidgetItem(raw)
+            raw_item.setFlags(raw_item.flags() & ~Qt.ItemFlag.ItemIsEditable)
+            self._table.setItem(row, 0, raw_item)
+            self._table.setItem(row, 1, QTableWidgetItem(display))
+        self._table.resizeColumnToContents(0)
+        content.addWidget(self._table, stretch=1)
+
+        btn_col = QVBoxLayout()
+        up_btn = QPushButton("Up")
+        up_btn.clicked.connect(self._move_up)
+        dn_btn = QPushButton("Down")
+        dn_btn.clicked.connect(self._move_down)
+        btn_col.addWidget(up_btn)
+        btn_col.addWidget(dn_btn)
+        btn_col.addStretch(1)
+        content.addLayout(btn_col)
+        layout.addLayout(content)
+
+        buttons = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok
+            | QDialogButtonBox.StandardButton.Cancel
+        )
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+    def _move_up(self) -> None:
+        row = self._table.currentRow()
+        if row <= 0:
+            return
+        self._swap_rows(row, row - 1)
+        self._table.selectRow(row - 1)
+
+    def _move_down(self) -> None:
+        row = self._table.currentRow()
+        if row < 0 or row >= self._table.rowCount() - 1:
+            return
+        self._swap_rows(row, row + 1)
+        self._table.selectRow(row + 1)
+
+    def _swap_rows(self, a: int, b: int) -> None:
+        for col in range(self._table.columnCount()):
+            item_a = self._table.takeItem(a, col)
+            item_b = self._table.takeItem(b, col)
+            if item_a is not None:
+                self._table.setItem(b, col, item_a)
+            if item_b is not None:
+                self._table.setItem(a, col, item_b)
+
+    def result_entries(self) -> list[tuple[str, str]]:
+        entries: list[tuple[str, str]] = []
+        for row in range(self._table.rowCount()):
+            raw_item = self._table.item(row, 0)
+            display_item = self._table.item(row, 1)
+            raw = raw_item.text() if raw_item is not None else ""
+            display = display_item.text() if display_item is not None else ""
+            entries.append((raw, display))
+        return entries
+
 
 HISTOGRAM_COLORMAP_NAMES = [
     "summer",
@@ -78,6 +180,7 @@ HISTOGRAM_COLORMAP_NAMES = [
 ]
 COMPONENT_PLOT_MIN_HEIGHT = 320
 PRIOR_PLOT_MIN_HEIGHT = 240
+RECENT_PROJECTS_KEY = "recent_project_dirs"
 
 
 class ProjectSetupTab(QWidget):
@@ -87,6 +190,8 @@ class ProjectSetupTab(QWidget):
     open_mdtrajectory_requested = Signal()
     open_xyz2pdb_requested = Signal()
     open_cluster_requested = Signal()
+    open_clusterdynamicsml_requested = Signal()
+    open_debye_waller_requested = Signal()
     scan_clusters_requested = Signal()
     build_components_requested = Signal()
     build_prior_weights_requested = Signal()
@@ -105,6 +210,7 @@ class ProjectSetupTab(QWidget):
 
     def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
+        self._auto_snap_enabled = True
         self._console_autoscroll_enabled = True
         self._summary_text = ""
         self._experimental_header_rows = 0
@@ -136,7 +242,19 @@ class ProjectSetupTab(QWidget):
         self._pending_saxs_preview_redraw = False
         self._pending_prior_preview_redraw = False
         self._active_template_name: str | None = None
+        self._project_selected = False
+        self._debye_waller_ready = False
+        self._debye_waller_status_note: str | None = None
+        self._predicted_structures_available = False
+        self._predicted_structure_count = 0
+        self._distribution_tooltips: dict[str, str] = {}
+        self._distribution_details: dict[str, str] = {}
+        self._current_distribution_details_text = (
+            "Create or load a computed distribution to review its saved "
+            "build attributes here."
+        )
         self._suspend_template_selection_signal = False
+        self._prior_x_axis_custom_order: list[tuple[str, str]] = []
         self._build_ui()
         self._update_data_trace_control_state()
         self._update_component_trace_control_state()
@@ -179,6 +297,13 @@ class ProjectSetupTab(QWidget):
         self._pane_splitter.setStretchFactor(0, 6)
         self._pane_splitter.setStretchFactor(1, 7)
         self._pane_splitter.setSizes([780, 680])
+        self._auto_snap_filter = PaneSnapFilter(
+            self._pane_splitter,
+            self._left_scroll_area,
+            self._right_scroll_area,
+            parent=self,
+        )
+        self.set_auto_snap_enabled(self._auto_snap_enabled)
         root.addWidget(self._pane_splitter)
 
     @staticmethod
@@ -284,7 +409,7 @@ class ProjectSetupTab(QWidget):
         self.use_predicted_structure_weights_checkbox.toggled.connect(
             self._on_predicted_structure_weights_toggled
         )
-        layout.addRow("", self.use_predicted_structure_weights_checkbox)
+        layout.addRow("", self._predicted_structure_controls_row())
 
         self.predicted_structure_status_label = QLabel(
             self._default_predicted_structure_status_text()
@@ -330,63 +455,31 @@ class ProjectSetupTab(QWidget):
         )
         layout.addRow("", self.solvent_status_label)
 
-        self.qmin_edit = QLineEdit()
-        self.qmax_edit = QLineEdit()
-        self.qmin_edit.textChanged.connect(self._redraw_saxs_preview)
-        self.qmax_edit.textChanged.connect(self._redraw_saxs_preview)
-        q_row = QHBoxLayout()
-        q_row.addWidget(QLabel("q min"))
-        q_row.addWidget(self.qmin_edit)
-        q_row.addWidget(QLabel("q max"))
-        q_row.addWidget(self.qmax_edit)
-        layout.addRow("q-range", q_row)
-
-        self.use_experimental_grid_checkbox = QCheckBox(
-            "Use experimental grid"
-        )
-        self.use_experimental_grid_checkbox.setChecked(True)
-        self.use_experimental_grid_checkbox.setToolTip(
-            "Use the experimental q-grid directly inside the selected q-range. "
-            "Disable this option to resample the experimental data onto a "
-            "custom evenly spaced grid for the forward model."
-        )
-        self.use_experimental_grid_checkbox.toggled.connect(
-            self._update_resample_grid_state
-        )
-        self.resample_points_spin = QSpinBox()
-        self.resample_points_spin.setRange(2, 50000)
-        self.resample_points_spin.setValue(500)
-        self.resample_points_spin.setToolTip(
-            "Number of evenly spaced q-points to generate between q min and "
-            "q max when resampling the model and experimental data."
-        )
-        grid_row = QHBoxLayout()
-        grid_row.addWidget(self.use_experimental_grid_checkbox)
-        grid_row.addStretch(1)
-        grid_row.addWidget(QLabel("Resample grid"))
-        grid_row.addWidget(self.resample_points_spin)
-        layout.addRow("Grid", grid_row)
-        self._update_resample_grid_state()
-
-        self.available_elements_list = QListWidget()
-        self.available_elements_list.setSelectionMode(
-            QAbstractItemView.SelectionMode.ExtendedSelection
-        )
-        self.available_elements_list.setMinimumHeight(104)
-        self.available_elements_list.setMaximumHeight(132)
-        self.available_elements_list.setSizePolicy(
-            QSizePolicy.Policy.Expanding,
-            QSizePolicy.Policy.Fixed,
-        )
-        layout.addRow("Recognized elements", self._elements_row())
-
-        self.exclude_elements_edit = QLineEdit()
-        self.exclude_elements_edit.setPlaceholderText("Example: H O")
-        self.exclude_elements_edit.textChanged.connect(
-            self._sync_available_element_selection
-        )
-        layout.addRow("Exclude elements", self.exclude_elements_edit)
         return group
+
+    def _predicted_structure_controls_row(self) -> QWidget:
+        row = QWidget()
+        layout = QHBoxLayout(row)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(6)
+        layout.addWidget(
+            self.use_predicted_structure_weights_checkbox,
+            stretch=1,
+        )
+        self.predicted_structure_ready_indicator = QLabel()
+        self.predicted_structure_ready_indicator.setFixedSize(14, 14)
+        self._refresh_predicted_structure_indicator()
+        layout.addWidget(self.predicted_structure_ready_indicator)
+        self.predict_structures_button = QPushButton("Predict Structures")
+        self.predict_structures_button.setToolTip(
+            "Open Cluster Dynamics (ML) to compute predicted structures "
+            "for this project."
+        )
+        self.predict_structures_button.clicked.connect(
+            self.open_clusterdynamicsml_requested.emit
+        )
+        layout.addWidget(self.predict_structures_button)
+        return row
 
     def _build_model_group(self) -> QGroupBox:
         group = QGroupBox("Model and Build")
@@ -443,25 +536,35 @@ class ProjectSetupTab(QWidget):
         button_layout = QVBoxLayout(button_widget)
         button_layout.setContentsMargins(0, 0, 0, 0)
         button_layout.setSpacing(8)
-        self.build_prior_weights_button = QPushButton("Generate Prior Weights")
+        self.build_prior_weights_button = QPushButton(
+            "Create Computed Distribution"
+        )
         self.build_prior_weights_button.clicked.connect(
             self.build_prior_weights_requested.emit
+        )
+        self.debye_waller_button = QPushButton("Compute Debye-Waller Factors")
+        self.debye_waller_button.clicked.connect(
+            self.open_debye_waller_requested.emit
+        )
+        self.debye_waller_help_button = self._prep_help_button(
+            self._debye_waller_help_tooltip_text()
         )
         self.component_build_mode_label = QLabel("Component build mode")
         self.component_build_mode_combo = QComboBox()
         self.component_build_mode_combo.setMinimumWidth(220)
         self.component_build_mode_combo.setToolTip(
-            "Choose whether Build SAXS Components uses the current "
-            "no-contrast Debye builder or launches the separate "
-            "contrast-mode workflow."
+            "Choose how this computed distribution will prepare SAXS "
+            "components. Debye modes use the direct component builders, "
+            "while Born Approximation launches the electron-density mapping workflow."
         )
         for mode, label in component_build_mode_choices():
             self.component_build_mode_combo.addItem(label, userData=mode)
-        self.component_build_mode_hint_label = QLabel(
-            "No Contrast Mode keeps the existing builder. Contrast Mode "
-            "opens the separate contrast workflow scaffold."
+        self.component_build_mode_help_button = self._prep_help_button(
+            "Create Computed Distribution saves the active template, q-range, "
+            "grid, excluded elements, cluster source, predicted-structure mode, "
+            "and build mode together. Build SAXS Components then opens the "
+            "matching component workflow for that saved distribution."
         )
-        self.component_build_mode_hint_label.setWordWrap(True)
         self.build_components_button = QPushButton("Build SAXS Components")
         self.build_components_button.clicked.connect(
             self.build_components_requested.emit
@@ -484,6 +587,9 @@ class ProjectSetupTab(QWidget):
         self.computed_distribution_combo = QComboBox()
         self.computed_distribution_combo.setMinimumWidth(420)
         self.computed_distribution_combo.setEnabled(False)
+        self.computed_distribution_combo.currentIndexChanged.connect(
+            self._update_distribution_details_panel
+        )
         self.load_distribution_button = QPushButton("Load Distribution")
         self.load_distribution_button.setEnabled(False)
         self.load_distribution_button.clicked.connect(
@@ -493,11 +599,45 @@ class ProjectSetupTab(QWidget):
             "Computed distribution",
             self._distribution_row(),
         )
-        button_layout.addWidget(self.build_prior_weights_button)
-        button_layout.addWidget(self.component_build_mode_label)
+        header_layout.addRow(
+            "Build attributes",
+            self._model_build_configuration_group(),
+        )
+        mode_label_row = QWidget()
+        mode_label_row_layout = QHBoxLayout(mode_label_row)
+        mode_label_row_layout.setContentsMargins(0, 0, 0, 0)
+        mode_label_row_layout.setSpacing(4)
+        mode_label_row_layout.addWidget(
+            self.component_build_mode_label, stretch=1
+        )
+        mode_label_row_layout.addWidget(self.component_build_mode_help_button)
+        button_layout.addWidget(mode_label_row)
         button_layout.addWidget(self.component_build_mode_combo)
-        button_layout.addWidget(self.component_build_mode_hint_label)
-        button_layout.addWidget(self.build_components_button)
+        button_layout.addWidget(self.build_prior_weights_button)
+        debye_waller_row = QWidget()
+        debye_waller_row_layout = QHBoxLayout(debye_waller_row)
+        debye_waller_row_layout.setContentsMargins(0, 0, 0, 0)
+        debye_waller_row_layout.setSpacing(6)
+        debye_waller_row_layout.addWidget(
+            self.debye_waller_button,
+            stretch=1,
+        )
+        self.debye_waller_ready_indicator = QLabel()
+        self.debye_waller_ready_indicator.setFixedSize(14, 14)
+        self._refresh_debye_waller_indicator()
+        debye_waller_row_layout.addWidget(self.debye_waller_ready_indicator)
+        debye_waller_row_layout.addWidget(self.debye_waller_help_button)
+        button_layout.addWidget(debye_waller_row)
+        build_btn_row = QWidget()
+        build_btn_row_layout = QHBoxLayout(build_btn_row)
+        build_btn_row_layout.setContentsMargins(0, 0, 0, 0)
+        build_btn_row_layout.setSpacing(6)
+        build_btn_row_layout.addWidget(self.build_components_button, stretch=1)
+        self.components_built_indicator = QLabel()
+        self.components_built_indicator.setFixedSize(14, 14)
+        self._refresh_components_built_indicator()
+        build_btn_row_layout.addWidget(self.components_built_indicator)
+        button_layout.addWidget(build_btn_row)
         button_layout.addWidget(self.view_contrast_distribution_button)
         button_layout.addStretch(1)
         button_widget.setSizePolicy(
@@ -561,6 +701,133 @@ class ProjectSetupTab(QWidget):
         clusters_layout.addWidget(self.recognized_clusters_table)
         lower_layout.addWidget(clusters_group, stretch=1)
         layout.addLayout(lower_layout, stretch=1)
+        layout.addWidget(self._distribution_details_group())
+        return group
+
+    def _model_build_configuration_group(self) -> QWidget:
+        container = QWidget()
+        layout = QVBoxLayout(container)
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.setSpacing(8)
+
+        self.qmin_edit = QLineEdit()
+        self.qmax_edit = QLineEdit()
+        self.qmin_edit.textChanged.connect(self._redraw_saxs_preview)
+        self.qmax_edit.textChanged.connect(self._redraw_saxs_preview)
+        q_row = QWidget()
+        q_layout = QHBoxLayout(q_row)
+        q_layout.setContentsMargins(0, 0, 0, 0)
+        q_layout.addWidget(QLabel("q min"))
+        q_layout.addWidget(self.qmin_edit)
+        q_layout.addWidget(QLabel("q max"))
+        q_layout.addWidget(self.qmax_edit)
+        layout.addWidget(q_row)
+
+        self.use_experimental_grid_checkbox = QCheckBox(
+            "Use experimental grid"
+        )
+        self.use_experimental_grid_checkbox.setChecked(True)
+        self.use_experimental_grid_checkbox.setToolTip(
+            "Use the experimental q-grid directly inside the selected q-range. "
+            "Disable this option to resample the experimental data onto a "
+            "custom evenly spaced grid for the forward model."
+        )
+        self.use_experimental_grid_checkbox.toggled.connect(
+            self._update_resample_grid_state
+        )
+        self.resample_points_spin = QSpinBox()
+        self.resample_points_spin.setRange(2, 50000)
+        self.resample_points_spin.setValue(500)
+        self.resample_points_spin.setToolTip(
+            "Number of evenly spaced q-points to generate between q min and "
+            "q max when resampling the model and experimental data."
+        )
+        grid_row = QWidget()
+        grid_layout = QHBoxLayout(grid_row)
+        grid_layout.setContentsMargins(0, 0, 0, 0)
+        grid_layout.addWidget(self.use_experimental_grid_checkbox)
+        grid_layout.addStretch(1)
+        grid_layout.addWidget(QLabel("Resample grid"))
+        grid_layout.addWidget(self.resample_points_spin)
+        layout.addWidget(grid_row)
+        self._update_resample_grid_state()
+
+        self.available_elements_list = QListWidget()
+        self.available_elements_list.setSelectionMode(
+            QAbstractItemView.SelectionMode.ExtendedSelection
+        )
+        self.available_elements_list.setMinimumHeight(104)
+        self.available_elements_list.setMaximumHeight(132)
+        self.available_elements_list.setSizePolicy(
+            QSizePolicy.Policy.Expanding,
+            QSizePolicy.Policy.Fixed,
+        )
+        recognized_group = QGroupBox("Recognized Elements")
+        recognized_layout = QVBoxLayout(recognized_group)
+        recognized_layout.setContentsMargins(8, 8, 8, 8)
+        recognized_layout.addWidget(self._elements_row())
+        layout.addWidget(recognized_group)
+
+        self.exclude_elements_edit = QLineEdit()
+        self.exclude_elements_edit.setPlaceholderText("Example: H O")
+        self.exclude_elements_edit.textChanged.connect(
+            self._sync_available_element_selection
+        )
+        exclude_group = QGroupBox("Exclude Elements")
+        exclude_layout = QVBoxLayout(exclude_group)
+        exclude_layout.setContentsMargins(8, 8, 8, 8)
+        exclude_layout.addWidget(self.exclude_elements_edit)
+        layout.addWidget(exclude_group)
+        return container
+
+    def _distribution_details_group(self) -> QWidget:
+        group = QGroupBox("Active Computed Distribution")
+        layout = QVBoxLayout(group)
+        layout.setContentsMargins(8, 8, 8, 8)
+        layout.setSpacing(6)
+
+        header_row = QWidget()
+        header_layout = QHBoxLayout(header_row)
+        header_layout.setContentsMargins(0, 0, 0, 0)
+        header_layout.setSpacing(6)
+        self.distribution_details_toggle_button = QToolButton()
+        self.distribution_details_toggle_button.setCheckable(True)
+        self.distribution_details_toggle_button.setChecked(True)
+        self.distribution_details_toggle_button.setToolButtonStyle(
+            Qt.ToolButtonStyle.ToolButtonTextBesideIcon
+        )
+        self.distribution_details_toggle_button.setArrowType(
+            Qt.ArrowType.DownArrow
+        )
+        self.distribution_details_toggle_button.setText("Show details")
+        self.distribution_details_toggle_button.clicked.connect(
+            self._toggle_distribution_details_visibility
+        )
+        header_layout.addWidget(self.distribution_details_toggle_button)
+        self.distribution_details_hint_label = QLabel(
+            "The active distribution summary tracks the identifying settings "
+            "for the selected computed distribution and whether its saved "
+            "artifacts are ready."
+        )
+        self.distribution_details_hint_label.setWordWrap(True)
+        header_layout.addWidget(
+            self.distribution_details_hint_label,
+            stretch=1,
+        )
+        layout.addWidget(header_row)
+
+        self.distribution_details_scroll = QScrollArea()
+        self.distribution_details_scroll.setWidgetResizable(True)
+        self.distribution_details_scroll.setMinimumHeight(180)
+        self.distribution_details_text = QTextEdit()
+        self.distribution_details_text.setReadOnly(True)
+        self.distribution_details_text.setPlainText(
+            self._current_distribution_details_text
+        )
+        self.distribution_details_scroll.setWidget(
+            self.distribution_details_text
+        )
+        layout.addWidget(self.distribution_details_scroll)
         return group
 
     def _template_row(self) -> QWidget:
@@ -767,8 +1034,22 @@ class ProjectSetupTab(QWidget):
         self.save_prior_plot_data_button.clicked.connect(
             self.save_prior_plot_data_requested.emit
         )
+        self.prior_x_axis_order_combo = QComboBox()
+        self.prior_x_axis_order_combo.addItem("Auto", userData="auto")
+        self.prior_x_axis_order_combo.addItem("Custom", userData="custom")
+        self.prior_x_axis_order_combo.currentIndexChanged.connect(
+            self._on_prior_x_axis_order_changed
+        )
+        self.edit_prior_x_axis_button = QPushButton("Edit Custom")
+        self.edit_prior_x_axis_button.setEnabled(False)
+        self.edit_prior_x_axis_button.clicked.connect(
+            self._on_edit_prior_x_axis_order
+        )
         controls.addWidget(QLabel("Mode"))
         controls.addWidget(self.prior_mode_combo)
+        controls.addWidget(QLabel("X-Axis Ordering"))
+        controls.addWidget(self.prior_x_axis_order_combo)
+        controls.addWidget(self.edit_prior_x_axis_button)
         controls.addWidget(self.secondary_filter_label)
         controls.addWidget(self.secondary_filter_combo)
         controls.addWidget(self.generate_prior_plot_button)
@@ -836,6 +1117,18 @@ class ProjectSetupTab(QWidget):
             "resulting folders below."
         )
 
+    @staticmethod
+    def _debye_waller_help_tooltip_text() -> str:
+        return (
+            "Debye-Waller factors capture thermal/disorder smearing from "
+            "the active PDB cluster ensemble. This step is optional and is "
+            "not enforced, but compute these factors before building SAXS "
+            "components if you plan to use them in downstream SAXS "
+            "workflows. The linked Debye-Waller tool inherits the active "
+            "project folder and clusters folder, and stays disabled until "
+            "the active clusters folder resolves to PDB cluster files."
+        )
+
     def _prep_help_button(self, tooltip: str) -> QToolButton:
         button = QToolButton()
         button.setText("?")
@@ -901,9 +1194,9 @@ class ProjectSetupTab(QWidget):
         return row
 
     def set_project_selected(self, selected: bool) -> None:
+        self._project_selected = bool(selected)
         self.forward_model_group.setEnabled(selected)
         self.model_group.setEnabled(selected)
-        self.use_predicted_structure_weights_checkbox.setEnabled(selected)
         self.computed_distribution_combo.setEnabled(
             selected and self.computed_distribution_combo.count() > 0
         )
@@ -916,6 +1209,11 @@ class ProjectSetupTab(QWidget):
             bool(selected and self._active_contrast_view_available)
         )
         self.prior_mode_combo.setEnabled(selected)
+        self.prior_x_axis_order_combo.setEnabled(selected)
+        self.edit_prior_x_axis_button.setEnabled(
+            selected
+            and self.prior_x_axis_order_combo.currentData() == "custom"
+        )
         self.generate_prior_plot_button.setEnabled(selected)
         self.save_prior_png_button.setEnabled(selected)
         self.save_component_plot_data_button.setEnabled(selected)
@@ -925,8 +1223,13 @@ class ProjectSetupTab(QWidget):
         if not selected:
             self._experimental_summary = None
             self._solvent_summary = None
+            self.set_predicted_structure_availability(False)
         self._refresh_data_status_labels()
         self._apply_model_only_mode_state()
+        self._refresh_debye_waller_controls()
+        if not selected:
+            self._debye_waller_status_note = None
+            self.set_debye_waller_ready(False)
 
     @contextmanager
     def batch_preview_updates(self):
@@ -1039,6 +1342,9 @@ class ProjectSetupTab(QWidget):
                 active_name=settings.selected_model_template,
             )
             self.set_component_build_mode(settings.component_build_mode)
+            self.set_prior_histogram_x_axis_order(
+                settings.prior_histogram_x_axis_order
+            )
 
             if settings.cluster_inventory_rows:
                 self._recognized_cluster_rows = list(
@@ -1058,6 +1364,8 @@ class ProjectSetupTab(QWidget):
                 settings.available_elements,
                 self._recognized_cluster_rows,
             )
+            self._refresh_debye_waller_controls()
+            self.refresh_debye_waller_project_status(settings.project_dir)
 
             if loadable_data_path:
                 try:
@@ -1235,7 +1543,17 @@ class ProjectSetupTab(QWidget):
         distributions: list[tuple[str, str]],
         *,
         selected_distribution_id: str | None = None,
+        distribution_tooltips: dict[str, str] | None = None,
+        distribution_details: dict[str, str] | None = None,
     ) -> None:
+        self._distribution_tooltips = {
+            str(key): str(value)
+            for key, value in (distribution_tooltips or {}).items()
+        }
+        self._distribution_details = {
+            str(key): str(value)
+            for key, value in (distribution_details or {}).items()
+        }
         current_id = (
             selected_distribution_id or self.selected_distribution_id()
         )
@@ -1246,6 +1564,14 @@ class ProjectSetupTab(QWidget):
                 str(label),
                 userData=str(distribution_id),
             )
+            item_index = self.computed_distribution_combo.count() - 1
+            tooltip = self._distribution_tooltips.get(str(distribution_id))
+            if tooltip:
+                self.computed_distribution_combo.setItemData(
+                    item_index,
+                    tooltip,
+                    Qt.ItemDataRole.ToolTipRole,
+                )
         if current_id:
             for index in range(self.computed_distribution_combo.count()):
                 if str(
@@ -1266,6 +1592,16 @@ class ProjectSetupTab(QWidget):
             self.model_group.isEnabled()
             and self._active_contrast_view_available
         )
+        self._update_distribution_details_panel()
+
+    def set_current_distribution_details(self, text: str | None) -> None:
+        details_text = str(text or "").strip()
+        self._current_distribution_details_text = (
+            details_text
+            or "Create or load a computed distribution to review its saved "
+            "build attributes here."
+        )
+        self._update_distribution_details_panel()
 
     def set_active_contrast_distribution_view_available(
         self,
@@ -1306,6 +1642,31 @@ class ProjectSetupTab(QWidget):
         self.component_build_mode_combo.blockSignals(False)
         self.component_build_mode_label.setText(
             f"Component build mode ({component_build_mode_label(normalized_mode)})"
+        )
+
+    def _toggle_distribution_details_visibility(self) -> None:
+        self._set_distribution_details_expanded(
+            self.distribution_details_toggle_button.isChecked()
+        )
+
+    def _set_distribution_details_expanded(self, expanded: bool) -> None:
+        self.distribution_details_toggle_button.blockSignals(True)
+        self.distribution_details_toggle_button.setChecked(bool(expanded))
+        self.distribution_details_toggle_button.blockSignals(False)
+        self.distribution_details_toggle_button.setArrowType(
+            Qt.ArrowType.DownArrow if expanded else Qt.ArrowType.RightArrow
+        )
+        self.distribution_details_scroll.setVisible(bool(expanded))
+
+    def _update_distribution_details_panel(self) -> None:
+        distribution_id = self.selected_distribution_id()
+        details_text = (
+            self._distribution_details.get(distribution_id or "")
+            if distribution_id is not None
+            else None
+        )
+        self.distribution_details_text.setPlainText(
+            details_text or self._current_distribution_details_text
         )
 
     def show_deprecated_templates(self) -> bool:
@@ -1349,7 +1710,19 @@ class ProjectSetupTab(QWidget):
         self.use_predicted_structure_weights_checkbox.blockSignals(True)
         self.use_predicted_structure_weights_checkbox.setChecked(bool(enabled))
         self.use_predicted_structure_weights_checkbox.blockSignals(False)
+        self._refresh_predicted_structure_controls()
         self._update_component_trace_control_state()
+
+    def set_predicted_structure_availability(
+        self,
+        available: bool,
+        *,
+        prediction_count: int = 0,
+    ) -> None:
+        self._predicted_structures_available = bool(available)
+        self._predicted_structure_count = max(int(prediction_count), 0)
+        self._refresh_predicted_structure_indicator()
+        self._refresh_predicted_structure_controls()
 
     def _default_predicted_structure_status_text(self) -> str:
         return (
@@ -1363,6 +1736,51 @@ class ProjectSetupTab(QWidget):
         self.predicted_structure_status_label.setText(
             normalized or self._default_predicted_structure_status_text()
         )
+
+    def _refresh_predicted_structure_indicator(self) -> None:
+        if self._predicted_structures_available:
+            self.predicted_structure_ready_indicator.setStyleSheet(
+                "background-color: #16a34a; border-radius: 7px;"
+            )
+            self.predicted_structure_ready_indicator.setToolTip(
+                f"{self._predicted_structure_count} predicted structure"
+                f"{'' if self._predicted_structure_count == 1 else 's'} "
+                f"{'is' if self._predicted_structure_count == 1 else 'are'} "
+                "available in this project."
+            )
+        else:
+            self.predicted_structure_ready_indicator.setStyleSheet(
+                "background-color: #6b7280; border-radius: 7px;"
+            )
+            self.predicted_structure_ready_indicator.setToolTip(
+                "Predicted structures have not been computed for this "
+                "project yet."
+            )
+
+    def _refresh_predicted_structure_controls(self) -> None:
+        checkbox_enabled = bool(
+            self._project_selected
+            and (
+                self._predicted_structures_available
+                or self.use_predicted_structure_weights()
+            )
+        )
+        self.use_predicted_structure_weights_checkbox.setEnabled(
+            checkbox_enabled
+        )
+        if self._predicted_structures_available:
+            self.use_predicted_structure_weights_checkbox.setToolTip(
+                "Include Cluster Dynamics ML Predicted Structures in the "
+                "SAXS component build, prior weights, Prefit, and DREAM "
+                "workflows. When disabled, the project uses observed "
+                "structures only."
+            )
+        else:
+            self.use_predicted_structure_weights_checkbox.setToolTip(
+                "Run Cluster Dynamics (ML) to compute predicted structures "
+                "for this project before enabling this option."
+            )
+        self.predict_structures_button.setEnabled(self._project_selected)
 
     def open_project_dir(self) -> Path | None:
         text = self.open_project_dir_edit.text().strip()
@@ -1557,6 +1975,75 @@ class ProjectSetupTab(QWidget):
             return None
         return int(self.resample_points_spin.value())
 
+    def prior_histogram_x_axis_order(self) -> list[list[str]]:
+        return [list(entry) for entry in self._prior_x_axis_custom_order]
+
+    def set_prior_histogram_x_axis_order(
+        self, order: list[list[str]] | None
+    ) -> None:
+        if order:
+            self._prior_x_axis_custom_order = [
+                (str(entry[0]), str(entry[1]))
+                for entry in order
+                if len(entry) >= 2
+            ]
+            idx = self.prior_x_axis_order_combo.findData("custom")
+            self.prior_x_axis_order_combo.blockSignals(True)
+            self.prior_x_axis_order_combo.setCurrentIndex(idx)
+            self.prior_x_axis_order_combo.blockSignals(False)
+            self.edit_prior_x_axis_button.setEnabled(True)
+        else:
+            self._prior_x_axis_custom_order = []
+            idx = self.prior_x_axis_order_combo.findData("auto")
+            self.prior_x_axis_order_combo.blockSignals(True)
+            self.prior_x_axis_order_combo.setCurrentIndex(idx)
+            self.prior_x_axis_order_combo.blockSignals(False)
+            self.edit_prior_x_axis_button.setEnabled(False)
+
+    def _active_prior_x_axis_order(self) -> list[tuple[str, str]] | None:
+        if (
+            self.prior_x_axis_order_combo.currentData() == "custom"
+            and self._prior_x_axis_custom_order
+        ):
+            return self._prior_x_axis_custom_order
+        return None
+
+    def _on_prior_x_axis_order_changed(self, _index: int) -> None:
+        is_custom = self.prior_x_axis_order_combo.currentData() == "custom"
+        self.edit_prior_x_axis_button.setEnabled(is_custom)
+        self._redraw_prior_preview_if_needed()
+
+    def _on_edit_prior_x_axis_order(self) -> None:
+        if not self._prior_x_axis_custom_order:
+            if self._current_prior_json_path is not None:
+                try:
+                    payload = build_prior_histogram_export_payload(
+                        self._current_prior_json_path,
+                        mode=self.prior_mode(),
+                        secondary_element=self.prior_secondary_element(),
+                    )
+                    entries = [
+                        (str(raw), str(display))
+                        for raw, display in zip(
+                            payload["labels"], payload["axis_labels"]
+                        )
+                    ]
+                except Exception:
+                    entries = []
+            else:
+                entries = []
+        else:
+            entries = list(self._prior_x_axis_custom_order)
+
+        dialog = _XAxisOrderDialog(entries, parent=self)
+        if dialog.exec() == QDialog.DialogCode.Accepted:
+            self._prior_x_axis_custom_order = dialog.result_entries()
+            self.autosave_project_requested.emit(
+                "updated prior histogram x-axis order"
+            )
+            if self.prior_x_axis_order_combo.currentData() == "custom":
+                self._redraw_prior_preview_if_needed()
+
     def prior_mode(self) -> str:
         return str(self.prior_mode_combo.currentData() or "structure_fraction")
 
@@ -1702,6 +2189,10 @@ class ProjectSetupTab(QWidget):
         if self._console_autoscroll_enabled:
             self._scroll_summary_to_end()
 
+    def set_auto_snap_enabled(self, enabled: bool) -> None:
+        self._auto_snap_enabled = bool(enabled)
+        self._auto_snap_filter.set_enabled(self._auto_snap_enabled)
+
     def _render_summary_text(self) -> None:
         scrollbar = self.summary_box.verticalScrollBar()
         previous_value = scrollbar.value()
@@ -1737,8 +2228,153 @@ class ProjectSetupTab(QWidget):
         scrollbar = self.summary_box.verticalScrollBar()
         scrollbar.setValue(scrollbar.maximum())
 
+    def _refresh_components_built_indicator(self) -> None:
+        built = bool(self._component_paths)
+        if built:
+            self.components_built_indicator.setStyleSheet(
+                "background-color: #16a34a; border-radius: 7px;"
+            )
+            self.components_built_indicator.setToolTip(
+                "SAXS components have been built for this distribution."
+            )
+        else:
+            self.components_built_indicator.setStyleSheet(
+                "background-color: #6b7280; border-radius: 7px;"
+            )
+            self.components_built_indicator.setToolTip(
+                "SAXS components have not been built yet for this distribution."
+            )
+
+    def set_debye_waller_ready(self, ready: bool) -> None:
+        self._debye_waller_ready = bool(ready)
+        if ready:
+            self._debye_waller_status_note = None
+        self._refresh_debye_waller_indicator()
+
+    def refresh_debye_waller_project_status(
+        self,
+        project_dir: str | Path | None = None,
+    ) -> bool:
+        resolved_project_dir: Path | None
+        if project_dir is None:
+            resolved_project_dir = self.open_project_dir()
+        else:
+            resolved_project_dir = Path(project_dir).expanduser().resolve()
+        active_clusters_dir = self.clusters_dir()
+        ready = False
+        note: str | None = None
+        if resolved_project_dir is not None:
+            summary_path = find_saved_project_debye_waller_analysis(
+                resolved_project_dir
+            )
+            if summary_path is not None:
+                try:
+                    saved_result = load_debye_waller_analysis_result(
+                        summary_path
+                    )
+                except Exception:
+                    note = (
+                        "Saved Debye-Waller factors were found for this "
+                        "project, but the saved analysis could not be loaded."
+                    )
+                else:
+                    if (
+                        active_clusters_dir is None
+                        or not active_clusters_dir.exists()
+                    ):
+                        note = (
+                            "Debye-Waller factors are saved in this project, "
+                            "but the active PDB clusters folder is missing or "
+                            "not currently selected."
+                        )
+                    elif (
+                        saved_result.clusters_dir
+                        == active_clusters_dir.expanduser().resolve()
+                    ):
+                        ready = True
+                    else:
+                        note = (
+                            "Debye-Waller factors were saved for a different "
+                            "clusters folder. Recompute them if you want to "
+                            "use factors with the current PDB clusters."
+                        )
+        self._debye_waller_status_note = note
+        self.set_debye_waller_ready(ready)
+        return ready
+
+    def refresh_debye_waller_controls(self) -> None:
+        self._refresh_debye_waller_controls()
+
+    def _refresh_debye_waller_indicator(self) -> None:
+        if self._debye_waller_ready:
+            self.debye_waller_ready_indicator.setStyleSheet(
+                "background-color: #16a34a; border-radius: 7px;"
+            )
+            self.debye_waller_ready_indicator.setToolTip(
+                "Debye-Waller factors have been computed and saved for the "
+                "active PDB clusters folder."
+            )
+            return
+        self.debye_waller_ready_indicator.setStyleSheet(
+            "background-color: #6b7280; border-radius: 7px;"
+        )
+        self.debye_waller_ready_indicator.setToolTip(
+            self._debye_waller_status_note
+            or (
+                "Debye-Waller factors have not been computed for the active "
+                "PDB clusters folder yet."
+            )
+        )
+
+    def _debye_waller_action_state(self) -> tuple[bool, str]:
+        if not self._project_selected:
+            return (
+                False,
+                "Open or create a project first to compute Debye-Waller "
+                "factors.",
+            )
+        clusters_dir = self.clusters_dir()
+        if clusters_dir is None or not clusters_dir.exists():
+            return (
+                False,
+                "Select an active PDB clusters folder to enable Debye-Waller "
+                "factor computation.",
+            )
+        try:
+            inspection = inspect_debye_waller_input(clusters_dir)
+        except Exception:
+            return (
+                False,
+                "Debye-Waller factor computation requires a readable PDB "
+                "clusters folder.",
+            )
+        if inspection.total_structure_files <= 0:
+            return (
+                False,
+                "No cluster structure files were found in the active PDB "
+                "clusters folder.",
+            )
+        if not inspection.is_pdb_only:
+            return (
+                False,
+                "Debye-Waller factor computation requires PDB cluster files "
+                "only. Convert XYZ clusters to PDB or choose a PDB clusters "
+                "folder.",
+            )
+        return (
+            True,
+            "Launch the linked Debye-Waller tool using the active project "
+            "folder and PDB clusters folder.",
+        )
+
+    def _refresh_debye_waller_controls(self) -> None:
+        enabled, tooltip = self._debye_waller_action_state()
+        self.debye_waller_button.setEnabled(enabled)
+        self.debye_waller_button.setToolTip(tooltip)
+
     def draw_component_plot(self, component_paths: list[Path] | None) -> None:
         self._component_paths = component_paths
+        self._refresh_components_built_indicator()
         if self._preview_updates_suspended():
             self._pending_saxs_preview_redraw = True
             self._pending_prior_preview_redraw = True
@@ -1967,6 +2603,7 @@ class ProjectSetupTab(QWidget):
                     secondary_element=self.prior_secondary_element(),
                     cmap=self.prior_cmap(),
                     structure_motif_colors=self.prior_structure_motif_colors(),
+                    custom_label_order=self._active_prior_x_axis_order(),
                     ax=axis,
                 )
             except Exception as exc:
@@ -2251,7 +2888,7 @@ class ProjectSetupTab(QWidget):
         selected = QFileDialog.getExistingDirectory(
             self,
             "Select an existing SAXS project folder",
-            self.open_project_dir_edit.text().strip() or str(Path.home()),
+            self._existing_project_browser_start_dir(),
         )
         if not selected:
             return
@@ -2265,6 +2902,46 @@ class ProjectSetupTab(QWidget):
             )
             return
         self.open_project_dir_edit.setText(str(project_dir))
+
+    @staticmethod
+    def _recent_projects_settings() -> QSettings:
+        return QSettings("SAXShell", "SAXS")
+
+    def _recent_project_parent_dir(self) -> str | None:
+        raw_value = self._recent_projects_settings().value(
+            RECENT_PROJECTS_KEY,
+            [],
+        )
+        if isinstance(raw_value, str):
+            candidates = [raw_value]
+        elif isinstance(raw_value, (list, tuple)):
+            candidates = [str(item) for item in raw_value]
+        else:
+            candidates = []
+        for candidate in candidates:
+            normalized = candidate.strip()
+            if not normalized:
+                continue
+            project_dir = Path(normalized).expanduser()
+            if not project_dir.exists():
+                continue
+            resolved_dir = project_dir.resolve()
+            parent_dir = (
+                resolved_dir.parent
+                if resolved_dir.parent.exists()
+                else resolved_dir
+            )
+            return str(parent_dir)
+        return None
+
+    def _existing_project_browser_start_dir(self) -> str:
+        current_text = self.open_project_dir_edit.text().strip()
+        if current_text:
+            return current_text
+        recent_parent_dir = self._recent_project_parent_dir()
+        if recent_parent_dir:
+            return recent_parent_dir
+        return str(Path.home())
 
     def _choose_clusters_directory(self) -> None:
         selected = QFileDialog.getExistingDirectory(
@@ -2675,6 +3352,8 @@ class ProjectSetupTab(QWidget):
 
     def _on_clusters_dir_edited(self) -> None:
         self.request_cluster_scan()
+        self._refresh_debye_waller_controls()
+        self.refresh_debye_waller_project_status()
         if self.clusters_dir() is not None:
             self.autosave_project_requested.emit(
                 "updated the clusters folder reference"
@@ -2716,6 +3395,7 @@ class ProjectSetupTab(QWidget):
         )
 
     def _on_predicted_structure_weights_toggled(self, enabled: bool) -> None:
+        self._refresh_predicted_structure_controls()
         self._update_component_trace_control_state()
         self.predicted_structure_weights_changed.emit(bool(enabled))
         self.autosave_project_requested.emit(

--- a/tests/generate_edm_contiguous_mode_report.py
+++ b/tests/generate_edm_contiguous_mode_report.py
@@ -1,0 +1,1293 @@
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import time
+from contextlib import contextmanager
+from pathlib import Path
+
+import numpy as np
+
+from saxshell.saxs.electron_density_mapping import workflow as density_workflow
+
+DEFAULT_SELECTION_PATH = Path(
+    "/Users/keithwhite/repos/cluster_extraction/"
+    "041_cp2k_pbi2_dmf_0p7M_RT/"
+    "clusters_xyz2pdb_splitxyz_f1002_t497p5fs_smartshell/"
+    "Pb2I4"
+)
+DEFAULT_OUTPUT_DIR = (
+    Path(__file__).resolve().parent
+    / "edm_contiguous_mode_report"
+    / "pb2i4_backend_comparison"
+)
+
+
+def _center_mode_label(center_mode: str) -> str:
+    if center_mode == "center_of_mass":
+        return "Geometric Mass Center"
+    if center_mode == "reference_element":
+        return "Reference Element"
+    return str(center_mode)
+
+
+def _combo_slug(
+    *,
+    center_mode: str,
+    use_contiguous_frame_mode: bool,
+    pin_contiguous_geometric_tracking: bool,
+) -> str:
+    center_slug = (
+        "geom_mass"
+        if center_mode == "center_of_mass"
+        else str(center_mode).replace("_", "-")
+    )
+    contiguous_slug = (
+        "contiguous-on" if use_contiguous_frame_mode else "contiguous-off"
+    )
+    pin_slug = "pin-on" if pin_contiguous_geometric_tracking else "pin-off"
+    return f"{center_slug}__{contiguous_slug}__{pin_slug}"
+
+
+def _effective_combo_key(
+    *,
+    center_mode: str,
+    use_contiguous_frame_mode: bool,
+    pin_contiguous_geometric_tracking: bool,
+) -> str:
+    pin_is_effective = bool(
+        center_mode == "center_of_mass"
+        and use_contiguous_frame_mode
+        and pin_contiguous_geometric_tracking
+    )
+    return _combo_slug(
+        center_mode=center_mode,
+        use_contiguous_frame_mode=use_contiguous_frame_mode,
+        pin_contiguous_geometric_tracking=pin_is_effective,
+    )
+
+
+def _vector_components(
+    values: np.ndarray | tuple[float, ...] | list[float],
+) -> tuple[float, float, float]:
+    array = np.asarray(values, dtype=float)
+    return (
+        float(array[0]),
+        float(array[1]),
+        float(array[2]),
+    )
+
+
+def _vector_list(
+    values: np.ndarray | tuple[float, ...] | list[float],
+) -> list[float]:
+    return [float(value) for value in np.asarray(values, dtype=float)]
+
+
+def _profile_metrics(
+    result_a: density_workflow.ElectronDensityProfileResult,
+    result_b: density_workflow.ElectronDensityProfileResult,
+) -> dict[str, float | bool]:
+    profile_a = np.asarray(
+        result_a.smeared_orientation_average_density,
+        dtype=float,
+    )
+    profile_b = np.asarray(
+        result_b.smeared_orientation_average_density,
+        dtype=float,
+    )
+    radial_centers = np.asarray(result_a.radial_centers, dtype=float)
+    difference = profile_a - profile_b
+    return {
+        "profiles_identical": bool(np.allclose(profile_a, profile_b)),
+        "max_abs_diff_e_per_a3": float(np.max(np.abs(difference))),
+        "mean_abs_diff_e_per_a3": float(np.mean(np.abs(difference))),
+        "rms_diff_e_per_a3": float(np.sqrt(np.mean(np.square(difference)))),
+        "integrated_abs_diff_e_per_a2": float(
+            np.trapezoid(np.abs(difference), radial_centers)
+        ),
+    }
+
+
+def _active_center_metrics(
+    result_a: density_workflow.ElectronDensityProfileResult,
+    result_b: density_workflow.ElectronDensityProfileResult,
+) -> dict[str, float | bool]:
+    centers_a = {
+        Path(entry.file_path): np.asarray(entry.active_center, dtype=float)
+        for entry in result_a.member_summaries
+    }
+    shifts: list[float] = []
+    for entry in result_b.member_summaries:
+        file_path = Path(entry.file_path)
+        if file_path not in centers_a:
+            continue
+        shifts.append(
+            float(
+                np.linalg.norm(
+                    centers_a[file_path]
+                    - np.asarray(entry.active_center, dtype=float)
+                )
+            )
+        )
+    if not shifts:
+        return {
+            "active_centers_identical": True,
+            "max_active_center_shift_a": 0.0,
+            "mean_active_center_shift_a": 0.0,
+        }
+    shift_array = np.asarray(shifts, dtype=float)
+    return {
+        "active_centers_identical": bool(
+            np.allclose(shift_array, np.zeros_like(shift_array))
+        ),
+        "max_active_center_shift_a": float(np.max(shift_array)),
+        "mean_active_center_shift_a": float(np.mean(shift_array)),
+    }
+
+
+def _write_profile_csv(
+    path: Path,
+    result: density_workflow.ElectronDensityProfileResult,
+) -> None:
+    radial_edges = np.asarray(result.mesh_geometry.radial_edges, dtype=float)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(
+            [
+                "r_inner_a",
+                "r_outer_a",
+                "r_center_a",
+                "orientation_average_density_e_per_a3",
+                "smeared_orientation_average_density_e_per_a3",
+                "orientation_density_stddev_e_per_a3",
+                "smeared_orientation_density_stddev_e_per_a3",
+                "electrons_in_shell",
+                "shell_volume_a3",
+            ]
+        )
+        for index, center in enumerate(result.radial_centers):
+            writer.writerow(
+                [
+                    f"{float(radial_edges[index]):.8f}",
+                    f"{float(radial_edges[index + 1]):.8f}",
+                    f"{float(center):.8f}",
+                    f"{float(result.orientation_average_density[index]):.8f}",
+                    f"{float(result.smeared_orientation_average_density[index]):.8f}",
+                    f"{float(result.orientation_density_stddev[index]):.8f}",
+                    f"{float(result.smeared_orientation_density_stddev[index]):.8f}",
+                    f"{float(result.shell_electron_counts[index]):.8f}",
+                    f"{float(result.shell_volumes[index]):.8f}",
+                ]
+            )
+
+
+def _write_detected_set_csv(
+    path: Path,
+    frame_sets: tuple[
+        density_workflow.ElectronDensityContiguousFrameSetSummary,
+        ...,
+    ],
+) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(
+            [
+                "set_index",
+                "series_label",
+                "frame_range_label",
+                "frame_count",
+                "first_frame_id",
+                "last_frame_id",
+                "first_file_name",
+                "last_file_name",
+            ]
+        )
+        for index, frame_set in enumerate(frame_sets, start=1):
+            writer.writerow(
+                [
+                    index,
+                    str(frame_set.series_label),
+                    str(frame_set.frame_range_label),
+                    int(frame_set.frame_count),
+                    int(frame_set.frame_ids[0]),
+                    int(frame_set.frame_ids[-1]),
+                    frame_set.file_paths[0].name,
+                    frame_set.file_paths[-1].name,
+                ]
+            )
+
+
+def _write_run_center_csvs(
+    output_dir: Path,
+    run_slug: str,
+    result: density_workflow.ElectronDensityProfileResult,
+    frame_sets: tuple[
+        density_workflow.ElectronDensityContiguousFrameSetSummary,
+        ...,
+    ],
+) -> tuple[Path, Path]:
+    summary_by_path = {
+        Path(entry.file_path): entry for entry in result.member_summaries
+    }
+    frame_csv_path = output_dir / f"{run_slug}__frame_centers.csv"
+    set_csv_path = output_dir / f"{run_slug}__set_summary.csv"
+
+    with frame_csv_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(
+            [
+                "set_index",
+                "series_label",
+                "frame_range_label",
+                "frame_count",
+                "frame_index_in_set",
+                "frame_id",
+                "frame_label",
+                "file_name",
+                "is_first_frame_in_set",
+                "reference_element",
+                "active_center_x_a",
+                "active_center_y_a",
+                "active_center_z_a",
+                "center_of_mass_x_a",
+                "center_of_mass_y_a",
+                "center_of_mass_z_a",
+                "geometric_center_x_a",
+                "geometric_center_y_a",
+                "geometric_center_z_a",
+                "reference_element_geometric_center_x_a",
+                "reference_element_geometric_center_y_a",
+                "reference_element_geometric_center_z_a",
+                "active_minus_reference_geom_x_a",
+                "active_minus_reference_geom_y_a",
+                "active_minus_reference_geom_z_a",
+                "active_minus_center_of_mass_x_a",
+                "active_minus_center_of_mass_y_a",
+                "active_minus_center_of_mass_z_a",
+            ]
+        )
+        for set_index, frame_set in enumerate(frame_sets, start=1):
+            for frame_index, file_path in enumerate(
+                frame_set.file_paths, start=1
+            ):
+                summary = summary_by_path[file_path]
+                active_center = np.asarray(summary.active_center, dtype=float)
+                center_of_mass = np.asarray(
+                    summary.center_of_mass, dtype=float
+                )
+                geometric_center = np.asarray(
+                    summary.geometric_center,
+                    dtype=float,
+                )
+                reference_center = np.asarray(
+                    summary.reference_element_geometric_center,
+                    dtype=float,
+                )
+                writer.writerow(
+                    [
+                        set_index,
+                        str(frame_set.series_label),
+                        str(frame_set.frame_range_label),
+                        int(frame_set.frame_count),
+                        frame_index,
+                        int(frame_set.frame_ids[frame_index - 1]),
+                        str(frame_set.frame_labels[frame_index - 1]),
+                        file_path.name,
+                        int(frame_index == 1),
+                        str(summary.reference_element),
+                        f"{active_center[0]:.8f}",
+                        f"{active_center[1]:.8f}",
+                        f"{active_center[2]:.8f}",
+                        f"{center_of_mass[0]:.8f}",
+                        f"{center_of_mass[1]:.8f}",
+                        f"{center_of_mass[2]:.8f}",
+                        f"{geometric_center[0]:.8f}",
+                        f"{geometric_center[1]:.8f}",
+                        f"{geometric_center[2]:.8f}",
+                        f"{reference_center[0]:.8f}",
+                        f"{reference_center[1]:.8f}",
+                        f"{reference_center[2]:.8f}",
+                        f"{(active_center - reference_center)[0]:.8f}",
+                        f"{(active_center - reference_center)[1]:.8f}",
+                        f"{(active_center - reference_center)[2]:.8f}",
+                        f"{(active_center - center_of_mass)[0]:.8f}",
+                        f"{(active_center - center_of_mass)[1]:.8f}",
+                        f"{(active_center - center_of_mass)[2]:.8f}",
+                    ]
+                )
+
+    with set_csv_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(
+            [
+                "set_index",
+                "series_label",
+                "frame_range_label",
+                "frame_count",
+                "first_file_name",
+                "unique_active_center_count_rounded_1e-6",
+                "first_frame_active_center_x_a",
+                "first_frame_active_center_y_a",
+                "first_frame_active_center_z_a",
+                "first_frame_center_of_mass_x_a",
+                "first_frame_center_of_mass_y_a",
+                "first_frame_center_of_mass_z_a",
+                "mean_active_center_x_a",
+                "mean_active_center_y_a",
+                "mean_active_center_z_a",
+                "max_active_center_shift_from_first_a",
+                "mean_active_center_shift_from_first_a",
+                "mean_active_minus_reference_geom_x_a",
+                "mean_active_minus_reference_geom_y_a",
+                "mean_active_minus_reference_geom_z_a",
+            ]
+        )
+        for set_index, frame_set in enumerate(frame_sets, start=1):
+            summaries = [
+                summary_by_path[file_path]
+                for file_path in frame_set.file_paths
+            ]
+            active_centers = np.vstack(
+                [
+                    np.asarray(summary.active_center, dtype=float)
+                    for summary in summaries
+                ]
+            )
+            center_of_mass_centers = np.vstack(
+                [
+                    np.asarray(summary.center_of_mass, dtype=float)
+                    for summary in summaries
+                ]
+            )
+            reference_centers = np.vstack(
+                [
+                    np.asarray(
+                        summary.reference_element_geometric_center,
+                        dtype=float,
+                    )
+                    for summary in summaries
+                ]
+            )
+            first_active_center = np.asarray(active_centers[0], dtype=float)
+            shifts_from_first = np.linalg.norm(
+                active_centers - first_active_center,
+                axis=1,
+            )
+            rounded_active_centers = {
+                tuple(np.round(center, 6)) for center in active_centers
+            }
+            mean_active_center = np.mean(active_centers, axis=0)
+            mean_offset = np.mean(
+                active_centers - reference_centers,
+                axis=0,
+            )
+            writer.writerow(
+                [
+                    set_index,
+                    str(frame_set.series_label),
+                    str(frame_set.frame_range_label),
+                    int(frame_set.frame_count),
+                    frame_set.file_paths[0].name,
+                    len(rounded_active_centers),
+                    f"{first_active_center[0]:.8f}",
+                    f"{first_active_center[1]:.8f}",
+                    f"{first_active_center[2]:.8f}",
+                    f"{center_of_mass_centers[0][0]:.8f}",
+                    f"{center_of_mass_centers[0][1]:.8f}",
+                    f"{center_of_mass_centers[0][2]:.8f}",
+                    f"{mean_active_center[0]:.8f}",
+                    f"{mean_active_center[1]:.8f}",
+                    f"{mean_active_center[2]:.8f}",
+                    f"{float(np.max(shifts_from_first)):.8f}",
+                    f"{float(np.mean(shifts_from_first)):.8f}",
+                    f"{mean_offset[0]:.8f}",
+                    f"{mean_offset[1]:.8f}",
+                    f"{mean_offset[2]:.8f}",
+                ]
+            )
+    return frame_csv_path, set_csv_path
+
+
+def _actual_run_display_label(run_key: str) -> str:
+    labels = {
+        "geom_mass__contiguous-off__pin-off": ("Geom Mass, contiguous off"),
+        "geom_mass__contiguous-on__pin-off": ("Geom Mass, contiguous on"),
+        "geom_mass__contiguous-on__pin-on": (
+            "Geom Mass, contiguous on, pinned"
+        ),
+        "reference-element__contiguous-off__pin-off": (
+            "Reference Element, contiguous off"
+        ),
+        "reference-element__contiguous-on__pin-off": (
+            "Reference Element, contiguous on"
+        ),
+    }
+    return labels.get(run_key, run_key)
+
+
+def _actual_run_plot_style(run_key: str) -> dict[str, object]:
+    styles: dict[str, dict[str, object]] = {
+        "geom_mass__contiguous-off__pin-off": {
+            "color": "#1d4ed8",
+            "linestyle": "-",
+            "linewidth": 2.0,
+        },
+        "geom_mass__contiguous-on__pin-off": {
+            "color": "#0f766e",
+            "linestyle": "--",
+            "linewidth": 2.0,
+        },
+        "geom_mass__contiguous-on__pin-on": {
+            "color": "#b45309",
+            "linestyle": "-.",
+            "linewidth": 2.2,
+        },
+        "reference-element__contiguous-off__pin-off": {
+            "color": "#7c3aed",
+            "linestyle": "-",
+            "linewidth": 2.0,
+        },
+        "reference-element__contiguous-on__pin-off": {
+            "color": "#a855f7",
+            "linestyle": ":",
+            "linewidth": 2.4,
+        },
+    }
+    return dict(styles.get(run_key, {}))
+
+
+def _ordered_actual_run_keys() -> list[str]:
+    return [
+        "geom_mass__contiguous-off__pin-off",
+        "geom_mass__contiguous-on__pin-off",
+        "geom_mass__contiguous-on__pin-on",
+        "reference-element__contiguous-off__pin-off",
+        "reference-element__contiguous-on__pin-off",
+    ]
+
+
+def _load_profile_csv(
+    path: Path,
+) -> dict[str, np.ndarray]:
+    radial_centers: list[float] = []
+    orientation_density: list[float] = []
+    smeared_density: list[float] = []
+    with path.open(encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            radial_centers.append(float(row["r_center_a"]))
+            orientation_density.append(
+                float(row["orientation_average_density_e_per_a3"])
+            )
+            smeared_density.append(
+                float(row["smeared_orientation_average_density_e_per_a3"])
+            )
+    return {
+        "r_center_a": np.asarray(radial_centers, dtype=float),
+        "orientation_average_density_e_per_a3": np.asarray(
+            orientation_density,
+            dtype=float,
+        ),
+        "smeared_orientation_average_density_e_per_a3": np.asarray(
+            smeared_density,
+            dtype=float,
+        ),
+    }
+
+
+def _load_set_summary_csv(
+    path: Path,
+) -> dict[str, np.ndarray]:
+    set_index: list[int] = []
+    frame_count: list[int] = []
+    unique_active_center_count: list[int] = []
+    max_shift_from_first: list[float] = []
+    mean_shift_from_first: list[float] = []
+    with path.open(encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            set_index.append(int(row["set_index"]))
+            frame_count.append(int(row["frame_count"]))
+            unique_active_center_count.append(
+                int(row["unique_active_center_count_rounded_1e-6"])
+            )
+            max_shift_from_first.append(
+                float(row["max_active_center_shift_from_first_a"])
+            )
+            mean_shift_from_first.append(
+                float(row["mean_active_center_shift_from_first_a"])
+            )
+    return {
+        "set_index": np.asarray(set_index, dtype=int),
+        "frame_count": np.asarray(frame_count, dtype=int),
+        "unique_active_center_count": np.asarray(
+            unique_active_center_count,
+            dtype=int,
+        ),
+        "max_active_center_shift_from_first_a": np.asarray(
+            max_shift_from_first,
+            dtype=float,
+        ),
+        "mean_active_center_shift_from_first_a": np.asarray(
+            mean_shift_from_first,
+            dtype=float,
+        ),
+    }
+
+
+def _load_detected_set_csv(
+    path: Path,
+) -> dict[str, np.ndarray]:
+    set_index: list[int] = []
+    frame_count: list[int] = []
+    with path.open(encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            set_index.append(int(row["set_index"]))
+            frame_count.append(int(row["frame_count"]))
+    return {
+        "set_index": np.asarray(set_index, dtype=int),
+        "frame_count": np.asarray(frame_count, dtype=int),
+    }
+
+
+def _pair_row_from_summary(
+    summary_payload: dict[str, object],
+    left_key: str,
+    right_key: str,
+) -> dict[str, object]:
+    rows = list(summary_payload["pairwise_profile_differences"])
+    for row in rows:
+        if (row["run_a"] == left_key and row["run_b"] == right_key) or (
+            row["run_a"] == right_key and row["run_b"] == left_key
+        ):
+            return row
+    raise KeyError(
+        f"Could not find pair row for {left_key!r} vs {right_key!r}."
+    )
+
+
+def _generate_plot_artifacts(
+    output_dir: Path,
+    summary_payload: dict[str, object],
+) -> list[str]:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    requested_runs = list(summary_payload["requested_runs"])
+    actual_run_entries: dict[str, dict[str, object]] = {}
+    for entry in requested_runs:
+        actual_run_entries.setdefault(str(entry["actual_run_key"]), entry)
+
+    profile_data = {
+        run_key: _load_profile_csv(Path(entry["profile_csv_path"]))
+        for run_key, entry in actual_run_entries.items()
+    }
+    set_summary_data = {
+        run_key: _load_set_summary_csv(Path(entry["set_summary_csv_path"]))
+        for run_key, entry in actual_run_entries.items()
+    }
+    detected_set_data = _load_detected_set_csv(
+        Path(summary_payload["detected_contiguous_frame_sets"]["csv_path"])
+    )
+    plot_paths: list[str] = []
+
+    overlay_path = output_dir / "profile_overlay_comparison.png"
+    fig, ax = plt.subplots(figsize=(11, 7))
+    for run_key in _ordered_actual_run_keys():
+        if run_key not in profile_data:
+            continue
+        series = profile_data[run_key]
+        ax.plot(
+            series["r_center_a"],
+            series["smeared_orientation_average_density_e_per_a3"],
+            label=_actual_run_display_label(run_key),
+            **_actual_run_plot_style(run_key),
+        )
+    ax.set_title("Pb2I4 EDM comparison: smeared profile overlays")
+    ax.set_xlabel("r (A)")
+    ax.set_ylabel("Smeared density (e-/A^3)")
+    ax.grid(alpha=0.25)
+    ax.legend(loc="best", fontsize=9)
+    fig.tight_layout()
+    fig.savefig(overlay_path, dpi=180)
+    plt.close(fig)
+    plot_paths.append(str(overlay_path))
+
+    difference_path = output_dir / "key_profile_differences.png"
+    fig, axes = plt.subplots(2, 2, figsize=(12, 9), sharex=True)
+    difference_pairs = [
+        (
+            "Geom off -> geom contiguous",
+            "geom_mass__contiguous-off__pin-off",
+            "geom_mass__contiguous-on__pin-off",
+        ),
+        (
+            "Geom contiguous -> geom pinned",
+            "geom_mass__contiguous-on__pin-off",
+            "geom_mass__contiguous-on__pin-on",
+        ),
+        (
+            "Ref off -> ref contiguous",
+            "reference-element__contiguous-off__pin-off",
+            "reference-element__contiguous-on__pin-off",
+        ),
+        (
+            "Geom off -> ref off",
+            "geom_mass__contiguous-off__pin-off",
+            "reference-element__contiguous-off__pin-off",
+        ),
+    ]
+    for axis, (title, left_key, right_key) in zip(
+        axes.flat,
+        difference_pairs,
+        strict=False,
+    ):
+        left_series = profile_data[left_key]
+        right_series = profile_data[right_key]
+        difference = (
+            right_series["smeared_orientation_average_density_e_per_a3"]
+            - left_series["smeared_orientation_average_density_e_per_a3"]
+        )
+        pair_row = _pair_row_from_summary(
+            summary_payload,
+            left_key,
+            right_key,
+        )
+        axis.plot(
+            left_series["r_center_a"],
+            difference,
+            color="#dc2626",
+            linewidth=2.0,
+        )
+        axis.axhline(0.0, color="#475569", linewidth=1.0, alpha=0.8)
+        axis.set_title(
+            f"{title}\nmax abs diff={float(pair_row['max_abs_diff_e_per_a3']):.4f}"
+        )
+        axis.set_xlabel("r (A)")
+        axis.set_ylabel("Delta smeared density (e-/A^3)")
+        axis.grid(alpha=0.25)
+    fig.tight_layout()
+    fig.savefig(difference_path, dpi=180)
+    plt.close(fig)
+    plot_paths.append(str(difference_path))
+
+    center_behavior_path = output_dir / "per_set_center_behavior.png"
+    fig, axes = plt.subplots(2, 1, figsize=(12, 9), sharex=True)
+    for run_key in [
+        "geom_mass__contiguous-off__pin-off",
+        "geom_mass__contiguous-on__pin-off",
+        "geom_mass__contiguous-on__pin-on",
+        "reference-element__contiguous-off__pin-off",
+    ]:
+        if run_key not in set_summary_data:
+            continue
+        series = set_summary_data[run_key]
+        style = _actual_run_plot_style(run_key)
+        axes[0].plot(
+            series["set_index"],
+            series["max_active_center_shift_from_first_a"],
+            label=_actual_run_display_label(run_key),
+            **style,
+        )
+        axes[1].plot(
+            series["set_index"],
+            series["unique_active_center_count"],
+            label=_actual_run_display_label(run_key),
+            **style,
+        )
+    axes[0].set_title("Per-set active-center drift relative to first frame")
+    axes[0].set_ylabel("Max shift from first frame (A)")
+    axes[0].grid(alpha=0.25)
+    axes[0].legend(loc="best", fontsize=9)
+    axes[1].set_title(
+        "Unique active centers observed within each contiguous set"
+    )
+    axes[1].set_xlabel("Contiguous set index")
+    axes[1].set_ylabel("Unique active center count")
+    axes[1].grid(alpha=0.25)
+    fig.tight_layout()
+    fig.savefig(center_behavior_path, dpi=180)
+    plt.close(fig)
+    plot_paths.append(str(center_behavior_path))
+
+    set_size_path = output_dir / "contiguous_set_size_distribution.png"
+    fig, axes = plt.subplots(1, 2, figsize=(12, 4.5))
+    axes[0].bar(
+        detected_set_data["set_index"],
+        detected_set_data["frame_count"],
+        color="#2563eb",
+        alpha=0.85,
+    )
+    axes[0].set_title("Contiguous set sizes by set index")
+    axes[0].set_xlabel("Contiguous set index")
+    axes[0].set_ylabel("Frames in set")
+    axes[0].grid(alpha=0.2, axis="y")
+    axes[1].hist(
+        detected_set_data["frame_count"],
+        bins=min(16, len(detected_set_data["frame_count"])),
+        color="#0f766e",
+        alpha=0.85,
+    )
+    axes[1].set_title("Distribution of contiguous set sizes")
+    axes[1].set_xlabel("Frames in set")
+    axes[1].set_ylabel("Number of sets")
+    axes[1].grid(alpha=0.2, axis="y")
+    fig.tight_layout()
+    fig.savefig(set_size_path, dpi=180)
+    plt.close(fig)
+    plot_paths.append(str(set_size_path))
+    return plot_paths
+
+
+def _render_report_lines(summary_payload: dict[str, object]) -> list[str]:
+    frame_set_summary = dict(summary_payload["detected_contiguous_frame_sets"])
+    key_comparisons = [
+        (
+            "Geometric Mass Center: contiguous off vs contiguous on (standard)",
+            _pair_row_from_summary(
+                summary_payload,
+                "geom_mass__contiguous-off__pin-off",
+                "geom_mass__contiguous-on__pin-off",
+            ),
+        ),
+        (
+            "Geometric Mass Center: contiguous on standard vs pinned",
+            _pair_row_from_summary(
+                summary_payload,
+                "geom_mass__contiguous-on__pin-off",
+                "geom_mass__contiguous-on__pin-on",
+            ),
+        ),
+        (
+            "Reference Element: contiguous off vs contiguous on",
+            _pair_row_from_summary(
+                summary_payload,
+                "reference-element__contiguous-off__pin-off",
+                "reference-element__contiguous-on__pin-off",
+            ),
+        ),
+        (
+            "Geometric Mass Center vs Reference Element, both contiguous off",
+            _pair_row_from_summary(
+                summary_payload,
+                "geom_mass__contiguous-off__pin-off",
+                "reference-element__contiguous-off__pin-off",
+            ),
+        ),
+    ]
+    mesh_settings = dict(summary_payload["mesh_settings"])
+    smearing_settings = dict(summary_payload["smearing_settings"])
+    report_lines = [
+        "# EDM Contiguous-Mode Comparison",
+        "",
+        f"- Selection: `{summary_payload['selection_path']}`",
+        f"- Output directory: `{summary_payload['output_dir']}`",
+        f"- Structures: {int(summary_payload['structure_count'])}",
+        (
+            "- Mesh: "
+            f"rstep={float(mesh_settings['rstep_a']):.3f} A, "
+            f"theta={int(mesh_settings['theta_divisions'])}, "
+            f"phi={int(mesh_settings['phi_divisions'])}, "
+            f"rmax={float(mesh_settings['rmax_a']):.3f} A"
+        ),
+        (
+            "- Smearing sigma: "
+            f"{float(smearing_settings['gaussian_sigma_a']):.6f} A"
+        ),
+        (
+            "- Detected contiguous sets: "
+            f"{int(frame_set_summary['count'])} sets across "
+            f"{int(frame_set_summary['total_frames'])} frames"
+        ),
+        (
+            "- Frames per set: "
+            f"min={int(frame_set_summary['min_frame_count'])}, "
+            f"max={int(frame_set_summary['max_frame_count'])}, "
+            f"mean={float(frame_set_summary['mean_frame_count']):.2f}"
+        ),
+        "",
+        "## Requested Runs",
+        "",
+        "| Run | Actual run | Contiguous applied | Pin applied | Runtime (s) | Notes |",
+        "| --- | --- | --- | --- | ---: | --- |",
+    ]
+    for entry in list(summary_payload["requested_runs"]):
+        report_lines.append(
+            "| "
+            f"{entry['requested_slug']} | "
+            f"{entry['actual_run_key']} | "
+            f"{entry['contiguous_frame_mode_applied']} | "
+            f"{entry['pinned_geometric_tracking_applied']} | "
+            f"{float(entry['elapsed_seconds']):.2f} | "
+            f"{'; '.join(entry['averaging_notes']) or 'None'} |"
+        )
+    report_lines.extend(
+        [
+            "",
+            "## Key Comparisons",
+            "",
+        ]
+    )
+    for title, row in key_comparisons:
+        report_lines.append(f"- {title}:")
+        report_lines.append(
+            "  "
+            f"max abs profile diff={float(row['max_abs_diff_e_per_a3']):.8f} e-/A^3, "
+            f"integrated abs diff={float(row['integrated_abs_diff_e_per_a2']):.8f} e-/A^2, "
+            f"max active-center shift={float(row['max_active_center_shift_a']):.8f} A."
+        )
+    report_lines.append(
+        "- Geometric Mass Center with contiguous off ignores the pin request, "
+        "so the `pin-on` and `pin-off` requested cases share the same actual run."
+    )
+    report_lines.extend(
+        [
+            "",
+            "## Output Files",
+            "",
+            f"- Summary JSON: `{Path(summary_payload['output_dir']) / 'summary.json'}`",
+            (
+                "- Pairwise CSV: "
+                f"`{summary_payload['pairwise_profile_differences_csv_path']}`"
+            ),
+            f"- Detected contiguous sets CSV: `{frame_set_summary['csv_path']}`",
+            "- Each computed run also writes:",
+            "  - one profile CSV",
+            "  - one frame-center CSV",
+            "  - one set-summary CSV",
+        ]
+    )
+    plot_files = list(summary_payload.get("plot_files") or [])
+    if plot_files:
+        report_lines.extend(
+            [
+                "",
+                "## Plot Files",
+                "",
+            ]
+        )
+        for plot_path in plot_files:
+            report_lines.append(f"- `{plot_path}`")
+    return report_lines
+
+
+@contextmanager
+def _single_worker_mode(enabled: bool):
+    if not enabled:
+        yield
+        return
+    original = density_workflow._resolve_electron_density_worker_count
+    density_workflow._resolve_electron_density_worker_count = lambda _count: 1
+    try:
+        yield
+    finally:
+        density_workflow._resolve_electron_density_worker_count = original
+
+
+def _default_mesh_settings(
+    reference_structure: density_workflow.ElectronDensityStructure,
+) -> density_workflow.ElectronDensityMeshSettings:
+    return density_workflow.ElectronDensityMeshSettings(
+        rstep=0.5,
+        theta_divisions=12,
+        phi_divisions=6,
+        rmax=min(max(float(reference_structure.rmax), 1.0), 10.0),
+    )
+
+
+def _prepare_element_caches(
+    reference_structure: density_workflow.ElectronDensityStructure,
+) -> list[str]:
+    unique_elements = sorted(set(reference_structure.elements))
+    for element in unique_elements:
+        density_workflow._atomic_mass(element)
+        density_workflow._atomic_number(element)
+        density_workflow._waasmaier_parameters(element)
+        density_workflow._effective_atomic_overlap_radius(element)
+    return unique_elements
+
+
+def _run_comparison(
+    *,
+    selection_path: Path,
+    output_dir: Path,
+    force_single_worker: bool,
+) -> dict[str, object]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    inspection = density_workflow.inspect_structure_input(selection_path)
+    if inspection.input_mode != "folder":
+        raise ValueError("The comparison report expects a folder selection.")
+    reference_structure = density_workflow.load_electron_density_structure(
+        inspection.reference_file
+    )
+    mesh_settings = _default_mesh_settings(reference_structure)
+    unique_elements = _prepare_element_caches(reference_structure)
+    detected_frame_sets, fallback_reason = (
+        density_workflow._detect_contiguous_frame_sets(
+            tuple(inspection.structure_files)
+        )
+    )
+    if fallback_reason is not None:
+        raise ValueError(fallback_reason)
+
+    run_requests = [
+        {
+            "center_mode": "center_of_mass",
+            "use_contiguous_frame_mode": False,
+            "pin_contiguous_geometric_tracking": False,
+        },
+        {
+            "center_mode": "center_of_mass",
+            "use_contiguous_frame_mode": False,
+            "pin_contiguous_geometric_tracking": True,
+        },
+        {
+            "center_mode": "center_of_mass",
+            "use_contiguous_frame_mode": True,
+            "pin_contiguous_geometric_tracking": False,
+        },
+        {
+            "center_mode": "center_of_mass",
+            "use_contiguous_frame_mode": True,
+            "pin_contiguous_geometric_tracking": True,
+        },
+        {
+            "center_mode": "reference_element",
+            "use_contiguous_frame_mode": False,
+            "pin_contiguous_geometric_tracking": False,
+        },
+        {
+            "center_mode": "reference_element",
+            "use_contiguous_frame_mode": False,
+            "pin_contiguous_geometric_tracking": True,
+        },
+        {
+            "center_mode": "reference_element",
+            "use_contiguous_frame_mode": True,
+            "pin_contiguous_geometric_tracking": False,
+        },
+        {
+            "center_mode": "reference_element",
+            "use_contiguous_frame_mode": True,
+            "pin_contiguous_geometric_tracking": True,
+        },
+    ]
+
+    computed_results: dict[
+        str,
+        density_workflow.ElectronDensityProfileResult,
+    ] = {}
+    run_metadata: dict[str, dict[str, object]] = {}
+
+    detected_set_csv_path = output_dir / "detected_contiguous_sets.csv"
+    _write_detected_set_csv(detected_set_csv_path, detected_frame_sets)
+
+    for request in run_requests:
+        requested_slug = _combo_slug(**request)
+        actual_key = _effective_combo_key(**request)
+        run_metadata[requested_slug] = {
+            "requested_slug": requested_slug,
+            "actual_run_key": actual_key,
+            "center_mode": str(request["center_mode"]),
+            "center_mode_label": _center_mode_label(
+                str(request["center_mode"])
+            ),
+            "use_contiguous_frame_mode": bool(
+                request["use_contiguous_frame_mode"]
+            ),
+            "pin_contiguous_geometric_tracking_requested_in_mesh": bool(
+                request["pin_contiguous_geometric_tracking"]
+            ),
+        }
+        if actual_key in computed_results:
+            continue
+        run_mesh_settings = density_workflow.ElectronDensityMeshSettings(
+            rstep=float(mesh_settings.rstep),
+            theta_divisions=int(mesh_settings.theta_divisions),
+            phi_divisions=int(mesh_settings.phi_divisions),
+            rmax=float(mesh_settings.rmax),
+            pin_contiguous_geometric_tracking=bool(
+                request["pin_contiguous_geometric_tracking"]
+            ),
+        )
+        print(
+            "Running",
+            actual_key,
+            f"(center={request['center_mode']},",
+            f"contiguous={request['use_contiguous_frame_mode']},",
+            f"pin={request['pin_contiguous_geometric_tracking']})",
+            flush=True,
+        )
+        start_time = time.perf_counter()
+        with _single_worker_mode(force_single_worker):
+            result = (
+                density_workflow.compute_electron_density_profile_for_input(
+                    inspection,
+                    run_mesh_settings,
+                    reference_structure=reference_structure,
+                    center_mode=str(request["center_mode"]),
+                    use_contiguous_frame_mode=bool(
+                        request["use_contiguous_frame_mode"]
+                    ),
+                )
+            )
+        elapsed_seconds = float(time.perf_counter() - start_time)
+        computed_results[actual_key] = result
+        profile_csv_path = output_dir / f"{actual_key}__profile.csv"
+        _write_profile_csv(profile_csv_path, result)
+        frame_csv_path, set_csv_path = _write_run_center_csvs(
+            output_dir,
+            actual_key,
+            result,
+            detected_frame_sets,
+        )
+        run_metadata[requested_slug].update(
+            {
+                "computed": True,
+                "elapsed_seconds": elapsed_seconds,
+                "profile_csv_path": str(profile_csv_path),
+                "frame_center_csv_path": str(frame_csv_path),
+                "set_summary_csv_path": str(set_csv_path),
+            }
+        )
+        print(
+            "Completed",
+            actual_key,
+            f"in {elapsed_seconds:.2f}s",
+            flush=True,
+        )
+
+    for request in run_requests:
+        requested_slug = _combo_slug(**request)
+        actual_key = _effective_combo_key(**request)
+        result = computed_results[actual_key]
+        metadata = run_metadata[requested_slug]
+        if "elapsed_seconds" not in metadata:
+            actual_metadata = next(
+                value
+                for value in run_metadata.values()
+                if value["actual_run_key"] == actual_key
+                and "elapsed_seconds" in value
+            )
+            metadata.update(
+                {
+                    "computed": False,
+                    "aliased_to": actual_key,
+                    "elapsed_seconds": float(
+                        actual_metadata["elapsed_seconds"]
+                    ),
+                    "profile_csv_path": str(
+                        actual_metadata["profile_csv_path"]
+                    ),
+                    "frame_center_csv_path": str(
+                        actual_metadata["frame_center_csv_path"]
+                    ),
+                    "set_summary_csv_path": str(
+                        actual_metadata["set_summary_csv_path"]
+                    ),
+                }
+            )
+        metadata.update(
+            {
+                "source_structure_count": int(result.source_structure_count),
+                "averaging_mode": str(result.averaging_mode),
+                "contiguous_frame_mode_requested": bool(
+                    result.contiguous_frame_mode_requested
+                ),
+                "contiguous_frame_mode_applied": bool(
+                    result.contiguous_frame_mode_applied
+                ),
+                "pinned_geometric_tracking_requested": bool(
+                    result.pinned_geometric_tracking_requested
+                ),
+                "pinned_geometric_tracking_applied": bool(
+                    result.pinned_geometric_tracking_applied
+                ),
+                "averaging_notes": [
+                    str(note) for note in result.averaging_notes
+                ],
+                "smearing_sigma_a": float(
+                    result.smearing_settings.gaussian_sigma_a
+                ),
+                "radial_shell_count": int(result.mesh_geometry.shell_count),
+            }
+        )
+
+    pairwise_rows: list[dict[str, object]] = []
+    unique_keys = sorted(computed_results)
+    for left_index, left_key in enumerate(unique_keys):
+        for right_key in unique_keys[left_index + 1 :]:
+            left_result = computed_results[left_key]
+            right_result = computed_results[right_key]
+            row: dict[str, object] = {
+                "run_a": left_key,
+                "run_b": right_key,
+            }
+            row.update(_profile_metrics(left_result, right_result))
+            row.update(_active_center_metrics(left_result, right_result))
+            pairwise_rows.append(row)
+
+    pairwise_csv_path = output_dir / "pairwise_profile_differences.csv"
+    with pairwise_csv_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "run_a",
+                "run_b",
+                "profiles_identical",
+                "max_abs_diff_e_per_a3",
+                "mean_abs_diff_e_per_a3",
+                "rms_diff_e_per_a3",
+                "integrated_abs_diff_e_per_a2",
+                "active_centers_identical",
+                "max_active_center_shift_a",
+                "mean_active_center_shift_a",
+            ],
+        )
+        writer.writeheader()
+        for row in pairwise_rows:
+            writer.writerow(row)
+
+    frame_counts = [
+        int(frame_set.frame_count) for frame_set in detected_frame_sets
+    ]
+    series_counts: dict[str, int] = {}
+    for frame_set in detected_frame_sets:
+        series_counts[str(frame_set.series_label)] = (
+            int(series_counts.get(str(frame_set.series_label), 0)) + 1
+        )
+
+    summary_payload: dict[str, object] = {
+        "selection_path": str(selection_path),
+        "inspection_reference_file": str(inspection.reference_file),
+        "output_dir": str(output_dir),
+        "force_single_worker": bool(force_single_worker),
+        "unique_elements": unique_elements,
+        "mesh_settings": mesh_settings.to_dict(),
+        "smearing_settings": density_workflow.ElectronDensitySmearingSettings()
+        .normalized()
+        .to_dict(),
+        "structure_count": int(len(inspection.structure_files)),
+        "detected_contiguous_frame_sets": {
+            "count": int(len(detected_frame_sets)),
+            "total_frames": int(sum(frame_counts)),
+            "min_frame_count": int(min(frame_counts)),
+            "max_frame_count": int(max(frame_counts)),
+            "mean_frame_count": float(np.mean(frame_counts)),
+            "series_counts": series_counts,
+            "csv_path": str(detected_set_csv_path),
+        },
+        "requested_runs": [
+            run_metadata[_combo_slug(**request)] for request in run_requests
+        ],
+        "pairwise_profile_differences_csv_path": str(pairwise_csv_path),
+        "pairwise_profile_differences": pairwise_rows,
+    }
+
+    summary_payload["plot_files"] = _generate_plot_artifacts(
+        output_dir,
+        summary_payload,
+    )
+    summary_json_path = output_dir / "summary.json"
+    report_path = output_dir / "report.md"
+    summary_payload["report_path"] = str(report_path)
+    summary_json_path.write_text(
+        json.dumps(summary_payload, indent=2),
+        encoding="utf-8",
+    )
+    report_path.write_text(
+        "\n".join(_render_report_lines(summary_payload)) + "\n",
+        encoding="utf-8",
+    )
+    return summary_payload
+
+
+def _generate_plots_only(
+    output_dir: Path,
+) -> dict[str, object]:
+    summary_json_path = output_dir / "summary.json"
+    if not summary_json_path.is_file():
+        raise FileNotFoundError(
+            f"Could not find existing summary JSON at {summary_json_path}."
+        )
+    summary_payload = json.loads(summary_json_path.read_text(encoding="utf-8"))
+    summary_payload["plot_files"] = _generate_plot_artifacts(
+        output_dir,
+        summary_payload,
+    )
+    report_path = output_dir / "report.md"
+    summary_payload["report_path"] = str(report_path)
+    summary_json_path.write_text(
+        json.dumps(summary_payload, indent=2),
+        encoding="utf-8",
+    )
+    report_path.write_text(
+        "\n".join(_render_report_lines(summary_payload)) + "\n",
+        encoding="utf-8",
+    )
+    return summary_payload
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run a backend EDM comparison across contiguous/pinned center-mode "
+            "settings and write report artifacts under tests/."
+        )
+    )
+    parser.add_argument(
+        "--selection",
+        type=Path,
+        default=DEFAULT_SELECTION_PATH,
+        help="Folder of contiguous PDB frames to analyze.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Directory where report artifacts will be written.",
+    )
+    parser.add_argument(
+        "--use-default-workers",
+        action="store_true",
+        help="Use the workflow's default worker-count resolution.",
+    )
+    parser.add_argument(
+        "--plots-only",
+        action="store_true",
+        help="Generate PNG plots from an existing summary/report bundle.",
+    )
+    args = parser.parse_args()
+    resolved_output_dir = args.output_dir.expanduser().resolve()
+    if args.plots_only:
+        summary = _generate_plots_only(resolved_output_dir)
+    else:
+        summary = _run_comparison(
+            selection_path=args.selection.expanduser().resolve(),
+            output_dir=resolved_output_dir,
+            force_single_worker=not bool(args.use_default_workers),
+        )
+    print(
+        json.dumps(
+            {
+                "summary_json": str(
+                    Path(summary["output_dir"]) / "summary.json"
+                ),
+                "report_path": str(summary["report_path"]),
+                "pairwise_csv": str(
+                    summary["pairwise_profile_differences_csv_path"]
+                ),
+                "plot_files": list(summary.get("plot_files") or []),
+            },
+            indent=2,
+        )
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cluster_cli.py
+++ b/tests/test_cluster_cli.py
@@ -57,6 +57,7 @@ def test_cluster_workflow_supports_notebook_style_end_to_end_usage(tmp_path):
     assert summary["estimated_box_dimensions"] == (2.0, 1.7, 0.0)
     assert selection.search_mode == "kdtree"
     assert selection.save_state_frequency == DEFAULT_SAVE_STATE_FREQUENCY
+    assert not selection.smart_solvation_shells
     assert selection.resolved_box_dimensions == (2.0, 1.7, 0.0)
     assert selection.output_dir == tmp_path / "clusters_splitxyz0001"
     assert export.output_dir == selection.output_dir
@@ -111,6 +112,7 @@ def test_clusters_cli_export_runs_complete_headless_workflow(
 
     assert exit_code == 0
     assert "Mode: XYZ frames" in captured.out
+    assert "Smart solvation shells: off" in captured.out
     assert "Search mode: KDTree" in captured.out
     assert (
         "Save-state frequency: every "

--- a/tests/test_cluster_ui.py
+++ b/tests/test_cluster_ui.py
@@ -117,6 +117,7 @@ def test_definitions_panel_switches_to_xyz_mode(qapp):
     assert not panel.use_pbc()
     assert panel.search_mode() == "kdtree"
     assert panel.save_state_frequency() == DEFAULT_SAVE_STATE_FREQUENCY
+    assert not panel.smart_solvation_shells_box.isEnabled()
     assert not panel.include_shell_atoms_in_stoichiometry()
 
 
@@ -148,6 +149,7 @@ def test_definitions_panel_starts_blank_with_builtin_preset_available(qapp):
     assert not panel.use_pbc()
     assert panel.search_mode() == "kdtree"
     assert panel.save_state_frequency() == DEFAULT_SAVE_STATE_FREQUENCY
+    assert panel.smart_solvation_shells()
     assert not panel.include_shell_atoms_in_stoichiometry()
 
 
@@ -165,6 +167,7 @@ def test_definitions_panel_saves_and_recalls_custom_presets_without_box(
     panel.set_default_cutoff(4.25)
     panel.set_shell_growth_levels((1, 2))
     panel.set_shared_shells(True)
+    panel.set_smart_solvation_shells(False)
     panel.set_include_shell_atoms_in_stoichiometry(True)
     panel.set_box_dimensions((10.0, 11.0, 12.0))
 
@@ -187,6 +190,7 @@ def test_definitions_panel_saves_and_recalls_custom_presets_without_box(
     panel.set_default_cutoff(None, emit_signal=False)
     panel.set_shell_growth_levels((), emit_signal=False)
     panel.set_shared_shells(False, emit_signal=False)
+    panel.set_smart_solvation_shells(True, emit_signal=False)
     panel.set_include_shell_atoms_in_stoichiometry(False, emit_signal=False)
 
     panel.load_preset("Custom solvent shell")
@@ -199,6 +203,7 @@ def test_definitions_panel_saves_and_recalls_custom_presets_without_box(
     assert panel.default_cutoff() == 4.25
     assert panel.shell_growth_levels() == (1, 2)
     assert panel.shared_shells()
+    assert not panel.smart_solvation_shells()
     assert panel.include_shell_atoms_in_stoichiometry()
     assert panel.box_dimensions() == (21.0, 22.0, 23.0)
 
@@ -442,6 +447,7 @@ def test_cluster_export_worker_emits_frame_progress(qapp, tmp_path):
         shell_levels=(1,),
         include_shell_levels=(0, 1),
         shared_shells=False,
+        smart_solvation_shells=False,
         include_shell_atoms_in_stoichiometry=False,
         output_dir=source_dir / "clusters_splitxyz0001",
     )

--- a/tests/test_debye_waller_analysis.py
+++ b/tests/test_debye_waller_analysis.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from saxshell.saxs.debye_waller.workflow import (
+    DebyeWallerWorkflow,
+    find_saved_project_debye_waller_analysis,
+    load_debye_waller_analysis_result,
+    save_debye_waller_analysis_to_project,
+)
+
+
+def _pdb_atom_line(
+    atom_id: int,
+    atom_name: str,
+    residue_name: str,
+    residue_number: int,
+    x_coord: float,
+    y_coord: float,
+    z_coord: float,
+    element: str,
+) -> str:
+    return (
+        f"ATOM  {atom_id:5d} {atom_name:<4} {residue_name:>3}  "
+        f"{residue_number:4d}    "
+        f"{x_coord:8.3f}{y_coord:8.3f}{z_coord:8.3f}"
+        f"  1.00  0.00          {element:>2}\n"
+    )
+
+
+def _write_water_frame(
+    path: Path,
+    *,
+    mol1_oxygen_x: float,
+    mol1_hydrogen_x: float,
+    mol2_oxygen_x: float,
+    mol2_hydrogen_x: float,
+) -> None:
+    lines = [
+        _pdb_atom_line(1, "O", "HOH", 1, mol1_oxygen_x, 0.0, 0.0, "O"),
+        _pdb_atom_line(2, "H1", "HOH", 1, mol1_hydrogen_x, 0.0, 0.0, "H"),
+        _pdb_atom_line(3, "O", "HOH", 2, mol2_oxygen_x, 0.0, 0.0, "O"),
+        _pdb_atom_line(4, "H1", "HOH", 2, mol2_hydrogen_x, 0.0, 0.0, "H"),
+        "END\n",
+    ]
+    path.write_text("".join(lines), encoding="utf-8")
+
+
+def test_debye_waller_workflow_rejects_xyz_cluster_files(tmp_path):
+    clusters_dir = tmp_path / "clusters"
+    structure_dir = clusters_dir / "H2O2"
+    structure_dir.mkdir(parents=True)
+    (structure_dir / "frame_0001.xyz").write_text(
+        "2\nframe\nO 0.0 0.0 0.0\nH 1.0 0.0 0.0\n",
+        encoding="utf-8",
+    )
+
+    workflow = DebyeWallerWorkflow(clusters_dir)
+
+    with pytest.raises(ValueError, match="PDB cluster files only"):
+        workflow.run()
+
+
+def test_debye_waller_workflow_computes_segmented_intra_and_inter_results(
+    tmp_path,
+):
+    clusters_dir = tmp_path / "clusters"
+    structure_dir = clusters_dir / "H2O2"
+    structure_dir.mkdir(parents=True)
+
+    _write_water_frame(
+        structure_dir / "water_frame_0001.pdb",
+        mol1_oxygen_x=0.0,
+        mol1_hydrogen_x=1.00,
+        mol2_oxygen_x=5.0,
+        mol2_hydrogen_x=6.00,
+    )
+    _write_water_frame(
+        structure_dir / "water_frame_0002.pdb",
+        mol1_oxygen_x=0.0,
+        mol1_hydrogen_x=1.10,
+        mol2_oxygen_x=5.2,
+        mol2_hydrogen_x=6.35,
+    )
+    _write_water_frame(
+        structure_dir / "water_frame_0004.pdb",
+        mol1_oxygen_x=0.0,
+        mol1_hydrogen_x=0.95,
+        mol2_oxygen_x=4.9,
+        mol2_hydrogen_x=6.05,
+    )
+    _write_water_frame(
+        structure_dir / "water_frame_0005.pdb",
+        mol1_oxygen_x=0.0,
+        mol1_hydrogen_x=1.05,
+        mol2_oxygen_x=5.1,
+        mol2_hydrogen_x=6.30,
+    )
+
+    output_dir = tmp_path / "out"
+    workflow = DebyeWallerWorkflow(
+        clusters_dir,
+        output_dir=output_dir,
+        output_basename="water_dw",
+    )
+    logs: list[str] = []
+    partial_updates = []
+    result = workflow.run(
+        log_callback=logs.append,
+        stoichiometry_callback=partial_updates.append,
+    )
+
+    assert len(result.stoichiometry_results) == 1
+    stoichiometry = result.stoichiometry_results[0]
+    assert stoichiometry.label == "H2O2"
+    assert len(stoichiometry.contiguous_frame_sets) == 2
+    assert [
+        entry.frame_ids for entry in stoichiometry.contiguous_frame_sets
+    ] == [
+        (1, 2),
+        (4, 5),
+    ]
+
+    pair_labels = {
+        (entry.scope, entry.pair_label): entry
+        for entry in stoichiometry.pair_summaries
+    }
+    assert ("intra_molecular", "HOH:H1-HOH:O") in pair_labels
+    assert ("inter_molecular", "H-O") in pair_labels
+    assert ("inter_molecular", "H-H") in pair_labels
+    assert ("inter_molecular", "O-O") in pair_labels
+
+    intra_row = pair_labels[("intra_molecular", "HOH:H1-HOH:O")]
+    assert intra_row.segment_count == 2
+    assert intra_row.mean_pair_count == pytest.approx(2.0)
+    assert intra_row.sigma_mean > 0.0
+    assert intra_row.b_factor_mean > 0.0
+
+    scope_rows = {
+        entry.scope: entry for entry in stoichiometry.scope_summaries
+    }
+    assert set(scope_rows) == {"intra_molecular", "inter_molecular"}
+    assert scope_rows["intra_molecular"].sigma_mean > 0.0
+    assert scope_rows["inter_molecular"].sigma_mean > 0.0
+
+    assert result.artifacts is not None
+    assert result.artifacts.summary_json_path.exists()
+    assert result.artifacts.aggregated_pair_summary_csv_path.exists()
+    assert result.artifacts.pair_summary_csv_path.exists()
+    assert result.artifacts.scope_summary_csv_path.exists()
+    assert result.artifacts.segment_csv_path.exists()
+    assert stoichiometry.info_summary is not None
+    assert stoichiometry.info_summary.total_frame_count == 4
+    assert stoichiometry.info_summary.total_frame_set_count == 2
+    assert stoichiometry.info_summary.average_frames_per_set == pytest.approx(
+        2.0
+    )
+    assert stoichiometry.info_summary.average_atoms_per_frame == pytest.approx(
+        4.0
+    )
+    assert (
+        stoichiometry.info_summary.average_molecules_per_frame
+        == pytest.approx(2.0)
+    )
+    assert (
+        stoichiometry.info_summary.average_solvent_like_molecules_per_frame
+        == pytest.approx(2.0)
+    )
+    assert stoichiometry.info_summary.unique_residue_names == ("HOH",)
+    assert stoichiometry.info_summary.unique_elements == ("H", "O")
+    assert (
+        stoichiometry.info_summary.solvent_like_molecule_signature == "HOH:HO"
+    )
+    aggregated_rows = {
+        (entry.scope, entry.pair_label): entry
+        for entry in result.aggregated_pair_summaries
+    }
+    assert ("intra_molecular", "HOH:H1-HOH:O") in aggregated_rows
+    assert ("inter_molecular", "H-O") in aggregated_rows
+    aggregated_intra = aggregated_rows[("intra_molecular", "HOH:H1-HOH:O")]
+    assert aggregated_intra.stoichiometry_count == 1
+    assert aggregated_intra.segment_count == 2
+    assert aggregated_intra.sigma_mean == pytest.approx(intra_row.sigma_mean)
+    assert aggregated_intra.b_factor_mean == pytest.approx(
+        intra_row.b_factor_mean
+    )
+
+    assert "H2O2: found 2 contiguous frame set(s)." in logs
+    assert (
+        "H2O2: frame set 1/2 spans frames 1-2 (2 frame(s)) in series 'water'."
+    ) in logs
+    assert (
+        "H2O2: frame set 2/2 spans frames 4-5 (2 frame(s)) in series 'water'."
+    ) in logs
+    assert any(
+        "accumulated" in entry and "segment row(s) so far" in entry
+        for entry in logs
+    )
+
+    assert len(partial_updates) == 2
+    assert all(update.label == "H2O2" for update in partial_updates)
+    assert len(partial_updates[0].segment_statistics) < len(
+        partial_updates[-1].segment_statistics
+    )
+    assert (
+        partial_updates[-1].segment_statistics
+        == stoichiometry.segment_statistics
+    )
+    assert partial_updates[-1].pair_summaries == stoichiometry.pair_summaries
+    assert partial_updates[-1].scope_summaries == stoichiometry.scope_summaries
+
+    payload = json.loads(
+        result.artifacts.summary_json_path.read_text(encoding="utf-8")
+    )
+    assert payload["inspection"]["is_pdb_only"] is True
+    assert payload["stoichiometry_results"][0]["label"] == "H2O2"
+    assert payload["aggregated_pair_summaries"][0]["segment_count"] >= 1
+    assert payload["stoichiometry_results"][0]["info_summary"][
+        "average_atoms_per_frame"
+    ] == pytest.approx(4.0)
+    assert (
+        payload["stoichiometry_results"][0]["pair_summaries"][0][
+            "segment_count"
+        ]
+        >= 1
+    )
+
+
+def test_debye_waller_analysis_can_be_saved_and_reloaded_from_project(
+    tmp_path,
+):
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    clusters_dir = tmp_path / "clusters"
+    structure_dir = clusters_dir / "H2O2"
+    structure_dir.mkdir(parents=True)
+
+    _write_water_frame(
+        structure_dir / "water_frame_0001.pdb",
+        mol1_oxygen_x=0.0,
+        mol1_hydrogen_x=1.00,
+        mol2_oxygen_x=5.0,
+        mol2_hydrogen_x=6.00,
+    )
+    _write_water_frame(
+        structure_dir / "water_frame_0002.pdb",
+        mol1_oxygen_x=0.0,
+        mol1_hydrogen_x=1.10,
+        mol2_oxygen_x=5.2,
+        mol2_hydrogen_x=6.35,
+    )
+
+    result = DebyeWallerWorkflow(
+        clusters_dir,
+        output_dir=tmp_path / "external_out",
+        output_basename="external_run",
+    ).run()
+
+    saved = save_debye_waller_analysis_to_project(result, project_dir)
+    summary_path = find_saved_project_debye_waller_analysis(project_dir)
+
+    assert summary_path is not None
+    assert summary_path.exists()
+    assert saved.artifacts is not None
+    assert saved.artifacts.summary_json_path == summary_path
+    assert saved.artifacts.aggregated_pair_summary_csv_path.exists()
+
+    reloaded = load_debye_waller_analysis_result(summary_path)
+
+    assert reloaded.project_dir == project_dir.resolve()
+    assert reloaded.output_dir == saved.output_dir
+    assert len(reloaded.stoichiometry_results) == 1
+    assert len(reloaded.aggregated_pair_summaries) >= 1
+    assert reloaded.stoichiometry_results[0].label == "H2O2"
+    assert reloaded.stoichiometry_results[0].info_summary is not None

--- a/tests/test_electron_density_mapping.py
+++ b/tests/test_electron_density_mapping.py
@@ -1,38 +1,54 @@
 from __future__ import annotations
 
+import json
 import os
+import threading
 import time
+from dataclasses import replace
 from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
 import pytest
 from matplotlib.backend_bases import MouseButton
-from PySide6.QtCore import Qt
+from PySide6.QtCore import QItemSelectionModel, Qt
 from PySide6.QtGui import QColor
-from PySide6.QtWidgets import QApplication
+from PySide6.QtTest import QTest
+from PySide6.QtWidgets import QApplication, QMessageBox, QScrollArea
 
+import saxshell.saxs.electron_density_mapping.workflow as density_workflow
 from saxshell.saxs.contrast.electron_density import (
     CONTRAST_SOLVENT_METHOD_DIRECT,
     ContrastSolventDensitySettings,
 )
+from saxshell.saxs.debye import atomic_form_factor
 from saxshell.saxs.electron_density_mapping.ui.main_window import (
     ElectronDensityMappingMainWindow,
+    _DebyeComparisonEntry,
+    _DebyeScatteringComparisonDialog,
+    launch_electron_density_mapping_ui,
+)
+from saxshell.saxs.electron_density_mapping.ui.viewer import (
+    ElectronDensityFourierPreviewPlot,
 )
 from saxshell.saxs.electron_density_mapping.workflow import (
+    ElectronDensityCalculationCanceled,
     ElectronDensityFourierTransformSettings,
     ElectronDensityMeshSettings,
     ElectronDensitySmearingSettings,
     apply_smearing_to_profile_result,
     apply_solvent_contrast_to_profile_result,
+    compute_average_debye_scattering_profile_for_input,
     compute_electron_density_profile,
     compute_electron_density_profile_for_input,
     compute_electron_density_scattering_profile,
+    compute_single_atom_debye_scattering_profile_for_input,
     inspect_structure_input,
     load_electron_density_structure,
     prepare_electron_density_fourier_transform,
     write_electron_density_profile_outputs,
 )
+from saxshell.saxs.ui.main_window import AUTO_SNAP_PANES_KEY
 
 xraydb = pytest.importorskip("xraydb")
 
@@ -46,9 +62,162 @@ def qapp():
     yield app
 
 
+@pytest.fixture(autouse=True)
+def _accept_default_questions(monkeypatch):
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.ui.main_window.QMessageBox.question",
+        lambda *args, **kwargs: QMessageBox.StandardButton.Yes,
+    )
+
+
 def _write_xyz(path: Path, lines: list[str]) -> Path:
     path.write_text("\n".join(lines) + "\n", encoding="utf-8")
     return path
+
+
+def _pdb_atom_line(
+    atom_id: int,
+    atom_name: str,
+    residue_name: str,
+    residue_number: int,
+    x_coord: float,
+    y_coord: float,
+    z_coord: float,
+    element: str,
+) -> str:
+    return (
+        f"ATOM  {atom_id:5d} {atom_name:<4} {residue_name:>3}  "
+        f"{residue_number:4d}    "
+        f"{x_coord:8.3f}{y_coord:8.3f}{z_coord:8.3f}"
+        f"  1.00  0.00          {element:>2}\n"
+    )
+
+
+def _write_water_debye_waller_frame(
+    path: Path,
+    *,
+    mol1_oxygen_x: float,
+    mol1_hydrogen_x: float,
+    mol2_oxygen_x: float,
+    mol2_hydrogen_x: float,
+) -> None:
+    path.write_text(
+        "".join(
+            [
+                _pdb_atom_line(
+                    1,
+                    "O",
+                    "HOH",
+                    1,
+                    mol1_oxygen_x,
+                    0.0,
+                    0.0,
+                    "O",
+                ),
+                _pdb_atom_line(
+                    2,
+                    "H1",
+                    "HOH",
+                    1,
+                    mol1_hydrogen_x,
+                    0.0,
+                    0.0,
+                    "H",
+                ),
+                _pdb_atom_line(
+                    3,
+                    "O",
+                    "HOH",
+                    2,
+                    mol2_oxygen_x,
+                    0.0,
+                    0.0,
+                    "O",
+                ),
+                _pdb_atom_line(
+                    4,
+                    "H1",
+                    "HOH",
+                    2,
+                    mol2_hydrogen_x,
+                    0.0,
+                    0.0,
+                    "H",
+                ),
+                "END\n",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_pb_o_pdb_frame(
+    path: Path,
+    *,
+    pb_x: float,
+    o_x: float,
+) -> None:
+    path.write_text(
+        "".join(
+            [
+                _pdb_atom_line(1, "PB", "CLS", 1, pb_x, 0.0, 0.0, "Pb"),
+                _pdb_atom_line(2, "O1", "CLS", 1, o_x, 0.0, 0.0, "O"),
+                "END\n",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def _write_project_debye_waller_analysis(
+    project_dir: Path,
+    tmp_path: Path,
+) -> Path:
+    from saxshell.saxs.debye_waller.workflow import (
+        DebyeWallerWorkflow,
+        save_debye_waller_analysis_to_project,
+    )
+
+    clusters_dir = tmp_path / "project_dw_clusters"
+    structure_dir = clusters_dir / "H2O2"
+    structure_dir.mkdir(parents=True)
+    _write_water_debye_waller_frame(
+        structure_dir / "water_frame_0001.pdb",
+        mol1_oxygen_x=0.0,
+        mol1_hydrogen_x=1.00,
+        mol2_oxygen_x=5.0,
+        mol2_hydrogen_x=6.00,
+    )
+    _write_water_debye_waller_frame(
+        structure_dir / "water_frame_0002.pdb",
+        mol1_oxygen_x=0.0,
+        mol1_hydrogen_x=1.10,
+        mol2_oxygen_x=5.2,
+        mol2_hydrogen_x=6.35,
+    )
+    _write_water_debye_waller_frame(
+        structure_dir / "water_frame_0004.pdb",
+        mol1_oxygen_x=0.0,
+        mol1_hydrogen_x=0.95,
+        mol2_oxygen_x=4.9,
+        mol2_hydrogen_x=6.05,
+    )
+    _write_water_debye_waller_frame(
+        structure_dir / "water_frame_0005.pdb",
+        mol1_oxygen_x=0.0,
+        mol1_hydrogen_x=1.05,
+        mol2_oxygen_x=5.1,
+        mol2_hydrogen_x=6.30,
+    )
+    result = DebyeWallerWorkflow(
+        clusters_dir,
+        project_dir=project_dir,
+        output_dir=tmp_path / "project_dw_out",
+        output_basename="electron_density_smearing",
+    ).run()
+    saved_result = save_debye_waller_analysis_to_project(result, project_dir)
+    assert saved_result.artifacts is not None
+    return saved_result.artifacts.summary_json_path.resolve()
 
 
 def _mesh_settings_for_structure(
@@ -65,6 +234,108 @@ def _mesh_settings_for_structure(
     return ElectronDensityMeshSettings(**payload)
 
 
+def _baseline_shell_electron_counts(
+    structure,
+    mesh_settings: ElectronDensityMeshSettings,
+) -> np.ndarray:
+    mesh_geometry = density_workflow.build_electron_density_mesh(
+        structure,
+        mesh_settings,
+    )
+    radial_edges = np.asarray(mesh_geometry.radial_edges, dtype=float)
+    shell_count = int(max(len(radial_edges) - 1, 0))
+    if shell_count <= 0:
+        return np.asarray([], dtype=float)
+
+    radial_distances = np.linalg.norm(
+        np.asarray(structure.centered_coordinates, dtype=float),
+        axis=1,
+    )
+    in_domain_mask = radial_distances <= (
+        float(mesh_geometry.domain_max_radius) + 1.0e-12
+    )
+    radial_indices = (
+        np.searchsorted(
+            radial_edges,
+            radial_distances[in_domain_mask],
+            side="right",
+        )
+        - 1
+    )
+    radial_indices = np.clip(radial_indices, 0, shell_count - 1)
+    atomic_numbers = np.asarray(structure.atomic_numbers, dtype=float)[
+        in_domain_mask
+    ]
+    return np.bincount(
+        radial_indices,
+        weights=atomic_numbers,
+        minlength=shell_count,
+    ).astype(float, copy=False)
+
+
+def _profile_result_with_shell_counts(
+    result,
+    shell_counts: np.ndarray,
+):
+    shell_count_array = np.asarray(shell_counts, dtype=float)
+    density_profile = np.divide(
+        shell_count_array,
+        np.asarray(result.shell_volumes, dtype=float),
+        out=np.zeros_like(shell_count_array, dtype=float),
+        where=np.asarray(result.shell_volumes, dtype=float) > 0.0,
+    )
+    zeros = np.zeros_like(density_profile, dtype=float)
+    baseline_result = replace(
+        result,
+        member_orientation_average_densities=(
+            np.asarray(density_profile, dtype=float).copy(),
+        ),
+        orientation_average_density=np.asarray(density_profile, dtype=float),
+        orientation_density_variance=zeros.copy(),
+        orientation_density_stddev=zeros.copy(),
+        smeared_orientation_average_density=np.asarray(
+            density_profile,
+            dtype=float,
+        ),
+        smeared_orientation_density_variance=zeros.copy(),
+        smeared_orientation_density_stddev=zeros.copy(),
+        shell_volume_average_density=np.asarray(density_profile, dtype=float),
+        shell_electron_counts=shell_count_array,
+    )
+    return apply_smearing_to_profile_result(
+        baseline_result,
+        result.smearing_settings,
+    )
+
+
+def _assert_shell_electron_total(
+    result,
+    expected_total: float,
+) -> None:
+    assert float(np.sum(result.shell_electron_counts)) == pytest.approx(
+        float(expected_total)
+    )
+
+
+def _assert_structure_shell_electron_total(result, structure) -> None:
+    _assert_shell_electron_total(
+        result,
+        float(np.sum(structure.atomic_numbers)),
+    )
+
+
+def _assert_density_profile_electron_total(
+    result,
+    expected_total: float,
+) -> None:
+    assert float(
+        np.sum(
+            np.asarray(result.orientation_average_density, dtype=float)
+            * np.asarray(result.shell_volumes, dtype=float)
+        )
+    ) == pytest.approx(float(expected_total))
+
+
 def _wait_for(condition, qapp, *, timeout_s: float = 10.0) -> None:
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
@@ -73,6 +344,125 @@ def _wait_for(condition, qapp, *, timeout_s: float = 10.0) -> None:
             return
         time.sleep(0.01)
     raise AssertionError("Timed out waiting for condition.")
+
+
+def _pane_snap_resize_result(
+    splitter,
+    pane_snap_filter,
+    *,
+    target_index: int,
+    desired_width: int | None = None,
+    other_width: int = 220,
+) -> tuple[list[int], list[int]]:
+    pane_widget = splitter.widget(target_index)
+    assert pane_widget is not None
+    click_widget = pane_widget
+    if isinstance(pane_widget, QScrollArea):
+        click_widget = pane_widget.viewport()
+    current_sizes = splitter.sizes()
+    current_total = sum(size for size in current_sizes if size > 0)
+    assert current_total > 0
+    resolved_width = (
+        max(720, int(current_total * 0.7))
+        if desired_width is None
+        else int(desired_width)
+    )
+    if target_index == 0:
+        splitter.setSizes([250, max(current_total - 250, 1)])
+    else:
+        splitter.setSizes([max(current_total - 250, 1), 250])
+    QApplication.processEvents()
+    before_sizes = splitter.sizes()
+
+    pane_snap_filter._preferred_width = lambda widget: (
+        resolved_width
+        if widget is splitter.widget(target_index)
+        else int(other_width)
+    )
+    QTest.mouseClick(
+        click_widget,
+        Qt.MouseButton.LeftButton,
+        Qt.KeyboardModifier.NoModifier,
+        click_widget.rect().center(),
+    )
+    QApplication.processEvents()
+    return before_sizes, splitter.sizes()
+
+
+def _write_cluster_folder_input(base_dir: Path) -> Path:
+    first_dir = base_dir / "PbI2"
+    second_dir = base_dir / "PbI3"
+    first_dir.mkdir(parents=True)
+    second_dir.mkdir(parents=True)
+    _write_xyz(
+        first_dir / "frame_0001_AAA.xyz",
+        [
+            "3",
+            "PbI2 frame 1",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+    )
+    _write_xyz(
+        second_dir / "frame_0001_AAA.xyz",
+        [
+            "4",
+            "PbI3 frame 1",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+            "I 0.0 0.0 2.8",
+        ],
+    )
+    return base_dir
+
+
+def _open_ready_cluster_folder_window(
+    qapp,
+    tmp_path: Path,
+    *,
+    folder_name: str,
+) -> ElectronDensityMappingMainWindow:
+    window = ElectronDensityMappingMainWindow(
+        initial_input_path=_write_cluster_folder_input(tmp_path / folder_name)
+    )
+    _wait_for(
+        lambda: window.cluster_group_table.rowCount() == 2,
+        qapp,
+    )
+    window.run_button.click()
+    _wait_for(
+        lambda: all(
+            state.profile_result is not None
+            for state in window._cluster_group_states
+        )
+        and window._calculation_thread is None,
+        qapp,
+    )
+    return window
+
+
+def _assert_batch_progress_dialog_visible(
+    window: ElectronDensityMappingMainWindow,
+    *,
+    title: str,
+    total: int,
+):
+    dialog = window._batch_operation_progress_dialog
+    assert dialog is not None
+    assert dialog.isVisible()
+    assert dialog.windowTitle() == title
+    assert dialog.progress_bar.maximum() == total
+    return dialog
+
+
+def _table_column_index(table, header_text: str) -> int:
+    for column_index in range(table.columnCount()):
+        header_item = table.horizontalHeaderItem(column_index)
+        if header_item is not None and header_item.text() == header_text:
+            return int(column_index)
+    raise AssertionError(f"Could not find table column {header_text!r}.")
 
 
 def test_inspect_structure_input_handles_single_files_and_folders(tmp_path):
@@ -121,7 +511,11 @@ def test_load_electron_density_structure_uses_mass_weighted_center_of_mass(
         ],
     )
 
-    structure = load_electron_density_structure(structure_path)
+    structure = load_electron_density_structure(
+        structure_path,
+        center_mode="reference_element",
+        reference_element="O",
+    )
     expected_x = (
         float(xraydb.atomic_mass("Pb")) * 2.0
         + float(xraydb.atomic_mass("H")) * 0.0
@@ -129,8 +523,9 @@ def test_load_electron_density_structure_uses_mass_weighted_center_of_mass(
 
     assert structure.center_of_mass[0] == pytest.approx(expected_x)
     assert structure.center_of_mass[0] != pytest.approx(1.0)
-    assert np.allclose(structure.active_center, structure.center_of_mass)
-    assert structure.center_mode == "center_of_mass"
+    assert structure.reference_element == "Pb"
+    assert np.allclose(structure.active_center, [2.0, 0.0, 0.0])
+    assert structure.center_mode == "reference_element"
     assert structure.rmax > 0.0
     assert structure.bonds
 
@@ -150,25 +545,34 @@ def test_load_electron_density_structure_tracks_reference_element_centers(
         ],
     )
 
-    structure = load_electron_density_structure(structure_path)
+    structure = load_electron_density_structure(
+        structure_path,
+        center_mode="reference_element",
+        reference_element="O",
+    )
     reference_centered = load_electron_density_structure(
         structure_path,
         center_mode="reference_element",
     )
 
-    assert structure.reference_element == "Pb"
+    assert structure.reference_element == "O"
     assert np.allclose(structure.geometric_center, [0.5, 0.5, 0.5])
     assert np.allclose(
         structure.reference_element_geometric_center,
-        [1.0, 0.0, 0.0],
+        [0.0, 0.0, 2.0],
     )
     assert structure.reference_element_offset_from_geometric_center == (
-        pytest.approx(np.sqrt(0.75))
+        pytest.approx(np.sqrt(2.75))
     )
+    assert np.allclose(
+        structure.active_center,
+        structure.reference_element_geometric_center,
+    )
+    assert reference_centered.reference_element == "Pb"
     assert reference_centered.center_mode == "reference_element"
     assert np.allclose(
         reference_centered.active_center,
-        structure.reference_element_geometric_center,
+        [1.0, 0.0, 0.0],
     )
 
 
@@ -193,9 +597,7 @@ def test_compute_electron_density_profile_tracks_shell_electrons(tmp_path):
         ),
     )
 
-    assert float(np.sum(result.shell_electron_counts)) == pytest.approx(
-        float(np.sum(structure.atomic_numbers))
-    )
+    _assert_structure_shell_electron_total(result, structure)
     assert float(np.sum(result.shell_volumes)) == pytest.approx(
         4.0 / 3.0 * np.pi * (result.mesh_geometry.domain_max_radius**3),
     )
@@ -255,19 +657,467 @@ def test_centered_atom_does_not_create_angular_averaging_singularity(tmp_path):
             rmax=0.4,
         ),
     )
-    expected_first_shell_density = float(
+    point_deposit_first_shell_density = float(
         structure.atomic_numbers[0] / result.shell_volumes[0]
     )
 
+    _assert_structure_shell_electron_total(result, structure)
+    _assert_density_profile_electron_total(
+        result,
+        float(structure.atomic_numbers[0]),
+    )
     assert result.shell_electron_counts[0] == pytest.approx(
         float(structure.atomic_numbers[0])
     )
-    assert result.orientation_average_density[0] == pytest.approx(
-        expected_first_shell_density
+    assert result.shell_volume_average_density[0] == pytest.approx(
+        point_deposit_first_shell_density
     )
-    assert result.orientation_average_density[0] == pytest.approx(
+    assert result.orientation_average_density[0] < (
         result.shell_volume_average_density[0]
     )
+    assert (
+        result.orientation_average_density[0]
+        < point_deposit_first_shell_density
+    )
+    assert np.count_nonzero(result.orientation_average_density > 0.0) > 1
+
+
+def test_single_heavy_atom_is_tagged_into_only_one_shell(tmp_path):
+    structure_path = _write_xyz(
+        tmp_path / "pbh3_cluster.xyz",
+        [
+            "4",
+            "PbH3 cluster",
+            "Pb 0.0 0.0 0.0",
+            "H 3.0 0.0 0.0",
+            "H 0.0 3.0 0.0",
+            "H 0.0 0.0 3.0",
+        ],
+    )
+    structure = load_electron_density_structure(
+        structure_path,
+        center_mode="reference_element",
+        reference_element="Pb",
+    )
+    mesh_settings = _mesh_settings_for_structure(
+        structure,
+        rstep=0.25,
+        theta_divisions=48,
+        phi_divisions=24,
+        rmax=3.5,
+    )
+    result = compute_electron_density_profile(
+        structure,
+        mesh_settings,
+    )
+    baseline_counts = _baseline_shell_electron_counts(
+        structure,
+        mesh_settings,
+    )
+    lead_electrons = float(xraydb.atomic_number("Pb"))
+
+    assert np.allclose(result.shell_electron_counts, baseline_counts)
+    assert result.shell_electron_counts[0] == pytest.approx(lead_electrons)
+    assert (
+        np.count_nonzero(result.shell_electron_counts >= lead_electrons) == 1
+    )
+    _assert_structure_shell_electron_total(result, structure)
+    _assert_density_profile_electron_total(
+        result,
+        float(np.sum(structure.atomic_numbers)),
+    )
+
+
+def test_centered_heavy_atom_density_is_spread_across_multiple_shells(
+    tmp_path,
+):
+    structure_path = _write_xyz(
+        tmp_path / "single_pb.xyz",
+        [
+            "1",
+            "single lead",
+            "Pb 0.0 0.0 0.0",
+        ],
+    )
+    structure = load_electron_density_structure(
+        structure_path,
+        center_mode="reference_element",
+        reference_element="Pb",
+    )
+    result = compute_electron_density_profile(
+        structure,
+        _mesh_settings_for_structure(
+            structure,
+            rstep=0.1,
+            theta_divisions=48,
+            phi_divisions=24,
+            rmax=2.0,
+        ),
+    )
+    point_deposit_first_shell_density = float(
+        structure.atomic_numbers[0] / result.shell_volumes[0]
+    )
+
+    _assert_structure_shell_electron_total(result, structure)
+    _assert_density_profile_electron_total(
+        result,
+        float(structure.atomic_numbers[0]),
+    )
+    assert result.shell_electron_counts[0] == pytest.approx(
+        float(structure.atomic_numbers[0])
+    )
+    assert result.orientation_average_density[0] < (
+        point_deposit_first_shell_density * 0.1
+    )
+    assert np.count_nonzero(result.orientation_average_density > 0.0) > 5
+
+
+def test_small_origin_centered_cluster_assigns_each_atom_to_one_shell(
+    tmp_path,
+):
+    structure_path = _write_xyz(
+        tmp_path / "small_origin_cluster.xyz",
+        [
+            "4",
+            "small origin-centered cluster",
+            "O 0.0 0.0 0.0",
+            "H 0.05 0.0 0.0",
+            "C 0.26 0.0 0.0",
+            "N 0.51 0.0 0.0",
+        ],
+    )
+    structure = load_electron_density_structure(
+        structure_path,
+        center_mode="reference_element",
+        reference_element="O",
+    )
+    result = compute_electron_density_profile(
+        structure,
+        _mesh_settings_for_structure(
+            structure,
+            rstep=0.25,
+            theta_divisions=24,
+            phi_divisions=18,
+            rmax=0.8,
+        ),
+    )
+
+    _assert_structure_shell_electron_total(result, structure)
+    _assert_density_profile_electron_total(
+        result,
+        float(np.sum(structure.atomic_numbers)),
+    )
+    assert np.allclose(result.shell_electron_counts[:4], [9.0, 6.0, 7.0, 0.0])
+    assert np.count_nonzero(result.shell_electron_counts) == 3
+
+
+def test_electron_density_profile_is_invariant_to_angular_mesh_resolution(
+    tmp_path,
+):
+    structure_path = _write_xyz(
+        tmp_path / "angular_mesh_invariance.xyz",
+        [
+            "4",
+            "angular mesh invariance",
+            "O 0.0 0.0 0.0",
+            "H 0.96 0.0 0.0",
+            "H -0.24 0.93 0.0",
+            "Pb 0.0 0.0 2.4",
+        ],
+    )
+    structure = load_electron_density_structure(structure_path)
+    coarse = compute_electron_density_profile(
+        structure,
+        _mesh_settings_for_structure(
+            structure,
+            rstep=0.2,
+            theta_divisions=8,
+            phi_divisions=6,
+            rmax=max(float(structure.rmax), 3.0),
+        ),
+    )
+    fine = compute_electron_density_profile(
+        structure,
+        _mesh_settings_for_structure(
+            structure,
+            rstep=0.2,
+            theta_divisions=96,
+            phi_divisions=72,
+            rmax=max(float(structure.rmax), 3.0),
+        ),
+    )
+
+    assert np.allclose(
+        coarse.shell_electron_counts,
+        fine.shell_electron_counts,
+    )
+    assert np.allclose(
+        coarse.shell_volumes,
+        fine.shell_volumes,
+    )
+    assert np.allclose(
+        coarse.orientation_average_density,
+        fine.orientation_average_density,
+    )
+    assert np.allclose(
+        coarse.shell_volume_average_density,
+        fine.shell_volume_average_density,
+    )
+    _assert_density_profile_electron_total(
+        coarse,
+        float(np.sum(structure.atomic_numbers)),
+    )
+    _assert_density_profile_electron_total(
+        fine,
+        float(np.sum(structure.atomic_numbers)),
+    )
+
+
+def test_single_heavy_atom_finite_radius_density_changes_downstream_trace(
+    tmp_path,
+):
+    structure_path = _write_xyz(
+        tmp_path / "pbh3_trace.xyz",
+        [
+            "4",
+            "PbH3 trace",
+            "Pb 0.0 0.0 0.0",
+            "H 3.0 0.0 0.0",
+            "H 0.0 3.0 0.0",
+            "H 0.0 0.0 3.0",
+        ],
+    )
+    structure = load_electron_density_structure(
+        structure_path,
+        center_mode="reference_element",
+        reference_element="Pb",
+    )
+    mesh_settings = _mesh_settings_for_structure(
+        structure,
+        rstep=0.2,
+        theta_divisions=36,
+        phi_divisions=18,
+        rmax=3.5,
+    )
+    result = compute_electron_density_profile(
+        structure,
+        mesh_settings,
+        smearing_settings=ElectronDensitySmearingSettings(
+            debye_waller_factor=0.006
+        ),
+    )
+    baseline_result = _profile_result_with_shell_counts(
+        result,
+        _baseline_shell_electron_counts(structure, mesh_settings),
+    )
+    settings = ElectronDensityFourierTransformSettings(
+        r_min=float(result.radial_centers[0]),
+        r_max=float(result.radial_centers[-1]),
+        q_min=0.05,
+        q_max=1.0,
+        q_step=0.05,
+        resampling_points=128,
+        use_solvent_subtracted_profile=False,
+    )
+
+    tagged_transform = compute_electron_density_scattering_profile(
+        result,
+        settings,
+    )
+    baseline_transform = compute_electron_density_scattering_profile(
+        baseline_result,
+        settings,
+    )
+
+    assert np.all(np.isfinite(tagged_transform.intensity))
+    assert np.all(tagged_transform.intensity >= 0.0)
+    assert np.allclose(tagged_transform.q_values, baseline_transform.q_values)
+    assert not np.allclose(
+        tagged_transform.intensity,
+        baseline_transform.intensity,
+    )
+    assert tagged_transform.intensity[0] < baseline_transform.intensity[0]
+
+
+def test_single_atom_debye_scattering_profile_for_input_averages_iq(
+    tmp_path,
+):
+    folder = tmp_path / "single_atom_cluster"
+    folder.mkdir()
+    _write_xyz(
+        folder / "frame_0001.xyz",
+        [
+            "1",
+            "single iodine 1",
+            "I 0.0 0.0 0.0",
+        ],
+    )
+    _write_xyz(
+        folder / "frame_0002.xyz",
+        [
+            "1",
+            "single iodine 2",
+            "I 2.5 -1.0 0.2",
+        ],
+    )
+
+    result = compute_single_atom_debye_scattering_profile_for_input(
+        inspect_structure_input(folder),
+        ElectronDensityFourierTransformSettings(
+            r_min=0.0,
+            r_max=1.0,
+            q_min=0.1,
+            q_max=0.5,
+            q_step=0.2,
+        ),
+    )
+
+    expected_q = np.asarray([0.1, 0.3, 0.5], dtype=float)
+    expected_intensity = np.square(atomic_form_factor("I", expected_q))
+
+    assert result.preview.source_mode == "single_atom_debye"
+    assert (
+        result.preview.source_profile_label == "Single-atom Debye scattering"
+    )
+    assert np.allclose(result.q_values, expected_q)
+    assert np.allclose(result.intensity, expected_intensity)
+    assert np.allclose(
+        result.scattering_amplitude,
+        np.sqrt(expected_intensity),
+    )
+
+
+def test_single_atom_debye_scattering_profile_for_input_computes_each_element_once(
+    tmp_path,
+    monkeypatch,
+):
+    folder = tmp_path / "single_atom_cluster"
+    folder.mkdir()
+    _write_xyz(
+        folder / "frame_0001.xyz",
+        [
+            "1",
+            "single iodine 1",
+            "I 0.0 0.0 0.0",
+        ],
+    )
+    _write_xyz(
+        folder / "frame_0002.xyz",
+        [
+            "1",
+            "single iodine 2",
+            "I 2.5 -1.0 0.2",
+        ],
+    )
+    _write_xyz(
+        folder / "frame_0003.xyz",
+        [
+            "1",
+            "single iodine 3",
+            "I -0.5 1.0 4.0",
+        ],
+    )
+
+    real_atomic_form_factor = atomic_form_factor
+    call_counter = {"count": 0}
+
+    def fake_atomic_form_factor(element, q_values):
+        call_counter["count"] += 1
+        return real_atomic_form_factor(element, q_values)
+
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.workflow.atomic_form_factor",
+        fake_atomic_form_factor,
+    )
+
+    result = compute_single_atom_debye_scattering_profile_for_input(
+        inspect_structure_input(folder),
+        ElectronDensityFourierTransformSettings(
+            r_min=0.0,
+            r_max=1.0,
+            q_min=0.1,
+            q_max=0.5,
+            q_step=0.2,
+        ),
+    )
+
+    assert call_counter["count"] == 1
+    np.testing.assert_allclose(
+        result.intensity,
+        np.square(real_atomic_form_factor("I", result.q_values)),
+    )
+
+
+def test_average_debye_scattering_profile_for_input_reuses_equivalent_single_atom_traces(
+    tmp_path,
+    monkeypatch,
+):
+    folder = tmp_path / "single_atom_cluster"
+    folder.mkdir()
+    _write_xyz(
+        folder / "frame_0001.xyz",
+        [
+            "1",
+            "single iodine 1",
+            "I 0.0 0.0 0.0",
+        ],
+    )
+    _write_xyz(
+        folder / "frame_0002.xyz",
+        [
+            "1",
+            "single iodine 2",
+            "I 2.5 -1.0 0.2",
+        ],
+    )
+    _write_xyz(
+        folder / "frame_0003.xyz",
+        [
+            "1",
+            "single iodine 3",
+            "I -0.5 1.0 4.0",
+        ],
+    )
+
+    real_compute_debye_intensity = density_workflow.compute_debye_intensity
+    call_counter = {"count": 0}
+
+    def fake_compute_debye_intensity(*args, **kwargs):
+        call_counter["count"] += 1
+        return real_compute_debye_intensity(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.workflow.compute_debye_intensity",
+        fake_compute_debye_intensity,
+    )
+
+    settings = ElectronDensityFourierTransformSettings(
+        r_min=0.0,
+        r_max=1.0,
+        q_min=0.1,
+        q_max=0.5,
+        q_step=0.2,
+    )
+    result = compute_average_debye_scattering_profile_for_input(
+        inspect_structure_input(folder),
+        settings,
+    )
+
+    expected_q = np.asarray([0.1, 0.3, 0.5], dtype=float)
+    expected_intensity = np.square(atomic_form_factor("I", expected_q))
+
+    assert call_counter["count"] == 1
+    assert result.source_structure_count == 3
+    assert result.unique_elements == ("I",)
+    assert any(
+        "single-atom type" in note.lower()
+        or "reused across the average" in note.lower()
+        for note in result.notes
+    )
+    np.testing.assert_allclose(result.q_values, expected_q)
+    np.testing.assert_allclose(result.mean_intensity, expected_intensity)
+    np.testing.assert_allclose(result.std_intensity, np.zeros_like(expected_q))
+    np.testing.assert_allclose(result.se_intensity, np.zeros_like(expected_q))
 
 
 def test_compute_electron_density_profile_for_folder_averages_and_tracks_variance(
@@ -299,11 +1149,17 @@ def test_compute_electron_density_profile_for_folder_averages_and_tracks_varianc
     reference_structure = load_electron_density_structure(
         inspection.reference_file
     )
+    first_structure = load_electron_density_structure(first_path)
+    second_structure = load_electron_density_structure(second_path)
     mesh_settings = _mesh_settings_for_structure(
         reference_structure,
         rstep=0.1,
         theta_divisions=24,
         phi_divisions=18,
+        rmax=max(
+            float(first_structure.rmax),
+            float(second_structure.rmax),
+        ),
     )
     progress_events: list[tuple[int, int, str]] = []
 
@@ -318,14 +1174,14 @@ def test_compute_electron_density_profile_for_folder_averages_and_tracks_varianc
         ),
     )
     first = compute_electron_density_profile(
-        load_electron_density_structure(first_path),
+        first_structure,
         mesh_settings,
         smearing_settings=ElectronDensitySmearingSettings(
             debye_waller_factor=0.006
         ),
     )
     second = compute_electron_density_profile(
-        load_electron_density_structure(second_path),
+        second_structure,
         mesh_settings,
         smearing_settings=ElectronDensitySmearingSettings(
             debye_waller_factor=0.006
@@ -360,8 +1216,157 @@ def test_compute_electron_density_profile_for_folder_averages_and_tracks_varianc
         averaged.smeared_orientation_density_variance,
         np.var(smeared_stack, axis=0),
     )
+    _assert_structure_shell_electron_total(first, first_structure)
+    _assert_structure_shell_electron_total(second, second_structure)
+    _assert_density_profile_electron_total(
+        first,
+        float(np.sum(first_structure.atomic_numbers)),
+    )
+    _assert_density_profile_electron_total(
+        second,
+        float(np.sum(second_structure.atomic_numbers)),
+    )
+    _assert_shell_electron_total(
+        averaged,
+        np.mean(
+            [
+                float(np.sum(first_structure.atomic_numbers)),
+                float(np.sum(second_structure.atomic_numbers)),
+            ]
+        ),
+    )
+    _assert_density_profile_electron_total(
+        averaged,
+        np.mean(
+            [
+                float(np.sum(first_structure.atomic_numbers)),
+                float(np.sum(second_structure.atomic_numbers)),
+            ]
+        ),
+    )
     assert progress_events
     assert "Averaging electron density" in progress_events[-2][2]
+
+
+def test_compute_electron_density_profile_for_input_parallelizes_batches(
+    tmp_path,
+    monkeypatch,
+):
+    folder = tmp_path / "parallel_ensemble"
+    folder.mkdir()
+    for index, oxygen_x in enumerate((0.0, 0.2, 0.4, 0.6), start=1):
+        _write_xyz(
+            folder / f"frame_{index:04d}.xyz",
+            [
+                "3",
+                f"frame {index}",
+                f"O {oxygen_x:.3f} 0.0 0.0",
+                f"H {oxygen_x + 0.96:.3f} 0.0 0.0",
+                f"H {oxygen_x - 0.24:.3f} 0.93 0.0",
+            ],
+        )
+    inspection = inspect_structure_input(folder)
+    reference_structure = load_electron_density_structure(
+        inspection.reference_file
+    )
+    mesh_settings = _mesh_settings_for_structure(
+        reference_structure,
+        rstep=0.15,
+        theta_divisions=24,
+        phi_divisions=18,
+    )
+    real_compute = density_workflow.compute_electron_density_profile
+    thread_names: list[str] = []
+
+    def _recording_compute(*args, **kwargs):
+        thread_names.append(threading.current_thread().name)
+        time.sleep(0.02)
+        return real_compute(*args, **kwargs)
+
+    monkeypatch.setattr(
+        density_workflow,
+        "_resolve_electron_density_worker_count",
+        lambda structure_count: 2,
+    )
+    monkeypatch.setattr(
+        density_workflow,
+        "compute_electron_density_profile",
+        _recording_compute,
+    )
+
+    result = compute_electron_density_profile_for_input(
+        inspection,
+        mesh_settings,
+    )
+
+    assert result.source_structure_count == 4
+    assert any(name.startswith("electron-density") for name in thread_names)
+
+
+def test_compute_electron_density_profile_for_input_reuses_reference_structure(
+    tmp_path,
+    monkeypatch,
+):
+    folder = tmp_path / "reused_reference"
+    folder.mkdir()
+    _write_xyz(
+        folder / "frame_0001.xyz",
+        [
+            "3",
+            "frame 1",
+            "O 0.0 0.0 0.0",
+            "H 0.96 0.0 0.0",
+            "H -0.24 0.93 0.0",
+        ],
+    )
+    _write_xyz(
+        folder / "frame_0002.xyz",
+        [
+            "3",
+            "frame 2",
+            "O 0.1 0.0 0.0",
+            "H 1.06 0.0 0.0",
+            "H -0.14 0.93 0.0",
+        ],
+    )
+    inspection = inspect_structure_input(folder)
+    reference_structure = load_electron_density_structure(
+        inspection.reference_file
+    )
+    mesh_settings = _mesh_settings_for_structure(reference_structure)
+    real_loader = density_workflow.load_electron_density_structure
+
+    def _guarded_load(file_path, *args, **kwargs):
+        if Path(file_path).expanduser().resolve() == inspection.reference_file:
+            raise AssertionError(
+                "The preloaded reference structure was reloaded."
+            )
+        return real_loader(file_path, *args, **kwargs)
+
+    monkeypatch.setattr(
+        density_workflow,
+        "load_electron_density_structure",
+        _guarded_load,
+    )
+
+    result = compute_electron_density_profile_for_input(
+        inspection,
+        mesh_settings,
+        reference_structure=reference_structure,
+    )
+
+    assert result.source_structure_count == 2
+    assert result.structure.file_path == inspection.reference_file
+
+
+def test_resolve_electron_density_worker_count_is_conservative(monkeypatch):
+    monkeypatch.setattr(density_workflow.os, "cpu_count", lambda: 12)
+    assert density_workflow._resolve_electron_density_worker_count(1) == 1
+    assert density_workflow._resolve_electron_density_worker_count(3) == 3
+    assert density_workflow._resolve_electron_density_worker_count(20) == 4
+
+    monkeypatch.setattr(density_workflow.os, "cpu_count", lambda: 2)
+    assert density_workflow._resolve_electron_density_worker_count(8) == 1
 
 
 def test_compute_electron_density_profile_for_input_uses_reference_element_mode(
@@ -414,6 +1419,331 @@ def test_compute_electron_density_profile_for_input_uses_reference_element_mode(
     assert second_path in result.source_files
 
 
+def test_compute_electron_density_profile_for_input_locks_contiguous_frame_sets(
+    tmp_path,
+):
+    folder = tmp_path / "contiguous_frames"
+    folder.mkdir()
+    _write_xyz(
+        folder / "frame_0001_AAA.xyz",
+        [
+            "2",
+            "frame 1",
+            "Pb 0.0 0.0 0.0",
+            "O 2.0 0.0 0.0",
+        ],
+    )
+    _write_xyz(
+        folder / "frame_0002_AAA.xyz",
+        [
+            "2",
+            "frame 2",
+            "Pb 10.0 0.0 0.0",
+            "O 13.0 0.0 0.0",
+        ],
+    )
+    _write_xyz(
+        folder / "frame_0004_AAA.xyz",
+        [
+            "2",
+            "frame 4",
+            "Pb 20.0 0.0 0.0",
+            "O 22.0 0.0 0.0",
+        ],
+    )
+    _write_xyz(
+        folder / "frame_0005_AAA.xyz",
+        [
+            "2",
+            "frame 5",
+            "Pb 30.0 0.0 0.0",
+            "O 34.0 0.0 0.0",
+        ],
+    )
+
+    inspection = inspect_structure_input(folder)
+    reference_structure = load_electron_density_structure(
+        inspection.reference_file
+    )
+    mesh_settings = _mesh_settings_for_structure(
+        reference_structure,
+        rmax=5.0,
+    )
+
+    standard = compute_electron_density_profile_for_input(
+        inspection,
+        mesh_settings,
+        use_contiguous_frame_mode=False,
+    )
+    locked = compute_electron_density_profile_for_input(
+        inspection,
+        mesh_settings,
+        use_contiguous_frame_mode=True,
+    )
+
+    assert locked.contiguous_frame_mode_requested
+    assert locked.contiguous_frame_mode_applied
+    assert locked.averaging_mode == "contiguous_frame_sets"
+    assert len(locked.contiguous_frame_sets) == 2
+    assert locked.contiguous_frame_sets[0].frame_ids == (1, 2)
+    assert locked.contiguous_frame_sets[1].frame_ids == (4, 5)
+    assert locked.contiguous_frame_sets[0].frame_labels == ("0001", "0002")
+
+    standard_offsets = [
+        float(entry.active_center[0] - pb_x)
+        for entry, pb_x in zip(
+            standard.member_summaries,
+            (0.0, 10.0, 20.0, 30.0),
+        )
+    ]
+    locked_offsets = [
+        float(entry.active_center[0] - pb_x)
+        for entry, pb_x in zip(
+            locked.member_summaries,
+            (0.0, 10.0, 20.0, 30.0),
+        )
+    ]
+
+    assert standard_offsets[0] != pytest.approx(standard_offsets[1])
+    assert standard_offsets[2] != pytest.approx(standard_offsets[3])
+    assert locked_offsets[0] == pytest.approx(locked_offsets[1])
+    assert locked_offsets[2] == pytest.approx(locked_offsets[3])
+    assert locked_offsets[0] != pytest.approx(locked_offsets[2])
+
+
+def test_compute_electron_density_profile_for_input_falls_back_when_frame_ids_missing(
+    tmp_path,
+):
+    folder = tmp_path / "noncontiguous_names"
+    folder.mkdir()
+    _write_xyz(
+        folder / "cluster_a.xyz",
+        [
+            "2",
+            "cluster a",
+            "Pb 0.0 0.0 0.0",
+            "O 2.0 0.0 0.0",
+        ],
+    )
+    _write_xyz(
+        folder / "cluster_b.xyz",
+        [
+            "2",
+            "cluster b",
+            "Pb 0.0 0.0 0.0",
+            "O 3.0 0.0 0.0",
+        ],
+    )
+
+    inspection = inspect_structure_input(folder)
+    reference_structure = load_electron_density_structure(
+        inspection.reference_file
+    )
+    mesh_settings = _mesh_settings_for_structure(
+        reference_structure,
+        rmax=5.0,
+    )
+
+    standard = compute_electron_density_profile_for_input(
+        inspection,
+        mesh_settings,
+        use_contiguous_frame_mode=False,
+    )
+    fallback = compute_electron_density_profile_for_input(
+        inspection,
+        mesh_settings,
+        use_contiguous_frame_mode=True,
+    )
+
+    assert fallback.contiguous_frame_mode_requested
+    assert not fallback.contiguous_frame_mode_applied
+    assert fallback.contiguous_frame_sets == ()
+    assert fallback.averaging_mode == "complete_average"
+    assert any(
+        "Falling back to complete averaging" in note
+        for note in fallback.averaging_notes
+    )
+    assert np.allclose(
+        fallback.orientation_average_density,
+        standard.orientation_average_density,
+    )
+
+
+def test_compute_electron_density_profile_for_input_can_pin_geometric_tracking_for_contiguous_pdb_frames(
+    tmp_path,
+):
+    folder = tmp_path / "pdb_contiguous_tracking"
+    folder.mkdir()
+    _write_pb_o_pdb_frame(
+        folder / "frame_0001.pdb",
+        pb_x=0.0,
+        o_x=4.0,
+    )
+    _write_pb_o_pdb_frame(
+        folder / "frame_0002.pdb",
+        pb_x=0.0,
+        o_x=8.0,
+    )
+
+    inspection = inspect_structure_input(folder)
+    reference_structure = load_electron_density_structure(
+        inspection.reference_file
+    )
+    standard_mesh = _mesh_settings_for_structure(
+        reference_structure,
+        rmax=10.0,
+        pin_contiguous_geometric_tracking=False,
+    )
+    pinned_mesh = ElectronDensityMeshSettings(
+        rstep=standard_mesh.rstep,
+        theta_divisions=standard_mesh.theta_divisions,
+        phi_divisions=standard_mesh.phi_divisions,
+        rmax=standard_mesh.rmax,
+        pin_contiguous_geometric_tracking=True,
+    )
+
+    shared = compute_electron_density_profile_for_input(
+        inspection,
+        standard_mesh,
+        use_contiguous_frame_mode=True,
+    )
+    pinned = compute_electron_density_profile_for_input(
+        inspection,
+        pinned_mesh,
+        use_contiguous_frame_mode=True,
+    )
+
+    assert pinned.contiguous_frame_mode_requested
+    assert pinned.contiguous_frame_mode_applied
+    assert pinned.pinned_geometric_tracking_requested
+    assert pinned.pinned_geometric_tracking_applied
+    assert any(
+        "Pinned each contiguous PDB frame set" in note
+        for note in pinned.averaging_notes
+    )
+    assert pinned.member_summaries[0].active_center[0] == pytest.approx(
+        pinned.member_summaries[1].active_center[0]
+    )
+    assert pinned.member_summaries[0].active_center[0] == pytest.approx(
+        pinned.member_summaries[0].center_of_mass[0]
+    )
+    assert pinned.member_summaries[1].center_of_mass[0] != pytest.approx(
+        pinned.member_summaries[1].active_center[0]
+    )
+    assert shared.member_summaries[1].active_center[0] != pytest.approx(
+        pinned.member_summaries[1].active_center[0]
+    )
+
+
+def test_compute_electron_density_profile_for_input_pinned_tracking_falls_back_to_standard_contiguous_lock_for_xyz(
+    tmp_path,
+):
+    folder = tmp_path / "xyz_pinned_tracking_fallback"
+    folder.mkdir()
+    _write_xyz(
+        folder / "frame_0001.xyz",
+        [
+            "2",
+            "frame one",
+            "Pb 0.0 0.0 0.0",
+            "O 2.0 0.0 0.0",
+        ],
+    )
+    _write_xyz(
+        folder / "frame_0002.xyz",
+        [
+            "2",
+            "frame two",
+            "Pb 0.0 0.0 0.0",
+            "O 4.0 0.0 0.0",
+        ],
+    )
+
+    inspection = inspect_structure_input(folder)
+    mesh_settings = ElectronDensityMeshSettings(
+        rstep=0.1,
+        theta_divisions=120,
+        phi_divisions=60,
+        rmax=5.0,
+        pin_contiguous_geometric_tracking=True,
+    )
+    result = compute_electron_density_profile_for_input(
+        inspection,
+        mesh_settings,
+        use_contiguous_frame_mode=True,
+    )
+
+    assert result.contiguous_frame_mode_requested
+    assert result.contiguous_frame_mode_applied
+    assert result.pinned_geometric_tracking_requested
+    assert not result.pinned_geometric_tracking_applied
+    assert any(
+        "requires contiguous PDB frame sets" in note
+        for note in result.averaging_notes
+    )
+
+
+def test_compute_electron_density_profile_for_input_skips_visual_metadata_for_non_reference_structures(
+    tmp_path,
+    monkeypatch,
+):
+    folder = tmp_path / "batch_visual_metadata"
+    folder.mkdir()
+    _write_xyz(
+        folder / "frame_0001.xyz",
+        [
+            "2",
+            "frame 1",
+            "Pb 0.0 0.0 0.0",
+            "O 2.0 0.0 0.0",
+        ],
+    )
+    _write_xyz(
+        folder / "frame_0002.xyz",
+        [
+            "2",
+            "frame 2",
+            "Pb 1.0 0.0 0.0",
+            "O 3.0 0.0 0.0",
+        ],
+    )
+
+    inspection = inspect_structure_input(folder)
+    mesh_settings = ElectronDensityMeshSettings(
+        rstep=0.25,
+        theta_divisions=18,
+        phi_divisions=12,
+        rmax=5.0,
+    )
+    calls = {"bonds": 0, "comment": 0}
+
+    def _fake_detect_bonds_records(_atoms):
+        calls["bonds"] += 1
+        return ()
+
+    def _fake_read_structure_comment(_path):
+        calls["comment"] += 1
+        return ""
+
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.workflow.detect_bonds_records",
+        _fake_detect_bonds_records,
+    )
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.workflow.read_structure_comment",
+        _fake_read_structure_comment,
+    )
+
+    result = compute_electron_density_profile_for_input(
+        inspection,
+        mesh_settings,
+    )
+
+    assert result.source_structure_count == 2
+    assert calls["bonds"] == 1
+    assert calls["comment"] == 1
+
+
 def test_prepare_fourier_transform_clamps_qmax_and_computes_intensity(
     tmp_path,
 ):
@@ -460,6 +1790,54 @@ def test_prepare_fourier_transform_clamps_qmax_and_computes_intensity(
     assert np.all(transform.intensity >= 0.0)
 
 
+def test_prepare_fourier_transform_mirrors_density_profile_by_default(
+    tmp_path,
+):
+    structure_path = _write_xyz(
+        tmp_path / "fourier_mirrored.xyz",
+        [
+            "3",
+            "fourier mirrored",
+            "O 0.0 0.0 0.0",
+            "H 0.96 0.0 0.0",
+            "H -0.24 0.93 0.0",
+        ],
+    )
+    structure = load_electron_density_structure(structure_path)
+    profile = compute_electron_density_profile(
+        structure,
+        _mesh_settings_for_structure(
+            structure,
+            rstep=0.1,
+            theta_divisions=24,
+            phi_divisions=18,
+        ),
+    )
+
+    preview = prepare_electron_density_fourier_transform(
+        profile,
+        ElectronDensityFourierTransformSettings(
+            r_max=float(profile.radial_centers[-1]),
+            window_function="hanning",
+            resampling_points=65,
+            q_min=0.02,
+            q_max=1.2,
+            q_step=0.01,
+        ),
+    )
+
+    assert preview.settings.domain_mode == "mirrored"
+    assert preview.available_r_min == pytest.approx(-preview.available_r_max)
+    assert preview.source_radial_values[0] == pytest.approx(
+        -preview.source_radial_values[-1]
+    )
+    assert np.allclose(
+        preview.source_density_values,
+        preview.source_density_values[::-1],
+    )
+    assert np.allclose(preview.window_values, preview.window_values[::-1])
+
+
 def test_prepare_fourier_transform_supports_origin_and_exafs_windows(tmp_path):
     structure_path = _write_xyz(
         tmp_path / "fourier_windows.xyz",
@@ -502,8 +1880,18 @@ def test_prepare_fourier_transform_supports_origin_and_exafs_windows(tmp_path):
                 q_step=0.05,
             ),
         )
-        assert preview.available_r_min == pytest.approx(0.0)
-        assert preview.source_radial_values[0] == pytest.approx(0.0)
+        assert preview.available_r_min == pytest.approx(
+            -float(profile.radial_centers[-1])
+        )
+        assert preview.available_r_max == pytest.approx(
+            float(profile.radial_centers[-1])
+        )
+        assert preview.source_radial_values[0] == pytest.approx(
+            -float(profile.radial_centers[-1])
+        )
+        assert preview.source_radial_values[-1] == pytest.approx(
+            float(profile.radial_centers[-1])
+        )
         center_index = int(np.argmax(preview.window_values))
         assert center_index in {
             len(preview.window_values) // 2,
@@ -511,6 +1899,7 @@ def test_prepare_fourier_transform_supports_origin_and_exafs_windows(tmp_path):
         }
         assert preview.window_values[0] <= preview.window_values[center_index]
         assert preview.window_values[-1] <= preview.window_values[center_index]
+        assert np.allclose(preview.window_values, preview.window_values[::-1])
 
 
 def test_apply_smearing_to_profile_result_reuses_member_profiles_exactly(
@@ -572,6 +1961,16 @@ def test_apply_smearing_to_profile_result_reuses_member_profiles_exactly(
     assert np.allclose(
         unsmeared.smeared_orientation_density_stddev,
         result.orientation_density_stddev,
+    )
+    assert float(
+        np.sum(
+            result.smeared_orientation_average_density * result.shell_volumes
+        )
+    ) <= (
+        float(
+            np.sum(result.orientation_average_density * result.shell_volumes)
+        )
+        + 1.0e-9
     )
 
 
@@ -683,13 +2082,36 @@ def test_prepare_fourier_transform_uses_solvent_subtracted_profile_when_availabl
 
     assert preview.source_profile_label.startswith("Solvent-subtracted")
     assert contrasted.solvent_contrast is not None
-    assert preview.source_radial_values[0] == pytest.approx(0.0)
-    assert preview.source_density_values[0] == pytest.approx(
-        contrasted.solvent_contrast.solvent_subtracted_smeared_density[0]
+    expected_positive = np.concatenate(
+        (
+            [
+                float(
+                    contrasted.solvent_contrast.solvent_subtracted_smeared_density[
+                        0
+                    ]
+                )
+            ],
+            np.asarray(
+                contrasted.solvent_contrast.solvent_subtracted_smeared_density,
+                dtype=float,
+            ),
+        )
+    )
+    center_index = len(preview.source_radial_values) // 2
+    assert preview.source_radial_values[0] == pytest.approx(
+        -float(contrasted.radial_centers[-1])
+    )
+    assert preview.source_radial_values[center_index] == pytest.approx(0.0)
+    assert preview.source_density_values[center_index] == pytest.approx(
+        expected_positive[0]
     )
     assert np.allclose(
-        preview.source_density_values[1:],
-        contrasted.solvent_contrast.solvent_subtracted_smeared_density,
+        preview.source_density_values[center_index:],
+        expected_positive,
+    )
+    assert np.allclose(
+        preview.source_density_values[: center_index + 1],
+        preview.source_density_values[center_index:][::-1],
     )
 
 
@@ -724,12 +2146,27 @@ def test_write_electron_density_profile_outputs_writes_csv_and_json(tmp_path):
     assert artifacts.csv_path.is_file()
     assert artifacts.json_path.is_file()
     payload = artifacts.json_path.read_text(encoding="utf-8")
+    payload_json = json.loads(payload)
     assert "center_of_mass_a" in payload
     assert "geometric_center_a" in payload
     assert "reference_element" in payload
     assert "active_center_a" in payload
     assert "mesh_settings" in payload
     assert "smearing_settings" in payload
+    assert (
+        payload_json["density_profile_metadata"][
+            "displayed_raw_density_method"
+        ]
+        == "finite_radius_shell_overlap"
+    )
+    assert (
+        payload_json["density_profile_metadata"]["shell_electron_count_role"]
+        == "point_tag_bookkeeping"
+    )
+    assert (
+        "Fourier/scattering outputs"
+        in payload_json["density_profile_metadata"]["interpretation_note"]
+    )
 
 
 def test_main_window_updates_mesh_only_when_requested(qapp, tmp_path):
@@ -767,6 +2204,387 @@ def test_main_window_updates_mesh_only_when_requested(qapp, tmp_path):
     assert window._active_mesh_geometry.domain_max_radius == pytest.approx(
         window._active_mesh_settings.rmax
     )
+    window.close()
+
+
+def test_main_window_contiguous_notice_tracks_active_center_mode(
+    qapp,
+    tmp_path,
+):
+    del qapp
+    structure_path = _write_xyz(
+        tmp_path / "contiguous_center_notice.xyz",
+        [
+            "5",
+            "contiguous center notice",
+            "Pb 0.0 0.0 0.0",
+            "Pb 2.0 0.0 0.0",
+            "H 0.0 4.0 0.0",
+            "H 0.0 6.0 0.0",
+            "O 0.0 0.0 2.0",
+        ],
+    )
+    window = ElectronDensityMappingMainWindow(
+        initial_input_path=structure_path
+    )
+
+    assert "Current active center mode: Geometric Mass Center" in (
+        window.contiguous_frame_mode_notice.text()
+    )
+
+    window.snap_center_button.click()
+    assert (
+        "Current active center mode: Nearest atom to geometric mass center"
+        in (window.contiguous_frame_mode_notice.text())
+    )
+
+    window.snap_reference_center_button.click()
+    assert (
+        "Current active center mode: Pb reference-element geometric center"
+        in (window.contiguous_frame_mode_notice.text())
+    )
+    window.close()
+
+
+def test_main_window_pinned_geometric_tracking_requires_pdb_folder_and_geometric_mass_center(
+    qapp,
+    tmp_path,
+):
+    del qapp
+    single_structure = _write_xyz(
+        tmp_path / "single_tracking.xyz",
+        [
+            "2",
+            "single tracking",
+            "Pb 0.0 0.0 0.0",
+            "O 2.0 0.0 0.0",
+        ],
+    )
+    single_window = ElectronDensityMappingMainWindow(
+        initial_input_path=single_structure
+    )
+    assert not single_window.pinned_geometric_tracking_checkbox.isEnabled()
+    single_window.close()
+
+    folder = tmp_path / "pdb_tracking_folder"
+    folder.mkdir()
+    _write_pb_o_pdb_frame(folder / "frame_0001.pdb", pb_x=0.0, o_x=4.0)
+    _write_pb_o_pdb_frame(folder / "frame_0002.pdb", pb_x=0.0, o_x=6.0)
+    window = ElectronDensityMappingMainWindow(initial_input_path=folder)
+
+    assert window.pinned_geometric_tracking_checkbox.isEnabled()
+    assert window.pinned_geometric_tracking_checkbox.isChecked()
+    assert (
+        window._mesh_settings_from_controls().pin_contiguous_geometric_tracking
+    )
+
+    window.snap_center_button.click()
+    assert not window.pinned_geometric_tracking_checkbox.isEnabled()
+    assert not window.pinned_geometric_tracking_checkbox.isChecked()
+    window.close()
+
+
+def test_main_window_warns_before_running_with_unconfirmed_mesh_settings(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    structure_path = _write_xyz(
+        tmp_path / "warn_default_mesh.xyz",
+        [
+            "3",
+            "warn default mesh",
+            "O 0.0 0.0 0.0",
+            "H 0.96 0.0 0.0",
+            "H -0.24 0.93 0.0",
+        ],
+    )
+    window = ElectronDensityMappingMainWindow(
+        initial_input_path=structure_path
+    )
+    prompts: list[tuple[str, str]] = []
+
+    def fake_question(*args, **kwargs):
+        del kwargs
+        prompts.append((str(args[1]), str(args[2])))
+        return QMessageBox.StandardButton.No
+
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.ui.main_window.QMessageBox.question",
+        fake_question,
+    )
+
+    window.run_button.click()
+    qapp.processEvents()
+
+    assert prompts
+    assert prompts[-1][0] == "Mesh Settings Not Updated"
+    assert "not updated from the defaults currently shown in the UI" in (
+        prompts[-1][1]
+    )
+    assert "Proceed with the electron-density calculation?" in prompts[-1][1]
+    assert window._calculation_thread is None
+    assert window._profile_result is None
+    window.close()
+
+
+def test_main_window_mesh_update_skips_defaults_warning_on_run(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    structure_path = _write_xyz(
+        tmp_path / "confirmed_mesh.xyz",
+        [
+            "3",
+            "confirmed mesh",
+            "O 0.0 0.0 0.0",
+            "H 0.96 0.0 0.0",
+            "H -0.24 0.93 0.0",
+        ],
+    )
+    window = ElectronDensityMappingMainWindow(
+        initial_input_path=structure_path
+    )
+    prompts: list[str] = []
+
+    def fake_question(*args, **kwargs):
+        del kwargs
+        prompts.append(str(args[2]))
+        return QMessageBox.StandardButton.Yes
+
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.ui.main_window.QMessageBox.question",
+        fake_question,
+    )
+
+    window.update_mesh_button.click()
+    window.run_button.click()
+    _wait_for(
+        lambda: window._profile_result is not None
+        and window._calculation_thread is None,
+        qapp,
+    )
+
+    assert not prompts
+    assert window._profile_result is not None
+    window.close()
+
+
+def test_main_window_preview_mode_marks_title_and_blocks_push(qapp):
+    del qapp
+    window = ElectronDensityMappingMainWindow(preview_mode=True)
+
+    assert window.windowTitle() == "Electron Density Mapping (Preview)"
+    assert "Preview Mode" in window.preview_mode_banner.text()
+    assert not window.push_to_model_button.isEnabled()
+    assert "Preview mode" in window.push_to_model_status_label.text()
+    window.close()
+
+
+def test_main_window_output_history_defaults_collapsed_and_tracks_outputs(
+    qapp,
+    tmp_path,
+):
+    structure_path = _write_xyz(
+        tmp_path / "history_capture.xyz",
+        [
+            "4",
+            "history capture",
+            "N 0.0 0.0 0.1",
+            "H 0.94 0.0 -0.2",
+            "H -0.47 0.81 -0.2",
+            "H -0.47 -0.81 -0.2",
+        ],
+    )
+    window = ElectronDensityMappingMainWindow(
+        initial_input_path=structure_path
+    )
+
+    assert not window.output_history_section.is_expanded
+    assert window.output_history_table.rowCount() == 0
+    assert not window.load_output_history_button.isEnabled()
+    assert not window.compare_output_history_button.isEnabled()
+    assert (
+        window.output_history_table.selectionMode()
+        == window.output_history_table.SelectionMode.ExtendedSelection
+    )
+
+    window.run_button.click()
+    _wait_for(
+        lambda: window._profile_result is not None
+        and window._calculation_thread is None,
+        qapp,
+    )
+
+    assert window.output_history_table.rowCount() == 1
+    assert window.output_history_table.item(0, 1).text() == "Electron Density"
+
+    window.solvent_method_combo.setCurrentIndex(
+        window.solvent_method_combo.findData(CONTRAST_SOLVENT_METHOD_DIRECT)
+    )
+    window.direct_density_spin.setValue(0.20)
+    window.compute_solvent_density_button.click()
+
+    assert window.output_history_table.rowCount() == 2
+    assert (
+        window.output_history_table.item(0, 1).text() == "Solvent Subtraction"
+    )
+
+    window.evaluate_fourier_button.click()
+
+    assert window.output_history_table.rowCount() == 3
+    assert window.output_history_table.item(0, 1).text() == "Fourier Transform"
+    assert (
+        Path(window.output_dir_edit.text())
+        / "electron_density_saved_output_history.json"
+    ).is_file()
+    window.close()
+
+
+def test_main_window_output_history_restores_preview_entries_in_non_preview_mode(
+    qapp,
+    tmp_path,
+):
+    structure_path = _write_xyz(
+        tmp_path / "history_restore.xyz",
+        [
+            "4",
+            "history restore",
+            "N 0.0 0.0 0.1",
+            "H 0.94 0.0 -0.2",
+            "H -0.47 0.81 -0.2",
+            "H -0.47 -0.81 -0.2",
+        ],
+    )
+    preview_window = ElectronDensityMappingMainWindow(
+        initial_input_path=structure_path
+    )
+    preview_window.run_button.click()
+    _wait_for(
+        lambda: preview_window._profile_result is not None
+        and preview_window._calculation_thread is None,
+        qapp,
+    )
+    preview_window.solvent_method_combo.setCurrentIndex(
+        preview_window.solvent_method_combo.findData(
+            CONTRAST_SOLVENT_METHOD_DIRECT
+        )
+    )
+    preview_window.direct_density_spin.setValue(0.18)
+    preview_window.compute_solvent_density_button.click()
+    preview_window.evaluate_fourier_button.click()
+    assert preview_window.output_history_table.rowCount() == 3
+    preview_window.close()
+
+    restored_window = ElectronDensityMappingMainWindow(
+        initial_input_path=structure_path,
+        preview_mode=False,
+    )
+    qapp.processEvents()
+
+    assert restored_window._profile_result is None
+    assert restored_window.output_history_table.rowCount() == 3
+    assert (
+        restored_window.output_history_table.item(0, 1).text()
+        == "Fourier Transform"
+    )
+
+    restored_window.output_history_table.selectRow(0)
+    qapp.processEvents()
+    restored_window.load_output_history_button.click()
+
+    assert restored_window._profile_result is not None
+    assert restored_window._fourier_result is not None
+    assert restored_window._profile_result.solvent_contrast is not None
+    restored_window.close()
+
+
+def test_main_window_push_controls_render_between_fourier_and_saved_outputs(
+    qapp,
+):
+    del qapp
+    window = ElectronDensityMappingMainWindow()
+
+    left_layout = window._left_scroll_area.widget().layout()
+
+    assert left_layout.indexOf(window.fourier_section) < left_layout.indexOf(
+        window.push_to_model_group
+    )
+    assert left_layout.indexOf(
+        window.push_to_model_group
+    ) < left_layout.indexOf(window.output_history_section)
+    window.close()
+
+
+def test_output_history_comparison_dialog_exports_png_and_csv(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    structure_path = _write_xyz(
+        tmp_path / "history_compare.xyz",
+        [
+            "4",
+            "history compare",
+            "N 0.0 0.0 0.1",
+            "H 0.94 0.0 -0.2",
+            "H -0.47 0.81 -0.2",
+            "H -0.47 -0.81 -0.2",
+        ],
+    )
+    window = ElectronDensityMappingMainWindow(
+        initial_input_path=structure_path
+    )
+    window.run_button.click()
+    _wait_for(
+        lambda: window._profile_result is not None
+        and window._calculation_thread is None,
+        qapp,
+    )
+    window.solvent_method_combo.setCurrentIndex(
+        window.solvent_method_combo.findData(CONTRAST_SOLVENT_METHOD_DIRECT)
+    )
+    window.direct_density_spin.setValue(0.22)
+    window.compute_solvent_density_button.click()
+    window.evaluate_fourier_button.click()
+
+    selection_model = window.output_history_table.selectionModel()
+    selection_model.clearSelection()
+    for row_index in (0, 1):
+        selection_model.select(
+            window.output_history_table.model().index(row_index, 0),
+            QItemSelectionModel.SelectionFlag.Select
+            | QItemSelectionModel.SelectionFlag.Rows,
+        )
+    qapp.processEvents()
+    assert window.compare_output_history_button.isEnabled()
+
+    window.compare_output_history_button.click()
+    qapp.processEvents()
+
+    dialog = window._output_history_compare_dialog
+    assert dialog is not None
+    assert len(dialog._entry_plot_widgets) == 2
+
+    png_dir = tmp_path / "png_exports"
+    csv_dir = tmp_path / "csv_exports"
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.ui.main_window.QFileDialog.getExistingDirectory",
+        lambda *args, **kwargs: str(png_dir),
+    )
+    dialog.save_all_png_button.click()
+
+    assert len(list(png_dir.glob("*.png"))) == 10
+
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.ui.main_window.QFileDialog.getExistingDirectory",
+        lambda *args, **kwargs: str(csv_dir),
+    )
+    dialog.export_all_csv_button.click()
+
+    assert len(list(csv_dir.glob("*.csv"))) == 2
+    dialog.close()
     window.close()
 
 
@@ -853,11 +2671,375 @@ def test_main_window_folder_run_averages_profiles_and_toggles_variance(
 
     assert window._profile_result.input_mode == "folder"
     assert window._profile_result.source_structure_count == 2
+    assert window.contiguous_frame_mode_checkbox.isChecked()
+    assert window._profile_result.contiguous_frame_mode_requested
+    assert window._profile_result.contiguous_frame_mode_applied
     assert len(window.profile_plot.figure.axes[0].collections) >= 1
 
     window.show_variance_checkbox.setChecked(False)
 
     assert len(window.profile_plot.figure.axes[0].collections) == 0
+    window.close()
+
+
+def test_launch_ui_defers_initial_input_loading(qapp, tmp_path):
+    structure_path = _write_xyz(
+        tmp_path / "deferred_launch.xyz",
+        [
+            "3",
+            "deferred launch",
+            "O 0.0 0.0 0.0",
+            "H 0.96 0.0 0.0",
+            "H -0.24 0.93 0.0",
+        ],
+    )
+
+    window = launch_electron_density_mapping_ui(
+        initial_input_path=structure_path
+    )
+
+    try:
+        assert window.input_path_edit.text() == str(structure_path.resolve())
+        assert window._inspection is None
+        assert window._structure is None
+
+        _wait_for(lambda: window._structure is not None, qapp)
+
+        assert window._inspection is not None
+        assert window._structure is not None
+        assert window._structure.file_path == structure_path.resolve()
+    finally:
+        window.close()
+
+
+def test_launch_ui_reports_startup_progress_for_computed_distribution_load(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    clusters_dir = tmp_path / "clusters"
+    cluster_dir = clusters_dir / "2mer"
+    cluster_dir.mkdir(parents=True)
+    structure_path = _write_xyz(
+        cluster_dir / "frame_0001.xyz",
+        [
+            "3",
+            "cluster frame",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+    )
+
+    load_started = threading.Event()
+    release_load = threading.Event()
+    original_load = load_electron_density_structure
+
+    def slow_load(file_path, *args, **kwargs):
+        load_started.set()
+        assert release_load.wait(timeout=5.0)
+        return original_load(file_path, *args, **kwargs)
+
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.ui.main_window.load_electron_density_structure",
+        slow_load,
+    )
+
+    window = launch_electron_density_mapping_ui(
+        initial_input_path=clusters_dir,
+        preview_mode=False,
+    )
+
+    try:
+        _wait_for(
+            lambda: load_started.is_set()
+            and "Loading cluster 1/1"
+            in window.calculation_progress_message.text(),
+            qapp,
+        )
+
+        assert not window.load_input_button.isEnabled()
+        assert window.calculation_progress_bar.maximum() == 3
+        assert window.calculation_progress_bar.value() == 1
+        assert window._cluster_group_states == []
+        assert window._workspace_load_progress_dialog is not None
+        assert window._workspace_load_progress_dialog.isVisible()
+        assert (
+            window._workspace_load_progress_dialog.windowTitle()
+            == "Loading Electron Density Mapping"
+        )
+        assert (
+            "Loading cluster 1/1"
+            in window._workspace_load_progress_dialog.message_label.text()
+        )
+        assert (
+            window._workspace_load_progress_dialog.progress_bar.maximum() == 3
+        )
+        assert window._workspace_load_progress_dialog.progress_bar.value() == 1
+
+        release_load.set()
+
+        _wait_for(
+            lambda: len(window._cluster_group_states) == 1
+            and window.load_input_button.isEnabled(),
+            qapp,
+        )
+
+        assert (
+            window._cluster_group_states[0].inspection.reference_file
+            == structure_path
+        )
+        assert "Cluster folders" in window.input_mode_value.text()
+        assert window._workspace_load_progress_dialog is not None
+        assert not window._workspace_load_progress_dialog.isVisible()
+        dialog_output = (
+            window._workspace_load_progress_dialog.output_box.toPlainText()
+        )
+        assert "Discovered 1 stoichiometry folder" in dialog_output
+        assert "Loading cluster 1/1" in dialog_output
+    finally:
+        release_load.set()
+        window.close()
+
+
+def test_load_input_from_edit_reports_progress_for_manual_folder_load(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    clusters_dir = tmp_path / "clusters"
+    cluster_dir = clusters_dir / "2mer"
+    cluster_dir.mkdir(parents=True)
+    structure_path = _write_xyz(
+        cluster_dir / "frame_0001.xyz",
+        [
+            "3",
+            "cluster frame",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+    )
+
+    load_started = threading.Event()
+    release_load = threading.Event()
+    original_load = load_electron_density_structure
+
+    def slow_load(file_path, *args, **kwargs):
+        load_started.set()
+        assert release_load.wait(timeout=5.0)
+        return original_load(file_path, *args, **kwargs)
+
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.ui.main_window.load_electron_density_structure",
+        slow_load,
+    )
+
+    window = ElectronDensityMappingMainWindow(preview_mode=False)
+
+    try:
+        window.input_path_edit.setText(str(clusters_dir))
+        window._load_input_from_edit()
+
+        _wait_for(
+            lambda: load_started.is_set()
+            and "Loading cluster 1/1"
+            in window.calculation_progress_message.text(),
+            qapp,
+        )
+
+        assert not window.load_input_button.isEnabled()
+        assert window._cluster_group_states == []
+        assert window._workspace_load_progress_dialog is not None
+        assert window._workspace_load_progress_dialog.isVisible()
+        assert (
+            "Loading cluster 1/1"
+            in window._workspace_load_progress_dialog.message_label.text()
+        )
+
+        release_load.set()
+
+        _wait_for(
+            lambda: len(window._cluster_group_states) == 1
+            and window.load_input_button.isEnabled(),
+            qapp,
+        )
+
+        assert (
+            window._cluster_group_states[0].inspection.reference_file
+            == structure_path
+        )
+        assert window._workspace_load_progress_dialog is not None
+        assert not window._workspace_load_progress_dialog.isVisible()
+    finally:
+        release_load.set()
+        window.close()
+
+
+def test_main_window_can_disable_contiguous_frame_mode(qapp, tmp_path):
+    folder = tmp_path / "frames_no_contiguous"
+    folder.mkdir()
+    _write_xyz(
+        folder / "frame_0001_AAA.xyz",
+        [
+            "2",
+            "frame one",
+            "Pb 0.0 0.0 0.0",
+            "O 2.0 0.0 0.0",
+        ],
+    )
+    _write_xyz(
+        folder / "frame_0002_AAA.xyz",
+        [
+            "2",
+            "frame two",
+            "Pb 10.0 0.0 0.0",
+            "O 13.0 0.0 0.0",
+        ],
+    )
+    window = ElectronDensityMappingMainWindow(initial_input_path=folder)
+    assert window.contiguous_frame_mode_checkbox.isChecked()
+
+    window.contiguous_frame_mode_checkbox.setChecked(False)
+    window.run_button.click()
+    _wait_for(
+        lambda: window._profile_result is not None
+        and window._calculation_thread is None,
+        qapp,
+    )
+
+    assert window._profile_result is not None
+    assert not window._profile_result.contiguous_frame_mode_requested
+    assert not window._profile_result.contiguous_frame_mode_applied
+    window.close()
+
+
+@pytest.mark.parametrize("target_index", [0, 1])
+def test_main_window_auto_snap_panes_resizes_clicked_pane(
+    qapp,
+    target_index,
+):
+    del qapp
+    window = ElectronDensityMappingMainWindow()
+    window.resize(1800, 980)
+    window.show()
+    QApplication.processEvents()
+
+    before_sizes, after_sizes = _pane_snap_resize_result(
+        window._pane_splitter,
+        window._auto_snap_filter,
+        target_index=target_index,
+    )
+
+    assert after_sizes[target_index] > before_sizes[target_index] + 20
+    window.close()
+
+
+def test_main_window_auto_snap_setting_defaults_enabled_and_persists(
+    qapp,
+    monkeypatch,
+):
+    del qapp
+
+    class _FakeSettings:
+        def __init__(self, values: dict[str, object] | None = None):
+            self.values = {} if values is None else dict(values)
+
+        def value(self, key, default=None):
+            return self.values.get(key, default)
+
+        def setValue(self, key, value):
+            self.values[key] = value
+
+    settings_store = _FakeSettings()
+
+    monkeypatch.setattr(
+        ElectronDensityMappingMainWindow,
+        "_ui_settings",
+        lambda self: settings_store,
+    )
+
+    first_window = ElectronDensityMappingMainWindow()
+
+    assert first_window.auto_snap_panes_action.isChecked()
+    assert first_window._auto_snap_filter.is_enabled()
+
+    first_window.auto_snap_panes_action.trigger()
+
+    assert settings_store.values[AUTO_SNAP_PANES_KEY] is False
+    assert not first_window.auto_snap_panes_action.isChecked()
+    assert not first_window._auto_snap_filter.is_enabled()
+
+    second_window = ElectronDensityMappingMainWindow()
+
+    assert not second_window.auto_snap_panes_action.isChecked()
+    assert not second_window._auto_snap_filter.is_enabled()
+
+    first_window.close()
+    second_window.close()
+
+
+@pytest.mark.parametrize("target_index", [0, 1])
+def test_main_window_auto_snap_focuses_clicked_pane_when_its_preferred_width_is_small(
+    qapp,
+    target_index,
+):
+    del qapp
+    window = ElectronDensityMappingMainWindow()
+    window.resize(1800, 980)
+    window.show()
+    QApplication.processEvents()
+
+    before_sizes, after_sizes = _pane_snap_resize_result(
+        window._pane_splitter,
+        window._auto_snap_filter,
+        target_index=target_index,
+        desired_width=220,
+        other_width=720,
+    )
+
+    assert after_sizes[target_index] > before_sizes[target_index] + 20
+    assert after_sizes[1 - target_index] < before_sizes[1 - target_index] - 20
+    window.close()
+
+
+def test_main_window_reports_contiguous_frame_fallback(qapp, tmp_path):
+    folder = tmp_path / "frames_fallback"
+    folder.mkdir()
+    _write_xyz(
+        folder / "cluster_a.xyz",
+        [
+            "2",
+            "cluster a",
+            "Pb 0.0 0.0 0.0",
+            "O 2.0 0.0 0.0",
+        ],
+    )
+    _write_xyz(
+        folder / "cluster_b.xyz",
+        [
+            "2",
+            "cluster b",
+            "Pb 0.0 0.0 0.0",
+            "O 3.0 0.0 0.0",
+        ],
+    )
+    window = ElectronDensityMappingMainWindow(initial_input_path=folder)
+    assert window.contiguous_frame_mode_checkbox.isChecked()
+
+    window.run_button.click()
+    _wait_for(
+        lambda: window._profile_result is not None
+        and window._calculation_thread is None,
+        qapp,
+    )
+
+    assert window._profile_result is not None
+    assert window._profile_result.contiguous_frame_mode_requested
+    assert not window._profile_result.contiguous_frame_mode_applied
+    assert "Falling back to complete averaging" in (
+        window.status_text.toPlainText()
+    )
     window.close()
 
 
@@ -911,6 +3093,79 @@ def test_main_window_evaluates_fourier_transform_and_toggles_log_axes(
     window.close()
 
 
+def test_main_window_uses_updated_fourier_defaults_and_inherited_q_range(
+    qapp,
+):
+    window = ElectronDensityMappingMainWindow()
+    assert window.fourier_qmin_spin.value() == pytest.approx(0.02)
+    assert window.fourier_qmax_spin.value() == pytest.approx(1.2)
+    assert window.fourier_qstep_spin.value() == pytest.approx(0.01)
+    assert window.fourier_resampling_points_spin.value() == 2048
+
+    inherited_window = ElectronDensityMappingMainWindow(
+        initial_project_q_min=0.15,
+        initial_project_q_max=0.9,
+    )
+    assert inherited_window.fourier_qmin_spin.value() == pytest.approx(0.15)
+    assert inherited_window.fourier_qmax_spin.value() == pytest.approx(0.9)
+    assert inherited_window.fourier_qstep_spin.value() == pytest.approx(0.01)
+    assert inherited_window.fourier_resampling_points_spin.value() == 2048
+
+    window.close()
+    inherited_window.close()
+
+
+def test_main_window_keeps_fourier_controls_editable_without_cluster_groups(
+    qapp,
+):
+    window = ElectronDensityMappingMainWindow()
+
+    assert not window.apply_fourier_to_all_button.isEnabled()
+    assert (
+        window.fourier_scope_status_label.text()
+        == "Batch Fourier editing becomes available in cluster-folder mode."
+    )
+    assert window.fourier_rmax_spin.isEnabled()
+    assert window.fourier_qmin_spin.isEnabled()
+    assert window.fourier_qmax_spin.isEnabled()
+    assert window.fourier_qstep_spin.isEnabled()
+    assert window.fourier_window_combo.isEnabled()
+    assert window.fourier_resampling_points_spin.isEnabled()
+    assert window.fourier_use_solvent_subtracted_checkbox.isEnabled()
+    assert window.fourier_legacy_mode_checkbox.isEnabled()
+    assert not window.fourier_rmin_spin.isEnabled()
+
+    window.fourier_legacy_mode_checkbox.setChecked(True)
+    qapp.processEvents()
+
+    assert window.fourier_rmin_spin.isEnabled()
+    window.close()
+
+
+def test_main_window_defaults_to_mirrored_fourier_domain_and_can_toggle_legacy(
+    qapp,
+):
+    window = ElectronDensityMappingMainWindow()
+    window.apply_fourier_to_all_button.setChecked(False)
+    qapp.processEvents()
+
+    assert not window.fourier_legacy_mode_checkbox.isChecked()
+    assert window.fourier_rmin_label.text() == "-r max"
+    assert not window.fourier_rmin_spin.isEnabled()
+
+    window.fourier_rmax_spin.setValue(3.25)
+    qapp.processEvents()
+    assert window.fourier_rmin_spin.value() == pytest.approx(-3.25)
+
+    window.fourier_legacy_mode_checkbox.setChecked(True)
+    qapp.processEvents()
+    assert window.fourier_rmin_label.text() == "r min"
+    assert window.fourier_rmin_spin.isEnabled()
+    assert window.fourier_rmin_spin.value() == pytest.approx(0.0)
+
+    window.close()
+
+
 def test_main_window_exposes_centered_exafs_window_options(qapp):
     del qapp
     window = ElectronDensityMappingMainWindow()
@@ -923,6 +3178,826 @@ def test_main_window_exposes_centered_exafs_window_options(qapp):
     assert "hanning" in window_names
     assert window.fourier_window_combo.currentData() == "hanning"
     window.close()
+
+
+def test_cluster_group_loading_uses_fast_atom_count_scan(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    del qapp
+    clusters_dir = tmp_path / "clusters"
+    group_dir = clusters_dir / "PbI2"
+    group_dir.mkdir(parents=True)
+    _write_xyz(
+        group_dir / "frame_0001.xyz",
+        [
+            "3",
+            "frame one",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+    )
+    _write_xyz(
+        group_dir / "frame_0002.xyz",
+        [
+            "4",
+            "frame two",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+            "I 0.0 0.0 2.8",
+        ],
+    )
+    _write_xyz(
+        group_dir / "frame_0003.xyz",
+        [
+            "5",
+            "frame three",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+            "I 0.0 0.0 2.8",
+            "I -2.8 0.0 0.0",
+        ],
+    )
+
+    load_calls: list[str] = []
+
+    def fake_load(file_path, *args, **kwargs):
+        del args, kwargs
+        resolved = Path(file_path).expanduser().resolve()
+        load_calls.append(resolved.name)
+        return SimpleNamespace(
+            file_path=resolved,
+            atom_count=99,
+        )
+
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.ui.main_window.load_electron_density_structure",
+        fake_load,
+    )
+
+    window = ElectronDensityMappingMainWindow()
+
+    states = window._cluster_group_states_for_path(clusters_dir)
+
+    assert len(states) == 1
+    assert states[0].average_atom_count == pytest.approx(4.0)
+    assert load_calls == ["frame_0001.xyz"]
+    window.close()
+
+
+def test_cluster_folder_single_atom_groups_use_direct_debye_scattering(
+    qapp,
+    tmp_path,
+):
+    del qapp
+    clusters_dir = tmp_path / "clusters"
+    single_dir = clusters_dir / "I"
+    multi_dir = clusters_dir / "PbI2"
+    single_dir.mkdir(parents=True)
+    multi_dir.mkdir(parents=True)
+    _write_xyz(
+        single_dir / "frame_0001.xyz",
+        [
+            "1",
+            "single iodine 1",
+            "I 0.0 0.0 0.0",
+        ],
+    )
+    _write_xyz(
+        single_dir / "frame_0002.xyz",
+        [
+            "1",
+            "single iodine 2",
+            "I 1.0 2.0 3.0",
+        ],
+    )
+    _write_xyz(
+        multi_dir / "frame_0001.xyz",
+        [
+            "3",
+            "PbI2 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+    )
+
+    window = ElectronDensityMappingMainWindow(initial_input_path=clusters_dir)
+
+    assert any(
+        state.key == "I" and state.single_atom_only
+        for state in window._cluster_group_states
+    )
+
+    window.run_button.click()
+    _wait_for(
+        lambda: all(
+            (
+                state.single_atom_only
+                and state.profile_result is None
+                and state.transform_result is not None
+            )
+            or (
+                not state.single_atom_only and state.profile_result is not None
+            )
+            for state in window._cluster_group_states
+        )
+        and window._calculation_thread is None,
+        QApplication.instance(),
+    )
+
+    states_by_key = {
+        state.key: state for state in window._cluster_group_states
+    }
+    log_text = window.status_text.toPlainText()
+
+    assert states_by_key["I"].transform_result is not None
+    assert states_by_key["I"].profile_result is None
+    assert states_by_key["I"].transform_result.preview.source_mode == (
+        "single_atom_debye"
+    )
+    assert states_by_key["PbI2"].profile_result is not None
+    assert (
+        "Preparing single-atom Debye scattering calculation." not in log_text
+    )
+    assert "Validating single-atom structure" not in log_text
+    assert "Computing single-atom Debye scattering from " not in log_text
+    assert "Single-atom Debye scattering profile ready." not in log_text
+
+    row_by_key = {
+        window.cluster_group_table.item(row_index, 0).text(): row_index
+        for row_index in range(window.cluster_group_table.rowCount())
+    }
+    assert window.cluster_group_table.item(row_by_key["I"], 6).text() == (
+        "Skipped (Debye)"
+    )
+    assert window.cluster_group_table.item(row_by_key["I"], 7).text() == (
+        "Ready (Debye)"
+    )
+
+    window.cluster_group_table.selectRow(row_by_key["I"])
+    QApplication.instance().processEvents()
+
+    assert window._profile_result is None
+    assert window._fourier_result is states_by_key["I"].transform_result
+    assert (
+        "direct debye scattering" in window.fourier_notice_value.text().lower()
+    )
+    assert (
+        window.scattering_plot.current_result
+        is states_by_key["I"].transform_result
+    )
+
+    window.fourier_qmax_spin.setValue(1.0)
+    window.evaluate_fourier_button.click()
+
+    assert states_by_key["I"].transform_result is not None
+    assert states_by_key["I"].transform_result.preview.source_mode == (
+        "single_atom_debye"
+    )
+    assert states_by_key["I"].transform_result.q_values[-1] == pytest.approx(
+        1.0
+    )
+    window.close()
+
+
+def test_cluster_folder_apply_to_all_fourier_updates_single_atom_debye_rows_with_shared_q_grid(
+    qapp,
+    tmp_path,
+):
+    clusters_dir = tmp_path / "clusters"
+    single_dir = clusters_dir / "I"
+    multi_dir = clusters_dir / "PbI2"
+    single_dir.mkdir(parents=True)
+    multi_dir.mkdir(parents=True)
+    _write_xyz(
+        single_dir / "frame_0001.xyz",
+        [
+            "1",
+            "single iodine 1",
+            "I 0.0 0.0 0.0",
+        ],
+    )
+    _write_xyz(
+        single_dir / "frame_0002.xyz",
+        [
+            "1",
+            "single iodine 2",
+            "I 1.0 2.0 3.0",
+        ],
+    )
+    _write_xyz(
+        multi_dir / "frame_0001.xyz",
+        [
+            "3",
+            "PbI2 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+    )
+
+    window = ElectronDensityMappingMainWindow(initial_input_path=clusters_dir)
+
+    _wait_for(
+        lambda: window.cluster_group_table.rowCount() == 2,
+        qapp,
+    )
+    window.run_button.click()
+    _wait_for(
+        lambda: window._calculation_thread is None
+        and all(
+            (state.single_atom_only and state.transform_result is not None)
+            or (
+                not state.single_atom_only and state.profile_result is not None
+            )
+            for state in window._cluster_group_states
+        ),
+        qapp,
+    )
+
+    window.fourier_qmin_spin.setValue(0.1)
+    window.fourier_qmax_spin.setValue(0.5)
+    window.fourier_qstep_spin.setValue(0.2)
+    window.evaluate_fourier_button.click()
+
+    expected_q = np.asarray([0.1, 0.3, 0.5], dtype=float)
+    states_by_key = {
+        state.key: state for state in window._cluster_group_states
+    }
+    row_by_key = {
+        window.cluster_group_table.item(row_index, 0).text(): row_index
+        for row_index in range(window.cluster_group_table.rowCount())
+    }
+
+    assert states_by_key["I"].transform_result is not None
+    assert states_by_key["I"].transform_result.preview.source_mode == (
+        "single_atom_debye"
+    )
+    np.testing.assert_allclose(
+        states_by_key["I"].transform_result.q_values,
+        expected_q,
+    )
+    assert states_by_key["PbI2"].profile_result is not None
+    assert states_by_key["PbI2"].transform_result is not None
+    assert window.fourier_settings_table.item(row_by_key["I"], 1).text() == (
+        "Ready (Debye)"
+    )
+    assert (
+        window.fourier_settings_table.item(row_by_key["PbI2"], 1).text()
+        == "Ready"
+    )
+    window.close()
+
+
+def test_batch_smearing_shows_progress_popup(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    window = _open_ready_cluster_folder_window(
+        qapp,
+        tmp_path,
+        folder_name="batch_smearing_progress",
+    )
+    window.apply_smearing_to_all_button.setChecked(True)
+    window.smearing_factor_spin.setValue(0.04)
+
+    seen_messages: list[str] = []
+
+    def wrapped_apply(result, settings):
+        dialog = _assert_batch_progress_dialog_visible(
+            window,
+            title="Applying Gaussian Smearing",
+            total=len(window._cluster_group_states),
+        )
+        seen_messages.append(dialog.message_label.text())
+        return apply_smearing_to_profile_result(result, settings)
+
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.ui.main_window.apply_smearing_to_profile_result",
+        wrapped_apply,
+    )
+
+    window.apply_smearing_button.click()
+
+    assert len(seen_messages) == len(window._cluster_group_states)
+    assert any(
+        "Applying Gaussian smearing to" in message for message in seen_messages
+    )
+    assert window._batch_operation_progress_dialog is not None
+    assert not window._batch_operation_progress_dialog.isVisible()
+    assert "complete" in window.calculation_progress_message.text().lower()
+    window.close()
+
+
+def test_batch_solvent_contrast_shows_progress_popup(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    window = _open_ready_cluster_folder_window(
+        qapp,
+        tmp_path,
+        folder_name="batch_contrast_progress",
+    )
+    base_profile = next(
+        state.profile_result
+        for state in window._cluster_group_states
+        if state.profile_result is not None
+    )
+    direct_density = float(
+        min(
+            np.max(
+                np.asarray(
+                    base_profile.smeared_orientation_average_density,
+                    dtype=float,
+                )
+            )
+            * 0.01,
+            50.0,
+        )
+    )
+    window.solvent_method_combo.setCurrentIndex(
+        window.solvent_method_combo.findData(CONTRAST_SOLVENT_METHOD_DIRECT)
+    )
+    window.direct_density_spin.setValue(direct_density)
+    window.apply_contrast_to_all_button.setChecked(True)
+
+    seen_messages: list[str] = []
+
+    def wrapped_apply(result, settings, *, solvent_name=None):
+        dialog = _assert_batch_progress_dialog_visible(
+            window,
+            title="Applying Electron Density Contrast",
+            total=len(window._cluster_group_states),
+        )
+        seen_messages.append(dialog.message_label.text())
+        return apply_solvent_contrast_to_profile_result(
+            result,
+            settings,
+            solvent_name=solvent_name,
+        )
+
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.ui.main_window.apply_solvent_contrast_to_profile_result",
+        wrapped_apply,
+    )
+
+    window.compute_solvent_density_button.click()
+
+    assert len(seen_messages) == len(window._cluster_group_states)
+    assert any(
+        "Applying solvent subtraction to" in message
+        for message in seen_messages
+    )
+    assert window._batch_operation_progress_dialog is not None
+    assert not window._batch_operation_progress_dialog.isVisible()
+    assert "complete" in window.calculation_progress_message.text().lower()
+    window.close()
+
+
+def test_batch_fourier_evaluation_shows_progress_popup(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    window = _open_ready_cluster_folder_window(
+        qapp,
+        tmp_path,
+        folder_name="batch_fourier_progress",
+    )
+    window.apply_fourier_to_all_button.setChecked(True)
+
+    seen_messages: list[str] = []
+
+    def wrapped_compute(result, settings):
+        dialog = _assert_batch_progress_dialog_visible(
+            window,
+            title="Evaluating Fourier Transforms",
+            total=len(window._cluster_group_states),
+        )
+        seen_messages.append(dialog.message_label.text())
+        return compute_electron_density_scattering_profile(
+            result,
+            settings,
+        )
+
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.ui.main_window.compute_electron_density_scattering_profile",
+        wrapped_compute,
+    )
+
+    window.evaluate_fourier_button.click()
+
+    assert len(seen_messages) == len(window._cluster_group_states)
+    assert any(
+        "Evaluating Fourier transform for" in message
+        for message in seen_messages
+    )
+    assert all(
+        state.transform_result is not None
+        for state in window._cluster_group_states
+    )
+    assert window._batch_operation_progress_dialog is not None
+    assert not window._batch_operation_progress_dialog.isVisible()
+    assert "complete" in window.calculation_progress_message.text().lower()
+    window.close()
+
+
+def test_cluster_row_selection_preserves_batch_fourier_transforms(
+    qapp,
+    tmp_path,
+):
+    clusters_dir = tmp_path / "batch_fourier_selection"
+    clusters_dir.mkdir()
+    structures = {
+        "PbI2": [
+            "3",
+            "PbI2 frame 1",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+        "PbI3": [
+            "4",
+            "PbI3 frame 1",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+            "I 0.0 0.0 2.8",
+        ],
+        "CsI": [
+            "2",
+            "CsI frame 1",
+            "Cs 0.0 0.0 0.0",
+            "I 3.2 0.0 0.0",
+        ],
+    }
+    for name, lines in structures.items():
+        stoichiometry_dir = clusters_dir / name
+        stoichiometry_dir.mkdir(parents=True)
+        _write_xyz(stoichiometry_dir / "frame_0001.xyz", lines)
+
+    window = ElectronDensityMappingMainWindow(initial_input_path=clusters_dir)
+
+    _wait_for(
+        lambda: window.cluster_group_table.rowCount() == len(structures),
+        qapp,
+    )
+    window.run_button.click()
+    _wait_for(
+        lambda: window._calculation_thread is None
+        and all(
+            state.profile_result is not None
+            for state in window._cluster_group_states
+        ),
+        qapp,
+    )
+
+    window.apply_fourier_to_all_button.setChecked(True)
+    window.evaluate_fourier_button.click()
+    qapp.processEvents()
+
+    assert all(
+        state.transform_result is not None
+        for state in window._cluster_group_states
+    )
+
+    window.apply_debye_to_all_button.setChecked(True)
+    qapp.processEvents()
+    assert "0/3 target rows" in window.debye_scattering_status_label.text()
+
+    for row_index, expected_state in enumerate(window._cluster_group_states):
+        window.cluster_group_table.selectRow(row_index)
+        qapp.processEvents()
+
+        active_state = window._active_cluster_group_state()
+        assert active_state is not None
+        assert active_state.key == expected_state.key
+        assert active_state.transform_result is not None
+        assert window._fourier_result is active_state.transform_result
+        assert (
+            window.scattering_plot.current_result
+            is active_state.transform_result
+        )
+        assert window.cluster_group_table.item(row_index, 7).text() == "Ready"
+        assert window.fourier_settings_table.item(row_index, 1).text() == (
+            "Ready"
+        )
+        assert all(
+            state.transform_result is not None
+            for state in window._cluster_group_states
+        )
+        assert "0/3 target rows" in (
+            window.debye_scattering_status_label.text()
+        )
+
+    window.close()
+
+
+def test_cluster_folder_load_defaults_batch_apply_to_all_scopes(
+    qapp,
+    tmp_path,
+):
+    window = ElectronDensityMappingMainWindow(
+        initial_input_path=_write_cluster_folder_input(
+            tmp_path / "default_batch_scope_clusters"
+        )
+    )
+
+    _wait_for(
+        lambda: window.cluster_group_table.rowCount() == 2,
+        qapp,
+    )
+
+    assert window.apply_smearing_to_all_button.isChecked()
+    assert window.apply_contrast_to_all_button.isChecked()
+    assert window.apply_fourier_to_all_button.isChecked()
+    assert not window.apply_debye_to_all_button.isChecked()
+
+    window.close()
+
+
+def test_main_window_debye_scattering_pane_builds_cluster_comparison_plot(
+    qapp,
+    tmp_path,
+):
+    clusters_dir = _write_cluster_folder_input(tmp_path / "debye_compare")
+    window = ElectronDensityMappingMainWindow(initial_input_path=clusters_dir)
+
+    window.run_button.click()
+    _wait_for(
+        lambda: all(
+            state.profile_result is not None
+            for state in window._cluster_group_states
+        )
+        and window._calculation_thread is None,
+        qapp,
+    )
+
+    window.apply_fourier_to_all_button.setChecked(True)
+    window.evaluate_fourier_button.click()
+    qapp.processEvents()
+
+    assert window.calculate_debye_scattering_button.isEnabled()
+    window.apply_debye_to_all_button.setChecked(True)
+    window.calculate_debye_scattering_button.click()
+    qapp.processEvents()
+
+    assert all(
+        state.debye_scattering_result is not None
+        for state in window._cluster_group_states
+        if not state.single_atom_only
+    )
+    for state in window._cluster_group_states:
+        if state.single_atom_only:
+            continue
+        assert state.transform_result is not None
+        assert state.debye_scattering_result is not None
+        np.testing.assert_allclose(
+            state.debye_scattering_result.q_values,
+            state.transform_result.q_values,
+        )
+
+    assert window.open_debye_scattering_compare_button.isEnabled()
+    window.open_debye_scattering_compare_button.click()
+    qapp.processEvents()
+
+    dialog = window._debye_scattering_compare_dialog
+    assert dialog is not None
+    assert dialog._trace_table.rowCount() == 2
+    assert dialog.autoscale_button.isChecked()
+    assert len(dialog._plot_widget.figure.axes) == 2
+    born_axis, debye_axis = dialog._plot_widget.figure.axes
+    assert "Born Approximation" in born_axis.get_ylabel()
+    assert "Debye Scattering" in debye_axis.get_ylabel()
+
+    dialog.close()
+    window.close()
+
+
+def test_main_window_debye_scattering_progress_bar_updates_for_single_run(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    structure_path = _write_xyz(
+        tmp_path / "debye_progress_single.xyz",
+        [
+            "3",
+            "debye progress single",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+    )
+    window = ElectronDensityMappingMainWindow(
+        initial_input_path=structure_path
+    )
+
+    window.run_button.click()
+    _wait_for(
+        lambda: window._profile_result is not None
+        and window._calculation_thread is None,
+        qapp,
+    )
+    window.evaluate_fourier_button.click()
+    _wait_for(
+        lambda: window._fourier_result is not None
+        and window.calculate_debye_scattering_button.isEnabled(),
+        qapp,
+    )
+
+    progress_snapshots: list[tuple[bool, int, int, str]] = []
+
+    def wrapped_compute(*args, progress_callback=None, **kwargs):
+        assert progress_callback is not None
+
+        def wrapped_progress(current, total, message):
+            progress_callback(current, total, message)
+            progress_snapshots.append(
+                (
+                    not window.debye_scattering_progress_bar.isHidden(),
+                    window.debye_scattering_progress_bar.value(),
+                    window.debye_scattering_progress_bar.maximum(),
+                    window.debye_scattering_status_label.text(),
+                )
+            )
+
+        return compute_average_debye_scattering_profile_for_input(
+            *args,
+            progress_callback=wrapped_progress,
+            **kwargs,
+        )
+
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.ui.main_window.compute_average_debye_scattering_profile_for_input",
+        wrapped_compute,
+    )
+
+    window.calculate_debye_scattering_button.click()
+
+    assert progress_snapshots
+    assert any(visible for visible, *_rest in progress_snapshots)
+    assert any(
+        maximum == 4 for _visible, _value, maximum, _text in progress_snapshots
+    )
+    assert any(
+        "Debye scattering average calculation" in text or "Debye trace" in text
+        for _visible, _value, _maximum, text in progress_snapshots
+    )
+    assert window.debye_scattering_progress_bar.isHidden()
+    assert window._debye_scattering_result is not None
+    window.close()
+
+
+def test_main_window_debye_scattering_progress_bar_updates_for_batch_run(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    window = _open_ready_cluster_folder_window(
+        qapp,
+        tmp_path,
+        folder_name="debye_progress_batch",
+    )
+    window.apply_fourier_to_all_button.setChecked(True)
+    window.evaluate_fourier_button.click()
+    qapp.processEvents()
+
+    progress_snapshots: list[tuple[int, int, str]] = []
+
+    def wrapped_compute(*args, progress_callback=None, **kwargs):
+        assert progress_callback is not None
+
+        def wrapped_progress(current, total, message):
+            progress_callback(current, total, message)
+            progress_snapshots.append(
+                (
+                    window.debye_scattering_progress_bar.value(),
+                    window.debye_scattering_progress_bar.maximum(),
+                    window.debye_scattering_status_label.text(),
+                )
+            )
+
+        return compute_average_debye_scattering_profile_for_input(
+            *args,
+            progress_callback=wrapped_progress,
+            **kwargs,
+        )
+
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.ui.main_window.compute_average_debye_scattering_profile_for_input",
+        wrapped_compute,
+    )
+
+    window.apply_debye_to_all_button.setChecked(True)
+    window.calculate_debye_scattering_button.click()
+
+    assert progress_snapshots
+    assert any(maximum == 8 for _value, maximum, _text in progress_snapshots)
+    assert any(
+        "Debye 1/2" in text for _value, _maximum, text in progress_snapshots
+    )
+    assert any(
+        "Debye 2/2" in text for _value, _maximum, text in progress_snapshots
+    )
+    assert window.debye_scattering_progress_bar.isHidden()
+    assert all(
+        state.debye_scattering_result is not None
+        for state in window._cluster_group_states
+    )
+    window.close()
+
+
+def test_debye_scattering_comparison_dialog_plots_compatible_born_and_debye_traces(
+    qapp,
+    tmp_path,
+):
+    born_path = _write_xyz(
+        tmp_path / "born.xyz",
+        [
+            "3",
+            "born cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+    )
+    born_structure = load_electron_density_structure(born_path)
+    born_profile = compute_electron_density_profile(
+        born_structure,
+        _mesh_settings_for_structure(
+            born_structure,
+            rstep=0.2,
+            theta_divisions=24,
+            phi_divisions=18,
+            rmax=3.5,
+        ),
+    )
+    born_settings = ElectronDensityFourierTransformSettings(
+        r_min=float(born_profile.radial_centers[0]),
+        r_max=float(born_profile.radial_centers[-1]),
+        q_min=0.1,
+        q_max=0.5,
+        q_step=0.2,
+        resampling_points=32,
+        use_solvent_subtracted_profile=False,
+    )
+    born_result = compute_electron_density_scattering_profile(
+        born_profile,
+        born_settings,
+    )
+
+    debye_folder = tmp_path / "debye"
+    debye_folder.mkdir()
+    _write_xyz(
+        debye_folder / "frame_0001.xyz",
+        [
+            "1",
+            "single iodine 1",
+            "I 0.0 0.0 0.0",
+        ],
+    )
+    _write_xyz(
+        debye_folder / "frame_0002.xyz",
+        [
+            "1",
+            "single iodine 2",
+            "I 1.0 2.0 3.0",
+        ],
+    )
+    debye_result = compute_average_debye_scattering_profile_for_input(
+        inspect_structure_input(debye_folder),
+        born_settings,
+    )
+
+    dialog = _DebyeScatteringComparisonDialog(
+        [
+            _DebyeComparisonEntry(
+                entry_id="pair-1",
+                label="PbI2",
+                color="#2563eb",
+                born_result=born_result,
+                debye_result=debye_result,
+                info_text="Compatible Born and Debye traces",
+            )
+        ]
+    )
+
+    assert dialog._trace_table.rowCount() == 1
+    assert dialog._visible_entries()[0].entry_id == "pair-1"
+    assert "Overlaying 1 visible trace pair" in dialog.status_label.text()
+    assert len(dialog._plot_widget.figure.axes) == 2
+    born_axis, debye_axis = dialog._plot_widget.figure.axes
+    assert born_axis.lines[0].get_linestyle() == "-"
+    assert debye_axis.lines[0].get_linestyle() == "--"
+    dialog.close()
 
 
 def test_main_window_smearing_commit_updates_smeared_profile(
@@ -981,6 +4056,116 @@ def test_main_window_smearing_commit_updates_smeared_profile(
     )
     assert window.smeared_profile_plot.current_result is updated_result
     assert window.profile_plot.current_result is updated_result
+    expected_raw_total = float(
+        np.sum(
+            np.asarray(updated_result.orientation_average_density, dtype=float)
+            * np.asarray(updated_result.shell_volumes, dtype=float)
+        )
+    )
+    expected_smeared_total = float(
+        np.sum(
+            np.asarray(
+                updated_result.smeared_orientation_average_density,
+                dtype=float,
+            )
+            * np.asarray(updated_result.shell_volumes, dtype=float)
+        )
+    )
+    assert (
+        window.profile_plot.current_integrated_electron_count
+        == pytest.approx(expected_raw_total)
+    )
+    assert (
+        window.smeared_profile_plot.current_integrated_electron_count
+        == pytest.approx(expected_smeared_total)
+    )
+    raw_texts = [
+        text.get_text() for text in window.profile_plot.figure.axes[0].texts
+    ]
+    smeared_texts = [
+        text.get_text()
+        for text in window.smeared_profile_plot.figure.axes[0].texts
+    ]
+    assert any("Integrated electrons:" in text for text in raw_texts)
+    assert any(f"{expected_raw_total:.6f}" in text for text in raw_texts)
+    assert any("Integrated electrons:" in text for text in smeared_texts)
+    assert any(
+        f"{expected_smeared_total:.6f}" in text for text in smeared_texts
+    )
+    window.close()
+
+
+def test_main_window_smearing_autosave_adds_reloadable_saved_output_entries(
+    qapp,
+    tmp_path,
+):
+    structure_path = _write_xyz(
+        tmp_path / "smearing_autosave.xyz",
+        [
+            "4",
+            "smearing autosave",
+            "N 0.0 0.0 0.1",
+            "H 0.94 0.0 -0.2",
+            "H -0.47 0.81 -0.2",
+            "H -0.47 -0.81 -0.2",
+        ],
+    )
+    window = ElectronDensityMappingMainWindow(
+        initial_input_path=structure_path
+    )
+
+    window.run_button.click()
+    _wait_for(
+        lambda: window._profile_result is not None
+        and window._calculation_thread is None,
+        qapp,
+    )
+
+    assert window.output_history_table.rowCount() == 1
+    assert window.output_history_table.item(0, 1).text() == "Electron Density"
+
+    window.smearing_factor_spin.lineEdit().setText("0.040000")
+    window.smearing_factor_spin.interpretText()
+    qapp.processEvents()
+
+    assert window.output_history_table.rowCount() == 1
+    assert window._saved_output_entries[-1].entry_kind == "density"
+
+    window.auto_save_smearing_outputs_checkbox.setChecked(True)
+    qapp.processEvents()
+    window.smearing_factor_spin.lineEdit().setText("0.020000")
+    window.smearing_factor_spin.interpretText()
+    qapp.processEvents()
+
+    assert window.output_history_table.rowCount() == 2
+    assert window.output_history_table.item(0, 1).text() == "Smearing"
+    assert window._saved_output_entries[-1].entry_kind == "smearing"
+    assert window._saved_output_entries[
+        -1
+    ].profile_result.smearing_settings.debye_waller_factor == pytest.approx(
+        0.02
+    )
+
+    window.output_history_table.selectRow(0)
+    qapp.processEvents()
+    assert window.load_output_history_button.isEnabled()
+    window.load_output_history_button.click()
+    qapp.processEvents()
+
+    assert window._profile_result is not None
+    assert (
+        window._profile_result.smearing_settings.debye_waller_factor
+        == pytest.approx(0.02)
+    )
+    assert window.smearing_factor_spin.value() == pytest.approx(0.02)
+
+    window.auto_save_smearing_outputs_checkbox.setChecked(False)
+    qapp.processEvents()
+    window.smearing_factor_spin.lineEdit().setText("0.010000")
+    window.smearing_factor_spin.interpretText()
+    qapp.processEvents()
+
+    assert window.output_history_table.rowCount() == 2
     window.close()
 
 
@@ -1035,7 +4220,12 @@ def test_main_window_computes_solvent_contrast_and_updates_fourier_source(
         0
     ].get_legend_handles_labels()[1]
     assert any("Direct solvent" in label for label in legend_labels)
-    assert any("Cutoff" in label for label in legend_labels)
+    if window._profile_result.solvent_contrast.cutoff_radius_a is not None:
+        assert window.fourier_rmax_spin.value() == pytest.approx(
+            window._profile_result.solvent_contrast.cutoff_radius_a,
+            abs=1.0e-4,
+        )
+        assert any("Cutoff" in label for label in legend_labels)
     assert (
         window.residual_profile_plot.current_contrast
         is window._profile_result.solvent_contrast
@@ -1050,17 +4240,118 @@ def test_main_window_computes_solvent_contrast_and_updates_fourier_source(
 
     assert window._fourier_preview is not None
     assert window._fourier_preview.source_profile_label == "Smeared ρ(r)"
-    assert window._fourier_preview.source_radial_values[0] == pytest.approx(
-        0.0
+    expected_positive = np.concatenate(
+        (
+            [
+                float(
+                    window._profile_result.smeared_orientation_average_density[
+                        0
+                    ]
+                )
+            ],
+            np.asarray(
+                window._profile_result.smeared_orientation_average_density,
+                dtype=float,
+            ),
+        )
     )
-    assert window._fourier_preview.source_density_values[0] == pytest.approx(
-        window._profile_result.smeared_orientation_average_density[0]
+    center_index = len(window._fourier_preview.source_radial_values) // 2
+    assert window._fourier_preview.source_radial_values[0] == pytest.approx(
+        -float(window._profile_result.radial_centers[-1])
+    )
+    assert window._fourier_preview.source_radial_values[
+        center_index
+    ] == pytest.approx(0.0)
+    assert window._fourier_preview.source_density_values[
+        center_index
+    ] == pytest.approx(expected_positive[0])
+    assert np.allclose(
+        window._fourier_preview.source_density_values[center_index:],
+        expected_positive,
     )
     assert np.allclose(
-        window._fourier_preview.source_density_values[1:],
-        window._profile_result.smeared_orientation_average_density,
+        window._fourier_preview.source_density_values[: center_index + 1],
+        window._fourier_preview.source_density_values[center_index:][::-1],
     )
     window.close()
+
+
+def test_fourier_preview_plot_renders_mirrored_profile_and_solvent_subtraction(
+    qapp,
+    tmp_path,
+):
+    structure_path = _write_xyz(
+        tmp_path / "fourier_plot_aesthetics.xyz",
+        [
+            "4",
+            "fourier plot aesthetics",
+            "N 0.0 0.0 0.1",
+            "H 0.94 0.0 -0.2",
+            "H -0.47 0.81 -0.2",
+            "H -0.47 -0.81 -0.2",
+        ],
+    )
+    structure = load_electron_density_structure(structure_path)
+    result = compute_electron_density_profile(
+        structure,
+        _mesh_settings_for_structure(
+            structure,
+            rstep=0.1,
+            theta_divisions=24,
+            phi_divisions=18,
+        ),
+    )
+    contrasted = apply_solvent_contrast_to_profile_result(
+        result,
+        ContrastSolventDensitySettings.from_values(
+            method=CONTRAST_SOLVENT_METHOD_DIRECT,
+            direct_electron_density_e_per_a3=float(
+                np.max(
+                    np.asarray(
+                        result.smeared_orientation_average_density,
+                        dtype=float,
+                    )
+                )
+                * 0.5
+            ),
+        ),
+        solvent_name="Direct solvent",
+    )
+    settings = ElectronDensityFourierTransformSettings(
+        r_min=0.0,
+        r_max=float(result.radial_centers[-1]),
+        window_function="hanning",
+        resampling_points=64,
+        q_min=0.02,
+        q_max=1.2,
+        q_step=0.01,
+    )
+    preview = prepare_electron_density_fourier_transform(contrasted, settings)
+
+    plot = ElectronDensityFourierPreviewPlot()
+    plot.set_preview(preview)
+
+    axis = plot.figure.axes[0]
+    assert axis.get_xlabel() == "Mirrored r (Å)"
+    assert axis.get_title(loc="left") == "Fourier-Transform Preparation"
+    assert len(plot.figure.axes) == 1
+
+    mirrored_source_line = next(
+        line
+        for line in axis.get_lines()
+        if line.get_label().startswith("Windowed Solvent-subtracted")
+    )
+    x_data = np.asarray(mirrored_source_line.get_xdata(), dtype=float)
+    assert x_data[0] == pytest.approx(-settings.r_max)
+    assert x_data[-1] == pytest.approx(settings.r_max)
+    assert np.min(x_data) < 0.0
+    assert np.max(x_data) > 0.0
+    trace_labels = [
+        line.get_label()
+        for line in axis.get_lines()
+        if not str(line.get_label()).startswith("_child")
+    ]
+    assert trace_labels == [mirrored_source_line.get_label()]
 
 
 def test_main_window_smearing_commit_updates_solvent_residual(
@@ -1151,12 +4442,14 @@ def test_main_window_defaults_rstep_and_rmax_from_structure(qapp, tmp_path):
         initial_input_path=structure_path
     )
 
-    assert window.rstep_spin.value() == pytest.approx(0.1)
+    assert window.rstep_spin.value() == pytest.approx(0.05)
     assert window.rmax_spin.value() == pytest.approx(
         window._structure.rmax,
         abs=1.0e-4,
     )
-    assert "calculated center" in window.reset_center_button.text().lower()
+    assert "geometric mass center" in (
+        window.reset_center_button.text().lower()
+    )
     window.close()
 
 
@@ -1360,6 +4653,7 @@ def test_snap_center_preserves_active_viewer_display_settings(qapp, tmp_path):
     ]
     assert len(overlay_texts) == 1
     overlay_text = overlay_texts[0].get_text()
+    assert f"ZOOM {viewer._current_zoom_percentage():05.1f}%" in overlay_text
     assert "ATOM 030.0%" in overlay_text
     assert "MESH 045.0%" in overlay_text
     assert "LINE 2.70px" in overlay_text
@@ -1446,6 +4740,7 @@ def test_viewer_visual_controls_apply_on_commit_and_show_active_overlay(
     ]
     assert len(overlay_texts) == 1
     overlay_text = overlay_texts[0].get_text()
+    assert f"ZOOM {viewer._current_zoom_percentage():05.1f}%" in overlay_text
     assert "ATOM 025.0%" in overlay_text
     assert "MESH 035.0%" in overlay_text
     assert "LINE 2.40px" in overlay_text
@@ -1485,6 +4780,44 @@ def test_viewer_supports_point_atoms_and_autoscale(qapp, tmp_path):
         viewer._default_view_radius(viewer.current_structure)
     )
     assert viewer._view_radius < 50.0
+    overlay_texts = [
+        text
+        for text in viewer._axis.texts
+        if getattr(text, "get_gid", lambda: None)() == "active-visual-settings"
+    ]
+    assert len(overlay_texts) == 1
+    assert "ZOOM 100.0%" in overlay_texts[0].get_text()
+    window.close()
+
+
+def test_viewer_rebases_default_zoom_around_legacy_two_hundred_percent(
+    qapp,
+    tmp_path,
+):
+    del qapp
+    structure_path = _write_xyz(
+        tmp_path / "viewer_zoom_rebase.xyz",
+        [
+            "4",
+            "viewer zoom rebase",
+            "C 0.0 0.0 0.0",
+            "H 0.9 0.0 0.0",
+            "H -0.45 0.78 0.0",
+            "H -0.45 -0.78 0.0",
+        ],
+    )
+    window = ElectronDensityMappingMainWindow(
+        initial_input_path=structure_path
+    )
+    viewer = window.structure_viewer
+
+    assert viewer._view_radius == pytest.approx(
+        viewer._legacy_default_view_radius(viewer.current_structure) * 0.5
+    )
+    assert viewer._current_zoom_percentage() == pytest.approx(
+        100.0,
+        abs=0.01,
+    )
     window.close()
 
 
@@ -1692,3 +5025,1903 @@ def test_smearing_settings_can_disable_or_smooth_profile(tmp_path):
         smeared.smeared_orientation_average_density,
         smeared.orientation_average_density,
     )
+
+
+def test_smearing_strength_changes_profile_without_increasing_total(
+    tmp_path,
+):
+    structure_path = _write_xyz(
+        tmp_path / "smearing_strength.xyz",
+        [
+            "4",
+            "smearing strength",
+            "O 0.0 0.0 0.0",
+            "H 0.95 0.0 0.0",
+            "H -0.25 0.92 0.0",
+            "H 0.0 0.0 1.8",
+        ],
+    )
+    structure = load_electron_density_structure(structure_path)
+    mesh_settings = _mesh_settings_for_structure(
+        structure,
+        rstep=0.1,
+        theta_divisions=24,
+        phi_divisions=18,
+    )
+
+    baseline = compute_electron_density_profile(
+        structure,
+        mesh_settings,
+        smearing_settings=ElectronDensitySmearingSettings(
+            debye_waller_factor=0.0
+        ),
+    )
+    light_smear = compute_electron_density_profile(
+        structure,
+        mesh_settings,
+        smearing_settings=ElectronDensitySmearingSettings(
+            debye_waller_factor=0.001
+        ),
+    )
+    heavy_smear = compute_electron_density_profile(
+        structure,
+        mesh_settings,
+        smearing_settings=ElectronDensitySmearingSettings(
+            debye_waller_factor=0.04
+        ),
+    )
+
+    baseline_density = np.asarray(
+        baseline.orientation_average_density,
+        dtype=float,
+    )
+    light_density = np.asarray(
+        light_smear.smeared_orientation_average_density,
+        dtype=float,
+    )
+    heavy_density = np.asarray(
+        heavy_smear.smeared_orientation_average_density,
+        dtype=float,
+    )
+    shell_volumes = np.asarray(baseline.shell_volumes, dtype=float)
+    baseline_total = float(np.sum(baseline_density * shell_volumes))
+    light_total = float(np.sum(light_density * shell_volumes))
+    heavy_total = float(np.sum(heavy_density * shell_volumes))
+
+    assert light_total <= baseline_total + 1.0e-9
+    assert heavy_total <= baseline_total + 1.0e-9
+    assert not np.allclose(light_density, heavy_density)
+    assert np.linalg.norm(light_density - baseline_density) < np.linalg.norm(
+        heavy_density - baseline_density
+    )
+
+
+def _build_distribution_workspace_inputs(
+    tmp_path,
+) -> tuple[Path, Path, Path]:
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    distribution_root = project_dir / "saved_distributions" / "dist_demo"
+    distribution_root.mkdir(parents=True)
+    (distribution_root / "distribution.json").write_text(
+        json.dumps(
+            {
+                "distribution_id": "dist_demo",
+                "component_artifacts_ready": False,
+                "prior_artifacts_ready": True,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    clusters_dir = tmp_path / "clusters"
+    first_dir = clusters_dir / "PbI2"
+    second_dir = clusters_dir / "PbI3"
+    first_dir.mkdir(parents=True)
+    second_dir.mkdir(parents=True)
+    _write_xyz(
+        first_dir / "frame_0001.xyz",
+        [
+            "3",
+            "PbI2 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+    )
+    _write_xyz(
+        second_dir / "frame_0001.xyz",
+        [
+            "4",
+            "PbI3 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+            "I 0.0 0.0 2.8",
+        ],
+    )
+    return project_dir, distribution_root, clusters_dir
+
+
+def test_main_window_restores_non_pushed_workspace_state(
+    qapp,
+    tmp_path,
+):
+    project_dir, distribution_root, clusters_dir = (
+        _build_distribution_workspace_inputs(tmp_path)
+    )
+    workspace_state_path = (
+        distribution_root / "electron_density_mapping" / "workspace_state.json"
+    )
+    summary_path = (
+        distribution_root
+        / "electron_density_mapping"
+        / "born_approximation_component_summary.json"
+    )
+
+    window = ElectronDensityMappingMainWindow(
+        initial_project_dir=project_dir,
+        initial_input_path=clusters_dir,
+        initial_output_dir=distribution_root / "electron_density_mapping",
+        initial_distribution_id="dist_demo",
+        initial_distribution_root_dir=distribution_root,
+        preview_mode=False,
+    )
+
+    window.run_button.click()
+    _wait_for(
+        lambda: all(
+            state.profile_result is not None
+            for state in window._cluster_group_states
+        )
+        and window._calculation_thread is None,
+        qapp,
+    )
+    window.apply_fourier_to_all_button.setChecked(True)
+    window.evaluate_fourier_button.click()
+    qapp.processEvents()
+
+    assert all(
+        state.transform_result is not None
+        for state in window._cluster_group_states
+    )
+    assert workspace_state_path.is_file()
+    assert not summary_path.is_file()
+    window.close()
+
+    restored = ElectronDensityMappingMainWindow(
+        initial_project_dir=project_dir,
+        initial_input_path=clusters_dir,
+        initial_output_dir=distribution_root / "electron_density_mapping",
+        initial_distribution_id="dist_demo",
+        initial_distribution_root_dir=distribution_root,
+        preview_mode=False,
+    )
+    qapp.processEvents()
+
+    assert all(
+        state.profile_result is not None
+        for state in restored._cluster_group_states
+    )
+    assert all(
+        state.transform_result is not None
+        for state in restored._cluster_group_states
+    )
+    assert restored.push_to_model_button.isEnabled()
+    restored.close()
+
+
+def test_main_window_restores_smearing_autosave_workspace_setting(
+    qapp,
+    tmp_path,
+):
+    project_dir, distribution_root, clusters_dir = (
+        _build_distribution_workspace_inputs(tmp_path)
+    )
+    workspace_state_path = (
+        distribution_root / "electron_density_mapping" / "workspace_state.json"
+    )
+
+    window = ElectronDensityMappingMainWindow(
+        initial_project_dir=project_dir,
+        initial_input_path=clusters_dir,
+        initial_output_dir=distribution_root / "electron_density_mapping",
+        initial_distribution_id="dist_demo",
+        initial_distribution_root_dir=distribution_root,
+        preview_mode=False,
+    )
+
+    window.run_button.click()
+    _wait_for(
+        lambda: all(
+            state.profile_result is not None
+            for state in window._cluster_group_states
+        )
+        and window._calculation_thread is None,
+        qapp,
+    )
+
+    window.auto_save_smearing_outputs_checkbox.setChecked(True)
+    qapp.processEvents()
+
+    assert workspace_state_path.is_file()
+    workspace_payload = json.loads(
+        workspace_state_path.read_text(encoding="utf-8")
+    )
+    assert workspace_payload["auto_save_smearing_outputs"] is True
+    window.close()
+
+    restored = ElectronDensityMappingMainWindow(
+        initial_project_dir=project_dir,
+        initial_input_path=clusters_dir,
+        initial_output_dir=distribution_root / "electron_density_mapping",
+        initial_distribution_id="dist_demo",
+        initial_distribution_root_dir=distribution_root,
+        preview_mode=False,
+    )
+    _wait_for(
+        lambda: restored.cluster_group_table.rowCount() == 2,
+        qapp,
+    )
+
+    assert restored.auto_save_smearing_outputs_checkbox.isChecked()
+    restored.close()
+
+
+def test_main_window_restores_debye_scattering_workspace_state(
+    qapp,
+    tmp_path,
+):
+    project_dir, distribution_root, clusters_dir = (
+        _build_distribution_workspace_inputs(tmp_path)
+    )
+    workspace_state_path = (
+        distribution_root / "electron_density_mapping" / "workspace_state.json"
+    )
+
+    window = ElectronDensityMappingMainWindow(
+        initial_project_dir=project_dir,
+        initial_input_path=clusters_dir,
+        initial_output_dir=distribution_root / "electron_density_mapping",
+        initial_distribution_id="dist_demo",
+        initial_distribution_root_dir=distribution_root,
+        preview_mode=False,
+    )
+
+    window.run_button.click()
+    _wait_for(
+        lambda: all(
+            state.profile_result is not None
+            for state in window._cluster_group_states
+        )
+        and window._calculation_thread is None,
+        qapp,
+    )
+    window.apply_fourier_to_all_button.setChecked(True)
+    window.evaluate_fourier_button.click()
+    qapp.processEvents()
+    window.apply_debye_to_all_button.setChecked(True)
+    window.calculate_debye_scattering_button.click()
+    qapp.processEvents()
+
+    assert workspace_state_path.is_file()
+    workspace_payload = json.loads(
+        workspace_state_path.read_text(encoding="utf-8")
+    )
+    assert all(
+        group_payload.get("debye_scattering_result") is not None
+        for group_payload in workspace_payload["cluster_groups"]
+    )
+    window.close()
+
+    restored = ElectronDensityMappingMainWindow(
+        initial_project_dir=project_dir,
+        initial_input_path=clusters_dir,
+        initial_output_dir=distribution_root / "electron_density_mapping",
+        initial_distribution_id="dist_demo",
+        initial_distribution_root_dir=distribution_root,
+        preview_mode=False,
+    )
+    qapp.processEvents()
+
+    assert all(
+        state.debye_scattering_result is not None
+        for state in restored._cluster_group_states
+    )
+    assert restored.open_debye_scattering_compare_button.isEnabled()
+    restored.open_debye_scattering_compare_button.click()
+    qapp.processEvents()
+    assert restored._debye_scattering_compare_dialog is not None
+    assert (
+        restored._debye_scattering_compare_dialog._trace_table.rowCount() == 2
+    )
+    restored._debye_scattering_compare_dialog.close()
+    restored.close()
+
+
+def test_main_window_restores_single_atom_debye_workspace_state(
+    qapp,
+    tmp_path,
+):
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    distribution_root = tmp_path / "distribution"
+    distribution_root.mkdir()
+    clusters_dir = tmp_path / "clusters"
+    single_dir = clusters_dir / "I"
+    multi_dir = clusters_dir / "PbI2"
+    single_dir.mkdir(parents=True)
+    multi_dir.mkdir(parents=True)
+    _write_xyz(
+        single_dir / "frame_0001.xyz",
+        [
+            "1",
+            "single iodine 1",
+            "I 0.0 0.0 0.0",
+        ],
+    )
+    _write_xyz(
+        single_dir / "frame_0002.xyz",
+        [
+            "1",
+            "single iodine 2",
+            "I 1.0 2.0 3.0",
+        ],
+    )
+    _write_xyz(
+        multi_dir / "frame_0001.xyz",
+        [
+            "3",
+            "PbI2 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+    )
+    workspace_state_path = (
+        distribution_root / "electron_density_mapping" / "workspace_state.json"
+    )
+
+    window = ElectronDensityMappingMainWindow(
+        initial_project_dir=project_dir,
+        initial_input_path=clusters_dir,
+        initial_output_dir=distribution_root / "electron_density_mapping",
+        initial_distribution_id="dist_demo",
+        initial_distribution_root_dir=distribution_root,
+        preview_mode=False,
+    )
+    window.run_button.click()
+    _wait_for(
+        lambda: window._calculation_thread is None
+        and window._cluster_group_state_by_key("I") is not None
+        and window._cluster_group_state_by_key("I").transform_result
+        is not None,
+        qapp,
+    )
+
+    assert workspace_state_path.is_file()
+    assert window._cluster_group_state_by_key("I").transform_result is not None
+    window.close()
+
+    restored = ElectronDensityMappingMainWindow(
+        initial_project_dir=project_dir,
+        initial_input_path=clusters_dir,
+        initial_output_dir=distribution_root / "electron_density_mapping",
+        initial_distribution_id="dist_demo",
+        initial_distribution_root_dir=distribution_root,
+        preview_mode=False,
+    )
+    _wait_for(
+        lambda: restored._cluster_group_state_by_key("I") is not None
+        and restored._cluster_group_state_by_key("I").transform_result
+        is not None,
+        qapp,
+    )
+
+    assert restored._cluster_group_state_by_key("I").profile_result is None
+    assert (
+        restored._cluster_group_state_by_key("I").transform_result is not None
+    )
+    row_by_key = {
+        restored.cluster_group_table.item(row_index, 0).text(): row_index
+        for row_index in range(restored.cluster_group_table.rowCount())
+    }
+    assert restored.cluster_group_table.item(row_by_key["I"], 7).text() == (
+        "Ready (Debye)"
+    )
+    restored.close()
+
+
+def test_main_window_imports_project_debye_waller_terms_for_smearing_defaults(
+    qapp,
+    tmp_path,
+):
+    del qapp
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    summary_path = _write_project_debye_waller_analysis(project_dir, tmp_path)
+
+    window = ElectronDensityMappingMainWindow(initial_project_dir=project_dir)
+
+    assert window._project_debye_waller_source_path == summary_path
+    assert window._active_smearing_settings.uses_pair_specific_terms
+    assert len(window._active_smearing_settings.pair_specific_terms) > 0
+    assert (
+        window._active_smearing_settings.pair_specific_terms
+        == window._active_smearing_settings.imported_pair_specific_terms
+    )
+    assert "Pair-specific Debye-Waller terms are selected by default" in (
+        window.smearing_summary_value.text()
+    )
+    window.close()
+
+
+def test_profile_result_serialization_preserves_project_debye_waller_terms(
+    qapp,
+    tmp_path,
+):
+    del qapp
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+    _write_project_debye_waller_analysis(project_dir, tmp_path)
+
+    window = ElectronDensityMappingMainWindow(initial_project_dir=project_dir)
+    structure_path = _write_xyz(
+        tmp_path / "smearing_pair_terms.xyz",
+        [
+            "3",
+            "pair-specific smearing terms",
+            "O 0.0 0.0 0.0",
+            "H 0.9 0.0 0.0",
+            "H -0.3 0.8 0.0",
+        ],
+    )
+    structure = load_electron_density_structure(structure_path)
+    profile_result = compute_electron_density_profile(
+        structure,
+        _mesh_settings_for_structure(structure, rstep=0.2),
+        smearing_settings=window._smearing_settings_from_controls(),
+    )
+
+    payload = window._serialize_profile_result(profile_result)
+    restored = window._deserialize_profile_result(payload)
+
+    assert restored.smearing_settings.uses_pair_specific_terms
+    assert (
+        restored.smearing_settings.debye_waller_mode
+        == profile_result.smearing_settings.debye_waller_mode
+    )
+    assert (
+        restored.smearing_settings.pair_specific_terms
+        == profile_result.smearing_settings.pair_specific_terms
+    )
+    assert (
+        restored.smearing_settings.imported_pair_specific_terms
+        == profile_result.smearing_settings.imported_pair_specific_terms
+    )
+    window.close()
+
+
+def test_main_window_push_to_model_writes_and_restores_born_components(
+    qapp,
+    tmp_path,
+):
+    project_dir, distribution_root, clusters_dir = (
+        _build_distribution_workspace_inputs(tmp_path)
+    )
+
+    pushed_payloads: list[dict[str, object]] = []
+    window = ElectronDensityMappingMainWindow(
+        initial_project_dir=project_dir,
+        initial_input_path=clusters_dir,
+        initial_output_dir=distribution_root / "electron_density_mapping",
+        initial_distribution_id="dist_demo",
+        initial_distribution_root_dir=distribution_root,
+        preview_mode=False,
+    )
+    window.born_components_built.connect(
+        lambda payload: pushed_payloads.append(dict(payload))
+    )
+
+    assert window.windowTitle() == "Electron Density Mapping"
+    assert "Computed Distribution Mode" in window.preview_mode_banner.text()
+    assert window.cluster_group_table.rowCount() == 2
+    assert not window.push_to_model_button.isEnabled()
+
+    window.run_button.click()
+    _wait_for(
+        lambda: all(
+            state.profile_result is not None
+            for state in window._cluster_group_states
+        )
+        and window._calculation_thread is None,
+        qapp,
+    )
+
+    for row_index in range(window.cluster_group_table.rowCount()):
+        window.cluster_group_table.selectRow(row_index)
+        qapp.processEvents()
+        window.evaluate_fourier_button.click()
+        assert window._active_cluster_group_state() is not None
+        assert (
+            window._active_cluster_group_state().transform_result is not None
+        )
+
+    assert window.push_to_model_button.isEnabled()
+    window.push_to_model_button.click()
+
+    component_map_path = distribution_root / "md_saxs_map.json"
+    summary_path = (
+        distribution_root
+        / "electron_density_mapping"
+        / "born_approximation_component_summary.json"
+    )
+    assert component_map_path.is_file()
+    assert summary_path.is_file()
+    component_map = json.loads(component_map_path.read_text(encoding="utf-8"))
+    assert component_map["saxs_map"]["PbI2"]["no_motif"] == "PbI2_no_motif.txt"
+    assert component_map["saxs_map"]["PbI3"]["no_motif"] == "PbI3_no_motif.txt"
+    assert pushed_payloads
+    assert pushed_payloads[-1]["distribution_id"] == "dist_demo"
+
+    restored = ElectronDensityMappingMainWindow(
+        initial_project_dir=project_dir,
+        initial_input_path=clusters_dir,
+        initial_output_dir=distribution_root / "electron_density_mapping",
+        initial_distribution_id="dist_demo",
+        initial_distribution_root_dir=distribution_root,
+        preview_mode=False,
+    )
+    qapp.processEvents()
+
+    assert restored.cluster_group_table.rowCount() == 2
+    assert all(
+        state.transform_result is not None
+        for state in restored._cluster_group_states
+    )
+    assert restored.push_to_model_button.isEnabled()
+    assert restored._selected_cluster_group_key == "PbI3"
+    restored.close()
+    window.close()
+
+
+def test_reset_calculations_clears_persisted_workspace_state_and_history(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    project_dir, distribution_root, clusters_dir = (
+        _build_distribution_workspace_inputs(tmp_path)
+    )
+    workspace_state_path = (
+        distribution_root / "electron_density_mapping" / "workspace_state.json"
+    )
+    saved_history_path = (
+        distribution_root
+        / "electron_density_mapping"
+        / "saved_output_history.json"
+    )
+    preview_history_path = (
+        distribution_root
+        / "electron_density_mapping"
+        / "electron_density_saved_output_history.json"
+    )
+    window = ElectronDensityMappingMainWindow(
+        initial_project_dir=project_dir,
+        initial_input_path=clusters_dir,
+        initial_output_dir=distribution_root / "electron_density_mapping",
+        initial_distribution_id="dist_demo",
+        initial_distribution_root_dir=distribution_root,
+        preview_mode=False,
+    )
+
+    window.run_button.click()
+    _wait_for(
+        lambda: all(
+            state.profile_result is not None
+            for state in window._cluster_group_states
+        )
+        and window._calculation_thread is None,
+        qapp,
+    )
+    window.apply_fourier_to_all_button.setChecked(True)
+    window.evaluate_fourier_button.click()
+    qapp.processEvents()
+
+    assert workspace_state_path.is_file()
+    assert saved_history_path.is_file()
+
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.ui.main_window.QInputDialog.getText",
+        lambda *args, **kwargs: ("RESET", True),
+    )
+    window.reset_calculations_button.click()
+    qapp.processEvents()
+
+    assert not workspace_state_path.exists()
+    assert not saved_history_path.exists()
+    assert not preview_history_path.exists()
+    assert window.output_history_table.rowCount() == 0
+    window.close()
+
+    restored = ElectronDensityMappingMainWindow(
+        initial_project_dir=project_dir,
+        initial_input_path=clusters_dir,
+        initial_output_dir=distribution_root / "electron_density_mapping",
+        initial_distribution_id="dist_demo",
+        initial_distribution_root_dir=distribution_root,
+        preview_mode=False,
+    )
+    qapp.processEvents()
+
+    assert all(
+        state.profile_result is None and state.transform_result is None
+        for state in restored._cluster_group_states
+    )
+    assert restored.output_history_table.rowCount() == 0
+    assert not restored.push_to_model_button.isEnabled()
+    restored.close()
+
+
+def test_cluster_group_table_starts_collapsed(qapp, tmp_path):
+    clusters_dir = tmp_path / "clusters"
+    first_dir = clusters_dir / "PbI2"
+    second_dir = clusters_dir / "PbI3"
+    first_dir.mkdir(parents=True)
+    second_dir.mkdir(parents=True)
+    _write_xyz(
+        first_dir / "frame_0001.xyz",
+        [
+            "3",
+            "PbI2 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+    )
+    _write_xyz(
+        second_dir / "frame_0001.xyz",
+        [
+            "4",
+            "PbI3 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+            "I 0.0 0.0 2.8",
+        ],
+    )
+
+    window = ElectronDensityMappingMainWindow(initial_input_path=clusters_dir)
+
+    assert window.cluster_group_table.rowCount() == 2
+    assert not window.cluster_group_table_section.is_expanded
+
+    window.cluster_group_table_section.expand()
+
+    assert window.cluster_group_table_section.is_expanded
+    window.close()
+
+
+def test_cluster_group_selection_preserves_zoom_percentage(
+    qapp,
+    tmp_path,
+):
+    clusters_dir = tmp_path / "clusters"
+    first_dir = clusters_dir / "PbI2"
+    second_dir = clusters_dir / "PbI3"
+    first_dir.mkdir(parents=True)
+    second_dir.mkdir(parents=True)
+    _write_xyz(
+        first_dir / "frame_0001.xyz",
+        [
+            "3",
+            "PbI2 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+    )
+    _write_xyz(
+        second_dir / "frame_0001.xyz",
+        [
+            "4",
+            "PbI3 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+            "I 0.0 0.0 2.8",
+        ],
+    )
+
+    window = ElectronDensityMappingMainWindow(initial_input_path=clusters_dir)
+    viewer = window.structure_viewer
+
+    viewer._view_radius = (
+        viewer._default_view_radius(viewer.current_structure) / 1.6
+    )
+    zoom_percentage = viewer._current_zoom_percentage()
+
+    window.cluster_group_table.selectRow(1)
+    qapp.processEvents()
+
+    assert window._selected_cluster_group_key == "PbI3"
+    assert viewer.current_structure is not None
+    assert viewer._current_zoom_percentage() == pytest.approx(zoom_percentage)
+    assert viewer._view_radius == pytest.approx(
+        viewer._default_view_radius(viewer.current_structure)
+        / (zoom_percentage / 100.0)
+    )
+    window.close()
+
+
+def test_cluster_group_initial_selection_starts_at_hundred_percent_zoom(
+    qapp,
+    tmp_path,
+):
+    clusters_dir = _write_cluster_folder_input(tmp_path / "clusters")
+    window = ElectronDensityMappingMainWindow(initial_input_path=clusters_dir)
+    viewer = window.structure_viewer
+
+    assert viewer.current_structure is not None
+    assert viewer.current_mesh_geometry is not None
+    assert viewer._current_zoom_percentage() == pytest.approx(
+        100.0,
+        abs=0.01,
+    )
+
+    overlay_texts = [
+        text
+        for text in viewer._axis.texts
+        if getattr(text, "get_gid", lambda: None)() == "active-visual-settings"
+    ]
+    assert len(overlay_texts) == 1
+    assert "ZOOM 100.0%" in overlay_texts[0].get_text()
+    window.close()
+
+
+def test_cluster_group_shared_mesh_rmax_survives_reference_element_updates(
+    qapp,
+    tmp_path,
+):
+    clusters_dir = tmp_path / "clusters"
+    first_dir = clusters_dir / "I2"
+    second_dir = clusters_dir / "PbI2"
+    first_dir.mkdir(parents=True)
+    second_dir.mkdir(parents=True)
+    _write_xyz(
+        first_dir / "frame_0001.xyz",
+        [
+            "2",
+            "I2 cluster",
+            "I 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+        ],
+    )
+    _write_xyz(
+        second_dir / "frame_0001.xyz",
+        [
+            "3",
+            "PbI2 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+    )
+
+    window = ElectronDensityMappingMainWindow(initial_input_path=clusters_dir)
+    viewer = window.structure_viewer
+    expected_rmax = max(
+        float(state.reference_structure.rmax)
+        for state in window._cluster_group_states
+    )
+
+    def mesh_line_count() -> int:
+        return sum(
+            1
+            for line in viewer._axis.get_lines()
+            if str(line.get_color()).lower() == str(viewer._mesh_color).lower()
+        )
+
+    assert window.rmax_spin.value() == pytest.approx(expected_rmax, abs=1.0e-4)
+    assert window._active_mesh_settings.rmax == pytest.approx(
+        expected_rmax,
+        abs=1.0e-4,
+    )
+    assert window._mesh_settings_from_controls().rmax == pytest.approx(
+        expected_rmax,
+        abs=1.0e-4,
+    )
+    assert viewer.current_mesh_geometry is not None
+    assert viewer.current_mesh_geometry.domain_max_radius == pytest.approx(
+        expected_rmax
+    )
+    assert mesh_line_count() > 0
+
+    window._apply_center_mode("reference_element")
+    qapp.processEvents()
+    window.update_mesh_button.click()
+    qapp.processEvents()
+
+    assert window._active_mesh_settings.rmax == pytest.approx(
+        expected_rmax,
+        abs=1.0e-4,
+    )
+    assert viewer.current_mesh_geometry is not None
+    assert viewer.current_mesh_geometry.domain_max_radius == pytest.approx(
+        expected_rmax,
+        abs=1.0e-4,
+    )
+
+    window.cluster_group_table.selectRow(1)
+    qapp.processEvents()
+
+    assert viewer.current_mesh_geometry is not None
+    assert viewer.current_mesh_geometry.domain_max_radius == pytest.approx(
+        expected_rmax,
+        abs=1.0e-4,
+    )
+    assert viewer._current_zoom_percentage() == pytest.approx(
+        100.0,
+        abs=0.01,
+    )
+    assert mesh_line_count() > 0
+    window.close()
+
+
+def test_cluster_group_reload_resets_zoom_to_hundred_percent(
+    qapp,
+    tmp_path,
+):
+    initial_clusters = _write_cluster_folder_input(
+        tmp_path / "clusters_initial"
+    )
+    replacement_clusters = _write_cluster_folder_input(
+        tmp_path / "clusters_replacement"
+    )
+    window = ElectronDensityMappingMainWindow(
+        initial_input_path=initial_clusters
+    )
+    viewer = window.structure_viewer
+
+    viewer._view_radius = (
+        viewer._default_view_radius(viewer.current_structure) / 0.13
+    )
+    viewer._draw_view(reset_view=False)
+    assert viewer._current_zoom_percentage() == pytest.approx(13.0)
+
+    window._load_input_path(replacement_clusters)
+    qapp.processEvents()
+
+    assert viewer.current_structure is not None
+    assert viewer.current_mesh_geometry is not None
+    assert viewer._current_zoom_percentage() == pytest.approx(100.0)
+    window.close()
+
+
+def test_cluster_group_table_center_element_defaults_to_heaviest_per_stoichiometry(
+    qapp,
+    tmp_path,
+):
+    clusters_dir = tmp_path / "clusters"
+    first_dir = clusters_dir / "NaCl"
+    second_dir = clusters_dir / "PbI2"
+    first_dir.mkdir(parents=True)
+    second_dir.mkdir(parents=True)
+    _write_xyz(
+        first_dir / "frame_0001.xyz",
+        [
+            "2",
+            "NaCl cluster",
+            "Na 0.0 0.0 0.0",
+            "Cl 2.5 0.0 0.0",
+        ],
+    )
+    _write_xyz(
+        second_dir / "frame_0001.xyz",
+        [
+            "3",
+            "PbI2 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+    )
+
+    window = ElectronDensityMappingMainWindow(initial_input_path=clusters_dir)
+    center_element_column = _table_column_index(
+        window.cluster_group_table,
+        "Center Element",
+    )
+    row_by_key = {
+        window.cluster_group_table.item(row_index, 0).text(): row_index
+        for row_index in range(window.cluster_group_table.rowCount())
+    }
+
+    nacl_combo = window.cluster_group_table.cellWidget(
+        row_by_key["NaCl"],
+        center_element_column,
+    )
+    pbi2_combo = window.cluster_group_table.cellWidget(
+        row_by_key["PbI2"],
+        center_element_column,
+    )
+
+    assert nacl_combo is not None
+    assert pbi2_combo is not None
+    assert nacl_combo.currentData() == "Cl"
+    assert pbi2_combo.currentData() == "Pb"
+
+    window.cluster_group_table.selectRow(row_by_key["NaCl"])
+    qapp.processEvents()
+    assert window.reference_element_combo.currentData() == "Cl"
+
+    window.cluster_group_table.selectRow(row_by_key["PbI2"])
+    qapp.processEvents()
+    assert window.reference_element_combo.currentData() == "Pb"
+    window.close()
+
+
+def test_cluster_group_reference_element_dropdown_is_per_row_and_used_on_group_run(
+    qapp,
+    tmp_path,
+):
+    clusters_dir = tmp_path / "clusters"
+    first_dir = clusters_dir / "PbI2"
+    second_dir = clusters_dir / "CsI"
+    first_dir.mkdir(parents=True)
+    second_dir.mkdir(parents=True)
+    _write_xyz(
+        first_dir / "frame_0001.xyz",
+        [
+            "3",
+            "PbI2 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+    )
+    _write_xyz(
+        second_dir / "frame_0001.xyz",
+        [
+            "2",
+            "CsI cluster",
+            "Cs 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+        ],
+    )
+
+    window = ElectronDensityMappingMainWindow(initial_input_path=clusters_dir)
+    center_element_column = _table_column_index(
+        window.cluster_group_table,
+        "Center Element",
+    )
+    row_by_key = {
+        window.cluster_group_table.item(row_index, 0).text(): row_index
+        for row_index in range(window.cluster_group_table.rowCount())
+    }
+
+    window._apply_center_mode("reference_element")
+
+    pbi2_combo = window.cluster_group_table.cellWidget(
+        row_by_key["PbI2"],
+        center_element_column,
+    )
+    assert pbi2_combo is not None
+    pbi2_combo.setCurrentIndex(max(pbi2_combo.findData("I"), 0))
+    qapp.processEvents()
+
+    window.cluster_group_table.selectRow(row_by_key["CsI"])
+    qapp.processEvents()
+    csi_combo = window.cluster_group_table.cellWidget(
+        row_by_key["CsI"],
+        center_element_column,
+    )
+    assert csi_combo is not None
+    assert csi_combo.currentData() == "Cs"
+    assert window.reference_element_combo.currentData() == "Cs"
+
+    window.cluster_group_table.selectRow(row_by_key["PbI2"])
+    qapp.processEvents()
+    assert window.reference_element_combo.currentData() == "I"
+
+    window.run_button.click()
+    _wait_for(
+        lambda: all(
+            state.profile_result is not None
+            for state in window._cluster_group_states
+        )
+        and window._calculation_thread is None,
+        qapp,
+    )
+
+    states_by_key = {
+        state.key: state for state in window._cluster_group_states
+    }
+    assert states_by_key["PbI2"].profile_result is not None
+    assert states_by_key["CsI"].profile_result is not None
+    assert (
+        states_by_key["PbI2"].profile_result.structure.reference_element == "I"
+    )
+    assert (
+        states_by_key["CsI"].profile_result.structure.reference_element == "Cs"
+    )
+    window.close()
+
+
+def test_cluster_group_mesh_settings_remain_shared_after_row_switches(
+    qapp,
+    tmp_path,
+):
+    clusters_dir = _write_cluster_folder_input(tmp_path / "clusters")
+    window = ElectronDensityMappingMainWindow(initial_input_path=clusters_dir)
+
+    window.rstep_spin.setValue(0.2)
+    window.theta_divisions_spin.setValue(36)
+    window.phi_divisions_spin.setValue(24)
+    window.rmax_spin.setValue(7.5)
+    window.update_mesh_button.click()
+    window.run_button.click()
+    _wait_for(
+        lambda: all(
+            state.profile_result is not None
+            for state in window._cluster_group_states
+        )
+        and window._calculation_thread is None,
+        qapp,
+    )
+
+    stored_mesh_settings = window._cluster_group_states[
+        0
+    ].profile_result.mesh_geometry.settings
+    assert stored_mesh_settings.rstep == pytest.approx(0.2)
+
+    window.rstep_spin.setValue(0.35)
+    window.theta_divisions_spin.setValue(48)
+    window.phi_divisions_spin.setValue(30)
+    window.rmax_spin.setValue(8.25)
+    window.update_mesh_button.click()
+
+    window.cluster_group_table.selectRow(1)
+    qapp.processEvents()
+
+    assert window._active_mesh_settings.rstep == pytest.approx(0.35)
+    assert window._active_mesh_settings.theta_divisions == 48
+    assert window._active_mesh_settings.phi_divisions == 30
+    assert window._active_mesh_settings.rmax == pytest.approx(8.25)
+    assert window.rstep_spin.value() == pytest.approx(0.35)
+    assert window.theta_divisions_spin.value() == 48
+    assert window.phi_divisions_spin.value() == 30
+    assert window.rmax_spin.value() == pytest.approx(8.25)
+
+    window.cluster_group_table.selectRow(0)
+    qapp.processEvents()
+
+    assert window._active_mesh_settings.rstep == pytest.approx(0.35)
+    assert window._active_mesh_settings.theta_divisions == 48
+    assert window._active_mesh_settings.phi_divisions == 30
+    assert window._active_mesh_settings.rmax == pytest.approx(8.25)
+    assert window.rstep_spin.value() == pytest.approx(0.35)
+    assert window.theta_divisions_spin.value() == 48
+    assert window.phi_divisions_spin.value() == 30
+    assert window.rmax_spin.value() == pytest.approx(8.25)
+    window.close()
+
+
+def test_cluster_group_table_stores_center_mode_and_reference_details(
+    qapp,
+    tmp_path,
+):
+    clusters_dir = _write_cluster_folder_input(tmp_path / "clusters")
+    window = ElectronDensityMappingMainWindow(initial_input_path=clusters_dir)
+    table = window.cluster_group_table
+    mode_column = _table_column_index(table, "Center Mode")
+    ref_column = _table_column_index(table, "Center Ref")
+    element_column = _table_column_index(table, "Center Element")
+
+    for row_index, state in enumerate(window._cluster_group_states):
+        mode_item = table.item(row_index, mode_column)
+        ref_item = table.item(row_index, ref_column)
+        combo = table.cellWidget(row_index, element_column)
+        assert mode_item is not None
+        assert ref_item is not None
+        assert mode_item.text() == "Mass COM"
+        assert ref_item.text() == "COM"
+        assert (
+            combo.currentData() == state.reference_structure.reference_element
+        )
+
+    window._apply_center_mode("nearest_atom")
+    qapp.processEvents()
+
+    for row_index, state in enumerate(window._cluster_group_states):
+        mode_item = table.item(row_index, mode_column)
+        ref_item = table.item(row_index, ref_column)
+        assert mode_item is not None
+        assert ref_item is not None
+        expected_reference = (
+            f"{state.reference_structure.nearest_atom_element} atom "
+            f"#{state.reference_structure.nearest_atom_index + 1}"
+        )
+        assert mode_item.text() == "Nearest Atom"
+        assert ref_item.text() == expected_reference
+        assert "Nearest atom" in ref_item.toolTip()
+
+    window._apply_center_mode("reference_element")
+    qapp.processEvents()
+
+    for row_index, state in enumerate(window._cluster_group_states):
+        mode_item = table.item(row_index, mode_column)
+        ref_item = table.item(row_index, ref_column)
+        combo = table.cellWidget(row_index, element_column)
+        assert mode_item is not None
+        assert ref_item is not None
+        assert (
+            combo.currentData() == state.reference_structure.reference_element
+        )
+        assert mode_item.text() == "Ref Element"
+        assert (
+            ref_item.text()
+            == f"{state.reference_structure.reference_element} geom center"
+        )
+        assert (
+            state.reference_structure.reference_element in ref_item.toolTip()
+        )
+    window.close()
+
+
+def test_cluster_group_row_switch_keeps_mesh_overlay_visible(
+    qapp,
+    tmp_path,
+):
+    clusters_dir = _write_cluster_folder_input(tmp_path / "mesh_clusters")
+    window = ElectronDensityMappingMainWindow(initial_input_path=clusters_dir)
+    viewer = window.structure_viewer
+
+    viewer._mesh_color = "#ff6600"
+    viewer._update_mesh_color_button_style()
+    viewer._draw_view(reset_view=False)
+
+    def mesh_line_count() -> int:
+        return sum(
+            1
+            for line in viewer._axis.get_lines()
+            if str(line.get_color()).lower() == "#ff6600"
+        )
+
+    assert viewer.current_mesh_geometry is not None
+    assert mesh_line_count() > 0
+
+    window.cluster_group_table.selectRow(1)
+    qapp.processEvents()
+
+    assert viewer.current_mesh_geometry is not None
+    assert mesh_line_count() > 0
+
+    window.cluster_group_table.selectRow(0)
+    qapp.processEvents()
+
+    assert viewer.current_mesh_geometry is not None
+    assert mesh_line_count() > 0
+    window.close()
+
+
+def test_cluster_group_selection_restores_per_cluster_viewer_state(
+    qapp,
+    tmp_path,
+):
+    clusters_dir = tmp_path / "clusters"
+    first_dir = clusters_dir / "PbI2"
+    second_dir = clusters_dir / "PbI3"
+    first_dir.mkdir(parents=True)
+    second_dir.mkdir(parents=True)
+    _write_xyz(
+        first_dir / "frame_0001.xyz",
+        [
+            "3",
+            "PbI2 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+    )
+    _write_xyz(
+        second_dir / "frame_0001.xyz",
+        [
+            "4",
+            "PbI3 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+            "I 0.0 0.0 2.8",
+        ],
+    )
+
+    window = ElectronDensityMappingMainWindow(initial_input_path=clusters_dir)
+    viewer = window.structure_viewer
+
+    viewer.atom_contrast_spin.setValue(25.0)
+    viewer.mesh_contrast_spin.setValue(35.0)
+    viewer.mesh_linewidth_spin.setValue(2.4)
+    viewer.show_mesh_checkbox.setChecked(False)
+    viewer.point_atoms_checkbox.setChecked(False)
+    viewer._mesh_color = "#ff6600"
+    viewer._update_mesh_color_button_style()
+    viewer._view_center = np.asarray([0.3, -0.5, 0.8], dtype=float)
+    viewer._view_radius = 6.75
+    viewer._scene_rotation = np.asarray(
+        [
+            [0.0, -1.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=float,
+    )
+    viewer._draw_view(reset_view=False)
+
+    window.cluster_group_table.selectRow(1)
+    qapp.processEvents()
+
+    viewer.atom_contrast_spin.setValue(70.0)
+    viewer.mesh_contrast_spin.setValue(80.0)
+    viewer.mesh_linewidth_spin.setValue(1.1)
+    viewer.show_mesh_checkbox.setChecked(True)
+    viewer.point_atoms_checkbox.setChecked(True)
+    viewer._mesh_color = "#0088cc"
+    viewer._update_mesh_color_button_style()
+    viewer._view_center = np.asarray([-0.2, 0.4, -0.6], dtype=float)
+    viewer._view_radius = 4.25
+    viewer._scene_rotation = np.asarray(
+        [
+            [0.0, 0.0, 1.0],
+            [0.0, 1.0, 0.0],
+            [-1.0, 0.0, 0.0],
+        ],
+        dtype=float,
+    )
+    viewer._draw_view(reset_view=False)
+
+    window.cluster_group_table.selectRow(0)
+    qapp.processEvents()
+
+    assert window._selected_cluster_group_key == "PbI2"
+    assert viewer._atom_contrast == pytest.approx(0.25)
+    assert viewer._mesh_contrast == pytest.approx(0.35)
+    assert viewer._mesh_linewidth == pytest.approx(2.4)
+    assert viewer._mesh_color == "#ff6600"
+    assert not viewer.show_mesh_checkbox.isChecked()
+    assert not viewer.point_atoms_checkbox.isChecked()
+    assert viewer._view_radius == pytest.approx(6.75)
+    assert np.allclose(viewer._view_center, [0.3, -0.5, 0.8])
+    assert np.allclose(
+        viewer._scene_rotation,
+        [
+            [0.0, -1.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+    )
+
+    window.cluster_group_table.selectRow(1)
+    qapp.processEvents()
+
+    assert window._selected_cluster_group_key == "PbI3"
+    assert viewer._atom_contrast == pytest.approx(0.70)
+    assert viewer._mesh_contrast == pytest.approx(0.80)
+    assert viewer._mesh_linewidth == pytest.approx(1.1)
+    assert viewer._mesh_color == "#0088cc"
+    assert viewer.show_mesh_checkbox.isChecked()
+    assert viewer.point_atoms_checkbox.isChecked()
+    assert viewer._view_radius == pytest.approx(4.25)
+    assert np.allclose(viewer._view_center, [-0.2, 0.4, -0.6])
+    assert np.allclose(
+        viewer._scene_rotation,
+        [
+            [0.0, 0.0, 1.0],
+            [0.0, 1.0, 0.0],
+            [-1.0, 0.0, 0.0],
+        ],
+    )
+    window.close()
+
+
+def test_cluster_view_cache_prewarm_prioritizes_more_complex_clusters(
+    qapp,
+    tmp_path,
+):
+    clusters_dir = tmp_path / "clusters"
+    clusters_dir.mkdir(parents=True)
+    cluster_specs = {
+        "PbI1": [
+            "2",
+            "PbI1 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+        ],
+        "PbI4": [
+            "5",
+            "PbI4 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+            "I 0.0 0.0 2.8",
+            "I -2.8 0.0 0.0",
+        ],
+        "PbI2": [
+            "3",
+            "PbI2 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+    }
+    for name, lines in cluster_specs.items():
+        cluster_dir = clusters_dir / name
+        cluster_dir.mkdir()
+        _write_xyz(cluster_dir / "frame_0001.xyz", lines)
+
+    window = ElectronDensityMappingMainWindow(initial_input_path=clusters_dir)
+    viewer = window.structure_viewer
+    viewer._scene_cache_max_entries = 2
+    viewer._scene_cache_max_bytes = 10**9
+
+    window._schedule_cluster_view_cache_prewarm()
+    _wait_for(
+        lambda: not window._cluster_view_cache_prewarm_queue
+        and not window._cluster_view_cache_prewarm_timer.isActive(),
+        qapp,
+    )
+
+    cached_keys = set(viewer._scene_cache.keys())
+    active_key = window._selected_cluster_group_key
+    assert active_key in cached_keys
+    assert "PbI4" in cached_keys
+    assert len(cached_keys) == 2
+    skipped_key = min(
+        (
+            state.key
+            for state in window._cluster_group_states
+            if state.key != active_key and state.key != "PbI4"
+        ),
+        key=lambda key: next(
+            window._cluster_group_render_complexity(state)
+            for state in window._cluster_group_states
+            if state.key == key
+        ),
+    )
+    assert skipped_key not in cached_keys
+    window.close()
+
+
+def test_cluster_group_switch_preserves_mesh_update_confirmation(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    clusters_dir = tmp_path / "clusters"
+    first_dir = clusters_dir / "PbI2"
+    second_dir = clusters_dir / "PbI3"
+    first_dir.mkdir(parents=True)
+    second_dir.mkdir(parents=True)
+    _write_xyz(
+        first_dir / "frame_0001.xyz",
+        [
+            "3",
+            "PbI2 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+    )
+    _write_xyz(
+        second_dir / "frame_0001.xyz",
+        [
+            "4",
+            "PbI3 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+            "I 0.0 0.0 2.8",
+        ],
+    )
+
+    window = ElectronDensityMappingMainWindow(initial_input_path=clusters_dir)
+    prompts: list[str] = []
+
+    def fake_question(*args, **kwargs):
+        del kwargs
+        prompts.append(str(args[2]))
+        return QMessageBox.StandardButton.Yes
+
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.ui.main_window.QMessageBox.question",
+        fake_question,
+    )
+
+    window.update_mesh_button.click()
+    window.cluster_group_table.selectRow(1)
+    qapp.processEvents()
+    window.run_button.click()
+    _wait_for(
+        lambda: all(
+            state.profile_result is not None
+            for state in window._cluster_group_states
+        )
+        and window._calculation_thread is None,
+        qapp,
+    )
+
+    assert not prompts
+    window.close()
+
+
+def test_cluster_group_switch_warns_after_unapplied_mesh_edits(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    clusters_dir = tmp_path / "clusters"
+    first_dir = clusters_dir / "PbI2"
+    second_dir = clusters_dir / "PbI3"
+    first_dir.mkdir(parents=True)
+    second_dir.mkdir(parents=True)
+    _write_xyz(
+        first_dir / "frame_0001.xyz",
+        [
+            "3",
+            "PbI2 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+    )
+    _write_xyz(
+        second_dir / "frame_0001.xyz",
+        [
+            "4",
+            "PbI3 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+            "I 0.0 0.0 2.8",
+        ],
+    )
+
+    window = ElectronDensityMappingMainWindow(initial_input_path=clusters_dir)
+    prompts: list[tuple[str, str]] = []
+
+    def fake_question(*args, **kwargs):
+        del kwargs
+        prompts.append((str(args[1]), str(args[2])))
+        return QMessageBox.StandardButton.No
+
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.ui.main_window.QMessageBox.question",
+        fake_question,
+    )
+
+    window.update_mesh_button.click()
+    window.rstep_spin.setValue(window.rstep_spin.value() + 0.05)
+    window.cluster_group_table.selectRow(1)
+    qapp.processEvents()
+    window.run_button.click()
+    qapp.processEvents()
+
+    assert prompts
+    assert prompts[-1][0] == "Mesh Settings Not Updated"
+    assert window._calculation_thread is None
+    window.close()
+
+
+def test_cluster_group_selection_syncs_fourier_rmax_to_solvent_cutoff(
+    qapp,
+    tmp_path,
+):
+    clusters_dir = tmp_path / "clusters"
+    first_dir = clusters_dir / "PbI2"
+    second_dir = clusters_dir / "PbI3"
+    first_dir.mkdir(parents=True)
+    second_dir.mkdir(parents=True)
+    _write_xyz(
+        first_dir / "frame_0001.xyz",
+        [
+            "3",
+            "PbI2 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+    )
+    _write_xyz(
+        second_dir / "frame_0001.xyz",
+        [
+            "4",
+            "PbI3 cluster",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+            "I 0.0 0.0 2.8",
+        ],
+    )
+
+    window = ElectronDensityMappingMainWindow(initial_input_path=clusters_dir)
+
+    assert window.cluster_group_table.rowCount() == 2
+    window.apply_contrast_to_all_button.setChecked(False)
+
+    window.run_button.click()
+    _wait_for(
+        lambda: all(
+            state.profile_result is not None
+            for state in window._cluster_group_states
+        )
+        and window._calculation_thread is None,
+        qapp,
+    )
+
+    window.solvent_method_combo.setCurrentIndex(
+        window.solvent_method_combo.findData(CONTRAST_SOLVENT_METHOD_DIRECT)
+    )
+
+    cutoff_by_key: dict[str, float] = {}
+    for row_index, state in enumerate(window._cluster_group_states):
+        window.cluster_group_table.selectRow(row_index)
+        qapp.processEvents()
+
+        if row_index == 0:
+            window.evaluate_fourier_button.click()
+            assert state.transform_result is not None
+
+        assert window._profile_result is not None
+        direct_density = float(
+            np.max(
+                np.asarray(
+                    window._profile_result.smeared_orientation_average_density,
+                    dtype=float,
+                )
+            )
+            * 0.5
+        )
+        window.direct_density_spin.setValue(direct_density)
+        window.compute_solvent_density_button.click()
+        qapp.processEvents()
+
+        assert state.profile_result is not None
+        assert state.profile_result.solvent_contrast is not None
+        assert (
+            state.profile_result.solvent_contrast.cutoff_radius_a is not None
+        )
+        cutoff_by_key[state.key] = float(
+            state.profile_result.solvent_contrast.cutoff_radius_a
+        )
+        assert window.fourier_rmax_spin.value() == pytest.approx(
+            cutoff_by_key[state.key],
+            abs=1.0e-4,
+        )
+        assert state.transform_result is None
+
+    for row_index, state in enumerate(window._cluster_group_states):
+        window.cluster_group_table.selectRow(row_index)
+        qapp.processEvents()
+        assert window.fourier_rmax_spin.value() == pytest.approx(
+            cutoff_by_key[state.key],
+            abs=1.0e-4,
+        )
+
+    window.close()
+
+
+def test_cluster_folder_manual_mode_runs_selected_row_and_locks_mesh(
+    qapp,
+    tmp_path,
+):
+    clusters_dir = _write_cluster_folder_input(tmp_path / "manual_clusters")
+    window = ElectronDensityMappingMainWindow(initial_input_path=clusters_dir)
+    window.update_mesh_button.click()
+    window.manual_mode_checkbox.setChecked(True)
+    window.cluster_group_table.selectRow(1)
+    qapp.processEvents()
+
+    window.run_button.click()
+    _wait_for(
+        lambda: window._calculation_thread is None
+        and window._cluster_group_states[1].profile_result is not None,
+        qapp,
+    )
+
+    assert window._cluster_group_states[0].profile_result is None
+    assert window._cluster_group_states[1].profile_result is not None
+    assert "1/2" in window.cluster_completion_tracker_label.text()
+    assert not window.rstep_spin.isEnabled()
+    assert not window.theta_divisions_spin.isEnabled()
+    assert not window.update_mesh_button.isEnabled()
+
+    window.manual_mode_checkbox.setChecked(False)
+    qapp.processEvents()
+
+    assert not window.rstep_spin.isEnabled()
+    assert not window.update_mesh_button.isEnabled()
+
+    window.manual_mode_checkbox.setChecked(True)
+    window.cluster_group_table.selectRow(0)
+    qapp.processEvents()
+    window.run_button.click()
+    _wait_for(
+        lambda: window._calculation_thread is None
+        and all(
+            state.profile_result is not None
+            for state in window._cluster_group_states
+        ),
+        qapp,
+    )
+
+    assert window.cluster_completion_indicator.text() == "COMPLETE"
+    assert "2/2" in window.cluster_completion_tracker_label.text()
+    window.close()
+
+
+def test_reset_calculated_densities_requires_secondary_auth_and_unlocks_mesh(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    clusters_dir = _write_cluster_folder_input(tmp_path / "reset_clusters")
+    window = ElectronDensityMappingMainWindow(initial_input_path=clusters_dir)
+    window.update_mesh_button.click()
+    window.manual_mode_checkbox.setChecked(True)
+    window.run_button.click()
+    _wait_for(
+        lambda: window._calculation_thread is None
+        and window._cluster_group_states[0].profile_result is not None,
+        qapp,
+    )
+
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.ui.main_window.QMessageBox.critical",
+        lambda *args, **kwargs: QMessageBox.StandardButton.Ok,
+    )
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.ui.main_window.QInputDialog.getText",
+        lambda *args, **kwargs: ("not-reset", True),
+    )
+    window.reset_calculations_button.click()
+    qapp.processEvents()
+
+    assert window._cluster_group_states[0].profile_result is not None
+    assert not window.rstep_spin.isEnabled()
+
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.ui.main_window.QInputDialog.getText",
+        lambda *args, **kwargs: ("RESET", True),
+    )
+    window.reset_calculations_button.click()
+    qapp.processEvents()
+
+    assert all(
+        state.profile_result is None and state.transform_result is None
+        for state in window._cluster_group_states
+    )
+    assert window.cluster_completion_indicator.text() == "PENDING"
+    assert "0/2" in window.cluster_completion_tracker_label.text()
+    assert window.rstep_spin.isEnabled()
+    assert window.update_mesh_button.isEnabled()
+    window.close()
+
+
+def test_stop_active_electron_density_calculation_keeps_window_open(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    structure_path = _write_xyz(
+        tmp_path / "stop_density.xyz",
+        [
+            "3",
+            "stop density",
+            "O 0.0 0.0 0.0",
+            "H 0.96 0.0 0.0",
+            "H -0.24 0.93 0.0",
+        ],
+    )
+    original_compute = compute_electron_density_profile_for_input
+
+    def slow_compute(
+        *args, progress_callback=None, cancel_callback=None, **kwargs
+    ):
+        for step in range(10):
+            if progress_callback is not None:
+                progress_callback(step, 10, f"Slow step {step + 1}/10")
+            time.sleep(0.03)
+            if cancel_callback is not None and cancel_callback():
+                raise ElectronDensityCalculationCanceled(
+                    "Electron-density calculation was stopped by the user."
+                )
+        return original_compute(
+            *args,
+            progress_callback=progress_callback,
+            cancel_callback=cancel_callback,
+            **kwargs,
+        )
+
+    monkeypatch.setattr(
+        "saxshell.saxs.electron_density_mapping.ui.main_window.compute_electron_density_profile_for_input",
+        slow_compute,
+    )
+
+    window = ElectronDensityMappingMainWindow(
+        initial_input_path=structure_path
+    )
+    window.update_mesh_button.click()
+    window.run_button.click()
+    _wait_for(lambda: window._calculation_thread is not None, qapp)
+    _wait_for(lambda: window.stop_calculation_button.isEnabled(), qapp)
+
+    window.stop_calculation_button.click()
+    _wait_for(lambda: window._calculation_thread is None, qapp)
+
+    assert window._profile_result is None
+    assert "stopped" in window.calculation_progress_message.text().lower()
+    assert "Slow step" not in window.status_text.toPlainText()
+    assert window.run_button.isEnabled()
+    assert not window.stop_calculation_button.isEnabled()
+    window.close()
+
+
+def test_cluster_folder_run_uses_contiguous_frame_mode_per_stoichiometry(
+    qapp,
+    tmp_path,
+):
+    clusters_dir = tmp_path / "clusters"
+    first_dir = clusters_dir / "PbI2"
+    second_dir = clusters_dir / "PbI3"
+    first_dir.mkdir(parents=True)
+    second_dir.mkdir(parents=True)
+    _write_xyz(
+        first_dir / "frame_0001_AAA.xyz",
+        [
+            "3",
+            "PbI2 frame 1",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+    )
+    _write_xyz(
+        first_dir / "frame_0002_AAA.xyz",
+        [
+            "3",
+            "PbI2 frame 2",
+            "Pb 10.0 0.0 0.0",
+            "I 12.9 0.0 0.0",
+            "I 10.0 2.9 0.0",
+        ],
+    )
+    _write_xyz(
+        second_dir / "frame_0005_AAA.xyz",
+        [
+            "4",
+            "PbI3 frame 5",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+            "I 0.0 0.0 2.8",
+        ],
+    )
+    _write_xyz(
+        second_dir / "frame_0006_AAA.xyz",
+        [
+            "4",
+            "PbI3 frame 6",
+            "Pb 10.0 0.0 0.0",
+            "I 12.9 0.0 0.0",
+            "I 10.0 2.9 0.0",
+            "I 10.0 0.0 2.9",
+        ],
+    )
+
+    window = ElectronDensityMappingMainWindow(initial_input_path=clusters_dir)
+    assert window.contiguous_frame_mode_checkbox.isChecked()
+
+    window.run_button.click()
+    _wait_for(
+        lambda: all(
+            state.profile_result is not None
+            for state in window._cluster_group_states
+        )
+        and window._calculation_thread is None,
+        qapp,
+    )
+
+    assert all(
+        state.profile_result is not None
+        and state.profile_result.contiguous_frame_mode_applied
+        and len(state.profile_result.contiguous_frame_sets) == 1
+        for state in window._cluster_group_states
+    )
+    window.close()
+
+
+def test_cluster_folder_run_reports_specific_progress_with_overall_bar(
+    qapp,
+    tmp_path,
+):
+    clusters_dir = tmp_path / "progress_clusters"
+    first_dir = clusters_dir / "PbI2"
+    second_dir = clusters_dir / "PbI3"
+    first_dir.mkdir(parents=True)
+    second_dir.mkdir(parents=True)
+    _write_xyz(
+        first_dir / "frame_0001_AAA.xyz",
+        [
+            "3",
+            "PbI2 frame 1",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+        ],
+    )
+    _write_xyz(
+        first_dir / "frame_0002_AAA.xyz",
+        [
+            "3",
+            "PbI2 frame 2",
+            "Pb 9.0 0.0 0.0",
+            "I 11.9 0.0 0.0",
+            "I 9.0 2.9 0.0",
+        ],
+    )
+    _write_xyz(
+        second_dir / "frame_0005_AAA.xyz",
+        [
+            "4",
+            "PbI3 frame 5",
+            "Pb 0.0 0.0 0.0",
+            "I 2.8 0.0 0.0",
+            "I 0.0 2.8 0.0",
+            "I 0.0 0.0 2.8",
+        ],
+    )
+    _write_xyz(
+        second_dir / "frame_0006_AAA.xyz",
+        [
+            "4",
+            "PbI3 frame 6",
+            "Pb 9.0 0.0 0.0",
+            "I 11.9 0.0 0.0",
+            "I 9.0 2.9 0.0",
+            "I 9.0 0.0 2.9",
+        ],
+    )
+
+    window = ElectronDensityMappingMainWindow(initial_input_path=clusters_dir)
+
+    window.run_button.click()
+    _wait_for(
+        lambda: all(
+            state.profile_result is not None
+            for state in window._cluster_group_states
+        )
+        and window._calculation_thread is None,
+        qapp,
+    )
+
+    log_text = window.status_text.toPlainText()
+
+    assert not window.calculation_overall_progress_bar.isHidden()
+    assert window.calculation_overall_progress_bar.maximum() == 2
+    assert window.calculation_overall_progress_bar.value() == 2
+    assert "2/2 groups complete" in (
+        window.calculation_overall_progress_message.text().lower()
+    )
+    assert (
+        "Prepared 2 electron-density profiles across 2 stoichiometry folders."
+        in log_text
+    )
+    assert "PbI2: Contiguous-frame evaluation locked 1 frame set" in log_text
+    assert "PbI3: Contiguous-frame evaluation locked 1 frame set" in log_text
+    assert (
+        "Preparing ensemble electron-density calculation for 2 structures"
+        not in (log_text)
+    )
+    assert "Loading structure 1/2: frame_0001_AAA.xyz" not in log_text
+    window.close()

--- a/tests/test_mdtrajectory_cluster.py
+++ b/tests/test_mdtrajectory_cluster.py
@@ -79,6 +79,24 @@ def _disconnected_frame_lines() -> list[str]:
     ]
 
 
+def _smart_shell_frame_lines(
+    *,
+    residue10_y: float,
+    residue11_y: float,
+) -> list[str]:
+    return [
+        "MODEL        1\n",
+        _pdb_atom_line(1, "PB1", "SOL", 1, 0.0, 0.0, 0.0, "Pb"),
+        _pdb_atom_line(2, "I1", "SOL", 1, 1.0, 0.0, 0.0, "I"),
+        _pdb_atom_line(3, "PB2", "SOL", 2, 2.0, 0.0, 0.0, "Pb"),
+        _pdb_atom_line(4, "O1", "WAT", 10, 0.2, residue10_y, 0.0, "O"),
+        _pdb_atom_line(5, "H1", "WAT", 10, 0.2, residue10_y + 0.7, 0.0, "H"),
+        _pdb_atom_line(6, "O1", "WAT", 11, 2.2, residue11_y, 0.0, "O"),
+        _pdb_atom_line(7, "H1", "WAT", 11, 2.2, residue11_y + 0.7, 0.0, "H"),
+        "ENDMDL\n",
+    ]
+
+
 def _connected_xyz_lines() -> list[str]:
     return [
         "5\n",
@@ -357,6 +375,102 @@ def test_shell_atoms_can_control_stoichiometry_bins(tmp_path):
     assert _relative_names(export.written_files) == [
         "Pb2IO/frame_0000_AAA.pdb"
     ]
+
+
+def test_smart_solvation_shells_keep_union_across_contiguous_pdb_frames(
+    tmp_path,
+):
+    frames_dir = tmp_path / "splitpdb0001"
+    frames_dir.mkdir()
+    (frames_dir / "frame_0000.pdb").write_text(
+        "".join(
+            _smart_shell_frame_lines(
+                residue10_y=1.0,
+                residue11_y=4.0,
+            )
+        )
+    )
+    (frames_dir / "frame_0001.pdb").write_text(
+        "".join(
+            _smart_shell_frame_lines(
+                residue10_y=4.0,
+                residue11_y=1.0,
+            )
+        )
+    )
+
+    analyzer = ExtractedFrameFolderClusterAnalyzer(
+        frames_dir=frames_dir,
+        atom_type_definitions=ATOM_TYPE_DEFINITIONS,
+        pair_cutoffs_def=PAIR_CUTOFFS,
+        smart_solvation_shells=True,
+    )
+
+    export = analyzer.export_cluster_pdbs(
+        tmp_path / "clusters_from_folder",
+        shell_levels=(1,),
+        include_shell_levels=(0, 1),
+    )
+
+    assert _relative_names(export.written_files) == [
+        "Pb2I/frame_0000_AAA.pdb",
+        "Pb2I/frame_0001_AAA.pdb",
+    ]
+    for path in export.written_files:
+        structure = PDBStructure.from_file(path)
+        assert {
+            atom.residue_number
+            for atom in structure.atoms
+            if atom.residue_name == "WAT"
+        } == {10, 11}
+
+
+def test_legacy_solvation_shells_preserve_per_frame_pdb_cutoffs(tmp_path):
+    frames_dir = tmp_path / "splitpdb0001"
+    frames_dir.mkdir()
+    (frames_dir / "frame_0000.pdb").write_text(
+        "".join(
+            _smart_shell_frame_lines(
+                residue10_y=1.0,
+                residue11_y=4.0,
+            )
+        )
+    )
+    (frames_dir / "frame_0001.pdb").write_text(
+        "".join(
+            _smart_shell_frame_lines(
+                residue10_y=4.0,
+                residue11_y=1.0,
+            )
+        )
+    )
+
+    analyzer = ExtractedFrameFolderClusterAnalyzer(
+        frames_dir=frames_dir,
+        atom_type_definitions=ATOM_TYPE_DEFINITIONS,
+        pair_cutoffs_def=PAIR_CUTOFFS,
+        smart_solvation_shells=False,
+    )
+
+    export = analyzer.export_cluster_pdbs(
+        tmp_path / "clusters_from_folder",
+        shell_levels=(1,),
+        include_shell_levels=(0, 1),
+    )
+
+    residues_by_name = {
+        path.name: {
+            atom.residue_number
+            for atom in PDBStructure.from_file(path).atoms
+            if atom.residue_name == "WAT"
+        }
+        for path in export.written_files
+    }
+
+    assert residues_by_name == {
+        "frame_0000_AAA.pdb": {10},
+        "frame_0001_AAA.pdb": {11},
+    }
 
 
 def test_extracted_xyz_frame_folder_cluster_analyzer_runs_and_exports(

--- a/tests/test_saxs_ui.py
+++ b/tests/test_saxs_ui.py
@@ -63,6 +63,7 @@ from saxshell.saxs.contrast.representatives import (
     analyze_contrast_representatives,
 )
 from saxshell.saxs.contrast.settings import (
+    COMPONENT_BUILD_MODE_BORN_APPROXIMATION,
     COMPONENT_BUILD_MODE_CONTRAST,
     COMPONENT_BUILD_MODE_NO_CONTRAST,
     ContrastRepresentativeSamplerSettings,
@@ -110,6 +111,7 @@ from saxshell.saxs.ui.experimental_data_loader import (
     ExperimentalDataHeaderDialog,
 )
 from saxshell.saxs.ui.main_window import (
+    AUTO_SNAP_PANES_KEY,
     PROJECT_LOAD_TOTAL_STEPS,
     InstallModelDialog,
     RuntimeBundleOpener,
@@ -141,6 +143,49 @@ def _table_column_index(table, label: str) -> int:
 
 def _plot_lines_by_gid(axis, gid: str):
     return [line for line in axis.get_lines() if line.get_gid() == gid]
+
+
+def _pane_snap_resize_result(
+    splitter: QSplitter,
+    pane_snap_filter,
+    *,
+    target_index: int,
+    desired_width: int | None = None,
+    other_width: int = 220,
+) -> tuple[list[int], list[int]]:
+    pane_widget = splitter.widget(target_index)
+    assert pane_widget is not None
+    click_widget = pane_widget
+    if isinstance(pane_widget, QScrollArea):
+        click_widget = pane_widget.viewport()
+    current_sizes = splitter.sizes()
+    current_total = sum(size for size in current_sizes if size > 0)
+    assert current_total > 0
+    resolved_width = (
+        max(720, int(current_total * 0.7))
+        if desired_width is None
+        else int(desired_width)
+    )
+    if target_index == 0:
+        splitter.setSizes([250, max(current_total - 250, 1)])
+    else:
+        splitter.setSizes([max(current_total - 250, 1), 250])
+    QApplication.processEvents()
+    before_sizes = splitter.sizes()
+
+    pane_snap_filter._preferred_width = lambda widget: (
+        resolved_width
+        if widget is splitter.widget(target_index)
+        else int(other_width)
+    )
+    QTest.mouseClick(
+        click_widget,
+        Qt.MouseButton.LeftButton,
+        Qt.KeyboardModifier.NoModifier,
+        click_widget.rect().center(),
+    )
+    QApplication.processEvents()
+    return before_sizes, splitter.sizes()
 
 
 def _write_component_file(path, q_values, intensities):
@@ -2703,14 +2748,38 @@ def test_main_window_menus_expose_project_tools_and_help(qapp, tmp_path):
     )
 
     assert window.tools_menu.title() == "Tools"
+    assert window.md_extraction_menu.title() == "MD Extraction"
+    assert window.structure_analysis_menu.title() == "Structure Analysis"
+    assert window.visualization_menu.title() == "Visualization"
     assert window.mdtrajectory_action.text() == "Open MD Trajectory Extraction"
     assert window.xyz2pdb_action.text() == "Open XYZ -> PDB Conversion"
     assert window.cluster_action.text() == "Open Cluster Extraction"
     assert window.bondanalysis_action.text() == "Open Bond Analysis"
-    assert [action.text() for action in window.tools_menu.actions()[:3]] == [
+    assert (
+        window.debye_waller_analysis_action.text()
+        == "Open Debye-Waller Analysis"
+    )
+    assert [action.text() for action in window.tools_menu.actions()] == [
+        "MD Extraction",
+        "Structure Analysis",
+        "Cluster Dynamics",
+        "PDF",
+        "Visualization",
+        "SAXS Calculation Preview",
+        "X-ray Toolkit",
+    ]
+    assert [
+        action.text() for action in window.md_extraction_menu.actions()
+    ] == [
         "Open MD Trajectory Extraction",
         "Open XYZ -> PDB Conversion",
         "Open Cluster Extraction",
+    ]
+    assert [
+        action.text() for action in window.structure_analysis_menu.actions()
+    ] == [
+        "Open Bond Analysis",
+        "Open Debye-Waller Analysis",
     ]
     assert (
         window.clusterdynamics_action.text() == "Open Cluster Dynamics (only)"
@@ -2719,11 +2788,17 @@ def test_main_window_menus_expose_project_tools_and_help(qapp, tmp_path):
         window.clusterdynamicsml_action.text() == "Open Cluster Dynamics (ML)"
     )
     assert window.fullrmc_action.text() == "Open fullrmc Setup"
+    assert window.structure_viewer_action.text() == "Structure Viewer"
+    assert window.blenderxyz_action.text() == "Open Blender XYZ Renderer"
+    assert window.component_calculation_preview_menu.title() == (
+        "SAXS Calculation Preview"
+    )
     assert window.contrast_mode_action.text() == "Open SAXS Contrast Mode"
     assert (
         window.electron_density_mapping_action.text()
         == "Open Electron Density Mapping"
     )
+    assert window.xray_toolkit_menu.title() == "X-ray Toolkit"
     assert (
         window.volume_fraction_action.text() == "Open Volume Fraction Estimate"
     )
@@ -3154,6 +3229,540 @@ def test_mdtrajectory_tool_uses_active_project_references(
     window.close()
 
 
+def test_debye_waller_tool_uses_active_project_clusters_dir(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    del qapp
+    project_dir, _paths = _build_minimal_saxs_project(tmp_path)
+    window = SAXSMainWindow(initial_project_dir=project_dir)
+    clusters_dir = tmp_path / "clusters"
+    clusters_dir.mkdir()
+    window.current_settings.clusters_dir = str(clusters_dir.resolve())
+    window.project_manager.save_project(window.current_settings)
+    launched: dict[str, object] = {}
+
+    class FakeDebyeWallerWindow(QWidget):
+        def __init__(self):
+            super().__init__()
+            launched["instance"] = self
+
+    def fake_launch_debye_waller_analysis_ui(**kwargs):
+        launched.update(kwargs)
+        return FakeDebyeWallerWindow()
+
+    monkeypatch.setattr(
+        "saxshell.saxs.debye_waller.ui.main_window.launch_debye_waller_analysis_ui",
+        fake_launch_debye_waller_analysis_ui,
+    )
+
+    window._open_debye_waller_analysis_tool()
+
+    assert launched["initial_project_dir"] == Path(project_dir).resolve()
+    assert launched["initial_clusters_dir"] == clusters_dir.resolve()
+    assert launched["instance"] in window._child_tool_windows
+    window.close()
+
+
+def _configure_debye_waller_project_clusters(
+    project_dir: Path,
+    tmp_path: Path,
+    *,
+    dirname: str = "project_dw_clusters",
+) -> Path:
+    def pdb_atom_line(
+        atom_id: int,
+        atom_name: str,
+        residue_name: str,
+        residue_number: int,
+        x_coord: float,
+        y_coord: float,
+        z_coord: float,
+        element: str,
+    ) -> str:
+        return (
+            f"ATOM  {atom_id:5d} {atom_name:<4} {residue_name:>3}  "
+            f"{residue_number:4d}    "
+            f"{x_coord:8.3f}{y_coord:8.3f}{z_coord:8.3f}"
+            f"  1.00  0.00          {element:>2}\n"
+        )
+
+    def write_water_frame(
+        path: Path,
+        *,
+        mol1_oxygen_x: float,
+        mol1_hydrogen_x: float,
+        mol2_oxygen_x: float,
+        mol2_hydrogen_x: float,
+    ) -> None:
+        lines = [
+            pdb_atom_line(1, "O", "HOH", 1, mol1_oxygen_x, 0.0, 0.0, "O"),
+            pdb_atom_line(2, "H1", "HOH", 1, mol1_hydrogen_x, 0.0, 0.0, "H"),
+            pdb_atom_line(3, "O", "HOH", 2, mol2_oxygen_x, 0.0, 0.0, "O"),
+            pdb_atom_line(4, "H1", "HOH", 2, mol2_hydrogen_x, 0.0, 0.0, "H"),
+            "END\n",
+        ]
+        path.write_text("".join(lines), encoding="utf-8")
+
+    clusters_dir = tmp_path / dirname
+    structure_dir = clusters_dir / "H2O2"
+    structure_dir.mkdir(parents=True, exist_ok=True)
+    write_water_frame(
+        structure_dir / "water_frame_0001.pdb",
+        mol1_oxygen_x=0.0,
+        mol1_hydrogen_x=1.00,
+        mol2_oxygen_x=5.0,
+        mol2_hydrogen_x=6.00,
+    )
+    write_water_frame(
+        structure_dir / "water_frame_0002.pdb",
+        mol1_oxygen_x=0.0,
+        mol1_hydrogen_x=1.10,
+        mol2_oxygen_x=5.2,
+        mol2_hydrogen_x=6.35,
+    )
+
+    manager = SAXSProjectManager()
+    settings = manager.load_project(project_dir)
+    settings.clusters_dir = str(clusters_dir.resolve())
+    manager.save_project(settings)
+    return clusters_dir
+
+
+def _write_debye_waller_project_result(project_dir: Path, tmp_path: Path):
+    from saxshell.saxs.debye_waller.workflow import (
+        DebyeWallerWorkflow,
+        save_debye_waller_analysis_to_project,
+    )
+
+    clusters_dir = _configure_debye_waller_project_clusters(
+        project_dir,
+        tmp_path,
+    )
+
+    result = DebyeWallerWorkflow(
+        clusters_dir,
+        project_dir=project_dir,
+        output_dir=tmp_path / "dw_external_out",
+        output_basename="dw_ui",
+    ).run()
+    return save_debye_waller_analysis_to_project(result, project_dir)
+
+
+def test_project_setup_debye_waller_button_requires_active_pdb_clusters_and_tracks_saved_result(
+    qapp,
+    tmp_path,
+):
+    del qapp
+    project_dir, _paths = _build_minimal_saxs_project(tmp_path)
+    window = SAXSMainWindow(initial_project_dir=project_dir)
+
+    assert not window.project_setup_tab.debye_waller_button.isEnabled()
+    assert "active PDB clusters folder" in (
+        window.project_setup_tab.debye_waller_button.toolTip()
+    )
+    assert "#6b7280" in (
+        window.project_setup_tab.debye_waller_ready_indicator.styleSheet()
+    )
+
+    _write_debye_waller_project_result(project_dir, tmp_path)
+    window.load_project(project_dir)
+
+    assert window.project_setup_tab.debye_waller_button.isEnabled()
+    assert "#16a34a" in (
+        window.project_setup_tab.debye_waller_ready_indicator.styleSheet()
+    )
+    assert (
+        "computed and saved"
+        in (
+            window.project_setup_tab.debye_waller_ready_indicator.toolTip()
+        ).lower()
+    )
+    help_tooltip = (
+        window.project_setup_tab.debye_waller_help_button.toolTip().lower()
+    )
+    assert "optional" in help_tooltip
+    assert "before building saxs components" in help_tooltip
+    assert "pdb cluster" in help_tooltip
+
+    _configure_debye_waller_project_clusters(
+        project_dir,
+        tmp_path,
+        dirname="project_dw_clusters_alt",
+    )
+    window.load_project(project_dir)
+
+    assert window.project_setup_tab.debye_waller_button.isEnabled()
+    assert "#6b7280" in (
+        window.project_setup_tab.debye_waller_ready_indicator.styleSheet()
+    )
+    assert (
+        "different clusters folder"
+        in (
+            window.project_setup_tab.debye_waller_ready_indicator.toolTip()
+        ).lower()
+    )
+    window.close()
+
+
+def test_project_setup_debye_waller_button_launches_linked_tool_and_refreshes_status(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    del qapp
+    from saxshell.saxs.debye_waller.workflow import (
+        DebyeWallerWorkflow,
+        save_debye_waller_analysis_to_project,
+    )
+
+    project_dir, _paths = _build_minimal_saxs_project(tmp_path)
+    clusters_dir = _configure_debye_waller_project_clusters(
+        project_dir,
+        tmp_path,
+        dirname="project_dw_clusters_launch",
+    )
+    window = SAXSMainWindow(initial_project_dir=project_dir)
+    launched: dict[str, object] = {}
+
+    class FakeDebyeWallerWindow(QWidget):
+        project_paths_registered = Signal(object)
+        project_analysis_saved = Signal(object)
+
+        def __init__(self):
+            super().__init__()
+            launched["instance"] = self
+
+    def fake_launch_debye_waller_analysis_ui(**kwargs):
+        launched.update(kwargs)
+        return FakeDebyeWallerWindow()
+
+    monkeypatch.setattr(
+        "saxshell.saxs.debye_waller.ui.main_window.launch_debye_waller_analysis_ui",
+        fake_launch_debye_waller_analysis_ui,
+    )
+
+    assert window.project_setup_tab.debye_waller_button.isEnabled()
+    assert "#6b7280" in (
+        window.project_setup_tab.debye_waller_ready_indicator.styleSheet()
+    )
+
+    window.project_setup_tab.debye_waller_button.click()
+
+    assert launched["initial_project_dir"] == Path(project_dir).resolve()
+    assert launched["initial_clusters_dir"] == clusters_dir.resolve()
+    assert launched["instance"] in window._child_tool_windows
+
+    result = DebyeWallerWorkflow(
+        clusters_dir,
+        project_dir=project_dir,
+        output_dir=tmp_path / "dw_linked_out",
+        output_basename="linked_refresh",
+    ).run()
+    save_debye_waller_analysis_to_project(result, project_dir)
+    launched["instance"].project_analysis_saved.emit(
+        {"project_dir": str(Path(project_dir).resolve())}
+    )
+    QApplication.processEvents()
+
+    assert "#16a34a" in (
+        window.project_setup_tab.debye_waller_ready_indicator.styleSheet()
+    )
+    window.close()
+
+
+def test_project_setup_debye_waller_button_reports_startup_progress_in_popup(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    del qapp
+    from saxshell.saxs.debye_waller.ui.main_window import (
+        DEBYE_WALLER_WINDOW_LOAD_TOTAL_STEPS,
+    )
+
+    project_dir, _paths = _build_minimal_saxs_project(tmp_path)
+    clusters_dir = _configure_debye_waller_project_clusters(
+        project_dir,
+        tmp_path,
+        dirname="project_dw_clusters_popup",
+    )
+    window = SAXSMainWindow(initial_project_dir=project_dir)
+    launched: dict[str, object] = {}
+
+    class FakeDebyeWallerWindow(QWidget):
+        project_paths_registered = Signal(object)
+        project_analysis_saved = Signal(object)
+
+    def fake_launch_debye_waller_analysis_ui(**kwargs):
+        launched.update(kwargs)
+        progress_callback = kwargs.get("startup_progress_callback")
+        log_callback = kwargs.get("startup_log_callback")
+        assert progress_callback is not None
+        assert log_callback is not None
+        progress_callback(
+            1,
+            DEBYE_WALLER_WINDOW_LOAD_TOTAL_STEPS,
+            "Preparing Debye-Waller analysis window...",
+        )
+        log_callback("Preparing Debye-Waller analysis window.")
+        progress_callback(
+            DEBYE_WALLER_WINDOW_LOAD_TOTAL_STEPS,
+            DEBYE_WALLER_WINDOW_LOAD_TOTAL_STEPS,
+            "Finalizing Debye-Waller window...",
+        )
+        log_callback("Debye-Waller analysis window is ready.")
+        return FakeDebyeWallerWindow()
+
+    monkeypatch.setattr(
+        "saxshell.saxs.debye_waller.ui.main_window.launch_debye_waller_analysis_ui",
+        fake_launch_debye_waller_analysis_ui,
+    )
+
+    window.project_setup_tab.debye_waller_button.click()
+
+    assert launched["initial_project_dir"] == Path(project_dir).resolve()
+    assert launched["initial_clusters_dir"] == clusters_dir.resolve()
+    assert window._progress_dialog is not None
+    assert not window._progress_dialog.isVisible()
+    dialog_output = window._progress_dialog.output_box.toPlainText()
+    assert "Loading Debye-Waller analysis from" in dialog_output
+    assert "Preparing Debye-Waller analysis window." in dialog_output
+    assert "Debye-Waller analysis window is ready." in dialog_output
+    window.close()
+
+
+def test_debye_waller_window_inherits_clusters_dir_from_project_reference(
+    qapp,
+    tmp_path,
+):
+    del qapp
+    from saxshell.saxs.debye_waller.ui.main_window import (
+        DebyeWallerAnalysisMainWindow,
+    )
+
+    project_dir, _paths = _build_minimal_saxs_project(tmp_path)
+    clusters_dir = tmp_path / "project_clusters"
+    clusters_dir.mkdir()
+
+    manager = SAXSProjectManager()
+    settings = manager.load_project(project_dir)
+    settings.clusters_dir = str(clusters_dir.resolve())
+    manager.save_project(settings)
+
+    window = DebyeWallerAnalysisMainWindow(initial_project_dir=project_dir)
+
+    assert window.clusters_dir_edit.text() == str(clusters_dir.resolve())
+    assert (
+        "inherited from the active project"
+        in window.summary_box.toPlainText().lower()
+    )
+    window.close()
+
+
+def test_debye_waller_window_browsing_clusters_reference_skips_registered_path_refresh(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    del qapp
+    from saxshell.saxs.debye_waller.ui.main_window import (
+        DebyeWallerAnalysisMainWindow,
+    )
+
+    project_dir, _paths = _build_minimal_saxs_project(tmp_path)
+    initial_clusters_dir = tmp_path / "initial_clusters"
+    initial_clusters_dir.mkdir()
+    updated_clusters_dir = tmp_path / "updated_clusters"
+    updated_clusters_dir.mkdir()
+
+    manager = SAXSProjectManager()
+    settings = manager.load_project(project_dir)
+    settings.clusters_dir = str(initial_clusters_dir.resolve())
+    manager.save_project(settings)
+    assert manager.load_project(project_dir).clusters_dir_snapshot is not None
+
+    window = DebyeWallerAnalysisMainWindow(initial_project_dir=project_dir)
+
+    save_calls: list[bool] = []
+    original_save_project = window._project_manager.save_project
+
+    def record_save_project(settings, *, refresh_registered_paths=True):
+        save_calls.append(bool(refresh_registered_paths))
+        return original_save_project(
+            settings,
+            refresh_registered_paths=refresh_registered_paths,
+        )
+
+    monkeypatch.setattr(
+        window._project_manager,
+        "save_project",
+        record_save_project,
+    )
+    monkeypatch.setattr(
+        "saxshell.saxs.debye_waller.ui.main_window.QFileDialog.getExistingDirectory",
+        lambda *args, **kwargs: str(updated_clusters_dir.resolve()),
+    )
+
+    window._browse_clusters_dir()
+
+    assert save_calls == [False]
+    saved_settings = SAXSProjectManager().load_project(project_dir)
+    assert saved_settings.clusters_dir == str(updated_clusters_dir.resolve())
+    assert saved_settings.clusters_dir_snapshot is None
+    window.close()
+
+
+def test_debye_waller_window_exposes_stoichiometry_info_tab(
+    qapp,
+    tmp_path,
+):
+    del qapp
+    from saxshell.saxs.debye_waller.ui.main_window import (
+        DebyeWallerAnalysisMainWindow,
+    )
+
+    project_dir, _paths = _build_minimal_saxs_project(tmp_path)
+    window = DebyeWallerAnalysisMainWindow(initial_project_dir=project_dir)
+
+    tab_labels = [
+        window.results_tabs.tabText(index)
+        for index in range(window.results_tabs.count())
+    ]
+
+    assert "Aggregated Pairs" in tab_labels
+    assert "Stoichiometries" in tab_labels
+    assert window.stoichiometry_info_table.columnCount() >= 1
+    assert window.aggregated_pair_table.columnCount() >= 1
+    window.close()
+
+
+def test_debye_waller_window_loads_saved_project_analysis(
+    qapp,
+    tmp_path,
+):
+    del qapp
+    from saxshell.saxs.debye_waller.ui.main_window import (
+        DebyeWallerAnalysisMainWindow,
+    )
+
+    project_dir, _paths = _build_minimal_saxs_project(tmp_path)
+    saved_result = _write_debye_waller_project_result(project_dir, tmp_path)
+
+    window = DebyeWallerAnalysisMainWindow(initial_project_dir=project_dir)
+
+    assert window._last_result is not None
+    assert window.aggregated_pair_table.rowCount() > 0
+    assert window.pair_summary_table.rowCount() > 0
+    assert window.stoichiometry_info_table.rowCount() > 0
+    assert "loaded saved debye-waller analysis" in (
+        window.log_box.toPlainText().lower()
+    )
+    assert window.output_dir_edit.text() == str(saved_result.output_dir)
+    window.close()
+
+
+def test_debye_waller_window_does_not_resave_project_during_startup(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    del qapp
+    from saxshell.saxs.debye_waller.ui.main_window import (
+        DebyeWallerAnalysisMainWindow,
+    )
+
+    project_dir, _paths = _build_minimal_saxs_project(tmp_path)
+    clusters_dir = _configure_debye_waller_project_clusters(
+        project_dir,
+        tmp_path,
+        dirname="project_dw_clusters_no_resave",
+    )
+    save_calls: list[str | None] = []
+    original_save_project = SAXSProjectManager.save_project
+
+    def wrapped_save_project(self, settings, *args, **kwargs):
+        save_calls.append(settings.clusters_dir)
+        return original_save_project(self, settings, *args, **kwargs)
+
+    monkeypatch.setattr(
+        SAXSProjectManager,
+        "save_project",
+        wrapped_save_project,
+    )
+
+    window = DebyeWallerAnalysisMainWindow(
+        initial_project_dir=project_dir,
+        initial_clusters_dir=clusters_dir,
+    )
+
+    assert save_calls == []
+    window.close()
+
+
+def test_debye_waller_window_autosaves_first_project_analysis(
+    qapp,
+    tmp_path,
+):
+    del qapp
+    from saxshell.saxs.debye_waller.ui.main_window import (
+        DebyeWallerAnalysisMainWindow,
+    )
+    from saxshell.saxs.debye_waller.workflow import (
+        DebyeWallerWorkflow,
+        find_saved_project_debye_waller_analysis,
+    )
+
+    project_dir, _paths = _build_minimal_saxs_project(tmp_path)
+    saved_result = _write_debye_waller_project_result(project_dir, tmp_path)
+    saved_summary_path = (
+        saved_result.artifacts.summary_json_path
+        if saved_result.artifacts is not None
+        else None
+    )
+    assert saved_summary_path is not None
+    saved_summary_path.unlink()
+
+    pair_csv = saved_result.artifacts.pair_summary_csv_path
+    scope_csv = saved_result.artifacts.scope_summary_csv_path
+    segment_csv = saved_result.artifacts.segment_csv_path
+    aggregated_pair_csv = (
+        saved_result.artifacts.aggregated_pair_summary_csv_path
+    )
+    for artifact_path in (
+        aggregated_pair_csv,
+        pair_csv,
+        scope_csv,
+        segment_csv,
+    ):
+        artifact_path.unlink()
+    saved_result.output_dir.rmdir()
+
+    clusters_dir = Path(
+        SAXSProjectManager().load_project(project_dir).clusters_dir
+    ).resolve()
+    result = DebyeWallerWorkflow(
+        clusters_dir,
+        project_dir=project_dir,
+        output_dir=tmp_path / "dw_new_run",
+        output_basename="new_run",
+    ).run()
+
+    window = DebyeWallerAnalysisMainWindow(initial_project_dir=project_dir)
+    window._project_had_saved_analysis_before_run = False
+    window._finish_run(result)
+
+    restored_path = find_saved_project_debye_waller_analysis(project_dir)
+    assert restored_path is not None
+    assert restored_path.exists()
+    assert "auto-saved the first debye-waller analysis" in (
+        window.log_box.toPlainText().lower()
+    )
+    assert window.save_project_button.isEnabled()
+    window.close()
+
+
 def test_cluster_tool_uses_active_project_frames_dir_and_project_dir(
     qapp, tmp_path, monkeypatch
 ):
@@ -3569,6 +4178,51 @@ def test_cluster_dynamics_ml_tool_uses_active_project_dir(
     window.close()
 
 
+def test_project_setup_predict_structures_button_opens_cluster_dynamics_ml_tool(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    del qapp
+    project_dir, _paths = _build_minimal_saxs_project(tmp_path)
+    window = SAXSMainWindow(initial_project_dir=project_dir)
+    launched: dict[str, object] = {}
+
+    class FakeClusterDynamicsMLWindow:
+        def __init__(
+            self,
+            initial_frames_dir=None,
+            initial_energy_file=None,
+            initial_project_dir=None,
+            initial_clusters_dir=None,
+            initial_experimental_data_file=None,
+        ):
+            launched["project_dir"] = initial_project_dir
+            launched["instance"] = self
+
+        def show(self):
+            launched["shown"] = True
+
+        def raise_(self):
+            launched["raised"] = True
+
+    monkeypatch.setattr(
+        "saxshell.clusterdynamicsml.ui.main_window.ClusterDynamicsMLMainWindow",
+        FakeClusterDynamicsMLWindow,
+    )
+
+    window.project_setup_tab.predict_structures_button.click()
+
+    assert (
+        launched["project_dir"]
+        == Path(window.current_settings.project_dir).resolve()
+    )
+    assert launched["shown"] is True
+    assert launched["raised"] is True
+    assert launched["instance"] in window._child_tool_windows
+    window.close()
+
+
 def test_contrast_mode_scaffold_window_populates_launch_context(
     qapp, tmp_path
 ):
@@ -3599,8 +4253,10 @@ def test_contrast_mode_scaffold_window_populates_launch_context(
     )
     _flush_contrast_window_launch_preview(window)
 
-    assert window.windowTitle() == "SAXSShell (Contrast Debye Workflow)"
-    assert window.mode_edit.text() == "Contrast Mode"
+    assert (
+        window.windowTitle() == "SAXSShell (Contrast Debye Workflow) (Preview)"
+    )
+    assert window.mode_edit.text() == "Contrast (Debye)"
     assert window.project_dir_edit.text() == str(project_dir.resolve())
     assert window.clusters_dir_edit.text() == str(clusters_dir.resolve())
     assert window.experimental_data_edit.text() == str(
@@ -3798,6 +4454,7 @@ def test_contrast_mode_tool_uses_active_project_context(
     assert launched["initial_q_min"] == pytest.approx(0.06)
     assert launched["initial_q_max"] == pytest.approx(0.75)
     assert launched["initial_template_name"] == POLY_LMA_HS_TEMPLATE
+    assert launched["preview_mode"] is True
     assert launched["instance"] in window._child_tool_windows
     assert window._contrast_mode_tool_window is launched["instance"]
     window.close()
@@ -4011,6 +4668,7 @@ def test_contrast_mode_tool_open_starts_clean_even_with_saved_distribution(
     assert launched["initial_distribution_id"] is None
     assert launched["initial_distribution_root_dir"] is None
     assert launched["initial_contrast_artifact_dir"] is None
+    assert launched["preview_mode"] is True
     window.close()
 
 
@@ -4049,6 +4707,7 @@ def test_electron_density_mapping_tool_uses_active_structure_folder(
 
     assert launched["initial_project_dir"] == Path(project_dir).resolve()
     assert launched["initial_input_path"] == pdb_frames_dir.resolve()
+    assert launched["preview_mode"] is True
     assert launched["instance"] in window._child_tool_windows
     window.close()
 
@@ -5276,6 +5935,95 @@ def test_dream_progress_label_wrap_does_not_resize_left_pane(qapp):
     assert "No DREAM dataset is loaded yet" in (
         window.dream_tab.filter_status_box.toPlainText()
     )
+
+
+@pytest.mark.parametrize(
+    ("tab_attr", "splitter_attr", "target_index"),
+    [
+        ("project_setup_tab", "_pane_splitter", 0),
+        ("project_setup_tab", "_pane_splitter", 1),
+        ("prefit_tab", "_pane_splitter", 0),
+        ("prefit_tab", "_pane_splitter", 1),
+        ("dream_tab", "_top_splitter", 0),
+        ("dream_tab", "_top_splitter", 1),
+    ],
+)
+def test_auto_snap_panes_resizes_clicked_supported_pane(
+    qapp,
+    tab_attr,
+    splitter_attr,
+    target_index,
+):
+    del qapp
+    window = SAXSMainWindow()
+    window.resize(1800, 980)
+    window.show()
+    tab = getattr(window, tab_attr)
+    window.tabs.setCurrentWidget(tab)
+    QApplication.processEvents()
+
+    splitter = getattr(tab, splitter_attr)
+    pane_snap_filter = tab._auto_snap_filter
+    before_sizes, after_sizes = _pane_snap_resize_result(
+        splitter,
+        pane_snap_filter,
+        target_index=target_index,
+    )
+
+    assert after_sizes[target_index] > before_sizes[target_index] + 20
+    window.close()
+
+
+def test_auto_snap_panes_disabled_preserves_manual_splitter_sizes(qapp):
+    del qapp
+    window = SAXSMainWindow()
+    window.resize(1800, 980)
+    window.show()
+    window._set_auto_snap_panes_enabled(False, persist=False)
+    window.tabs.setCurrentWidget(window.prefit_tab)
+    QApplication.processEvents()
+
+    splitter = window.prefit_tab._pane_splitter
+    splitter.setSizes([900, 300])
+    QApplication.processEvents()
+    before_sizes = splitter.sizes()
+    QTest.mouseClick(
+        window.prefit_tab._plot_group,
+        Qt.MouseButton.LeftButton,
+        Qt.KeyboardModifier.NoModifier,
+        window.prefit_tab._plot_group.rect().center(),
+    )
+    QApplication.processEvents()
+    after_sizes = splitter.sizes()
+
+    assert abs(after_sizes[0] - before_sizes[0]) <= 2
+    assert abs(after_sizes[1] - before_sizes[1]) <= 2
+    window.close()
+
+
+@pytest.mark.parametrize("target_index", [0, 1])
+def test_auto_snap_panes_focus_clicked_pane_when_its_preferred_width_is_small(
+    qapp,
+    target_index,
+):
+    del qapp
+    window = SAXSMainWindow()
+    window.resize(1800, 980)
+    window.show()
+    window.tabs.setCurrentWidget(window.project_setup_tab)
+    QApplication.processEvents()
+
+    before_sizes, after_sizes = _pane_snap_resize_result(
+        window.project_setup_tab._pane_splitter,
+        window.project_setup_tab._auto_snap_filter,
+        target_index=target_index,
+        desired_width=220,
+        other_width=720,
+    )
+
+    assert after_sizes[target_index] > before_sizes[target_index] + 20
+    assert after_sizes[1 - target_index] < before_sizes[1 - target_index] - 20
+    window.close()
 
 
 def test_dream_zeta_spin_uses_scientific_notation(qapp):
@@ -6892,15 +7640,26 @@ def test_project_setup_component_build_mode_defaults_and_round_trips(qapp):
     )
 
     assert tab.component_build_mode() == COMPONENT_BUILD_MODE_NO_CONTRAST
-    assert tab.component_build_mode_combo.currentText() == "No Contrast Mode"
+    assert (
+        tab.component_build_mode_combo.currentText() == "No Contrast (Debye)"
+    )
 
     tab.set_component_build_mode(COMPONENT_BUILD_MODE_CONTRAST)
     assert tab.component_build_mode() == COMPONENT_BUILD_MODE_CONTRAST
-    assert tab.component_build_mode_combo.currentText() == "Contrast Mode"
+    assert tab.component_build_mode_combo.currentText() == "Contrast (Debye)"
+
+    tab.set_component_build_mode(COMPONENT_BUILD_MODE_BORN_APPROXIMATION)
+    assert (
+        tab.component_build_mode() == COMPONENT_BUILD_MODE_BORN_APPROXIMATION
+    )
+    assert (
+        tab.component_build_mode_combo.currentText()
+        == "Born Approximation (Average)"
+    )
 
     tab.set_project_settings(settings, [])
     assert tab.component_build_mode() == COMPONENT_BUILD_MODE_CONTRAST
-    assert "Contrast Mode" in tab.component_build_mode_label.text()
+    assert "Contrast (Debye)" in tab.component_build_mode_label.text()
 
 
 def test_distribution_identity_and_label_include_component_build_mode(
@@ -6917,10 +7676,10 @@ def test_distribution_identity_and_label_include_component_build_mode(
     assert project_module.distribution_id_for_settings(
         no_contrast_settings
     ) != project_module.distribution_id_for_settings(contrast_settings)
-    assert "Build: No Contrast Mode" in (
+    assert "Build: No Contrast (Debye)" in (
         project_module.distribution_label_for_settings(no_contrast_settings)
     )
-    assert "Build: Contrast Mode" in (
+    assert "Build: Contrast (Debye)" in (
         project_module.distribution_label_for_settings(contrast_settings)
     )
 
@@ -9634,6 +10393,145 @@ def test_open_project_uses_existing_project_field(qapp, tmp_path):
     assert window.project_setup_tab.project_name_edit.text() == "saxs_project"
 
 
+def test_existing_project_browser_starts_in_recent_project_parent(
+    qapp, tmp_path, monkeypatch
+):
+    del qapp
+
+    class _FakeSettings:
+        def __init__(self, values: dict[str, object]):
+            self.values = dict(values)
+
+        def value(self, key, default=None):
+            return self.values.get(key, default)
+
+        def setValue(self, key, value):
+            self.values[key] = value
+
+    recent_root = tmp_path / "recent_projects"
+    recent_root.mkdir()
+    project_dir, _paths = _build_minimal_saxs_project(recent_root)
+    settings_store = _FakeSettings(
+        {"recent_project_dirs": [str(project_dir.resolve())]}
+    )
+    captured: dict[str, str] = {}
+
+    monkeypatch.setattr(
+        "saxshell.saxs.ui.project_setup_tab.QSettings",
+        lambda *args, **kwargs: settings_store,
+    )
+
+    def _capture_existing_directory(*args, **kwargs):
+        captured["start_dir"] = args[2]
+        return ""
+
+    monkeypatch.setattr(
+        "saxshell.saxs.ui.project_setup_tab.QFileDialog.getExistingDirectory",
+        _capture_existing_directory,
+    )
+
+    tab = ProjectSetupTab()
+    tab._browse_existing_project_directory()
+
+    assert captured["start_dir"] == str(project_dir.resolve().parent)
+
+
+def test_open_project_dialog_uses_recent_project_parent_when_field_is_empty(
+    qapp, tmp_path, monkeypatch
+):
+    del qapp
+
+    class _FakeSettings:
+        def __init__(self, values: dict[str, object]):
+            self.values = dict(values)
+
+        def value(self, key, default=None):
+            return self.values.get(key, default)
+
+        def setValue(self, key, value):
+            self.values[key] = value
+
+    recent_root = tmp_path / "recent_projects"
+    recent_root.mkdir()
+    project_dir, _paths = _build_minimal_saxs_project(recent_root)
+    settings_store = _FakeSettings(
+        {"recent_project_dirs": [str(project_dir.resolve())]}
+    )
+    captured: dict[str, str] = {}
+
+    monkeypatch.setattr(
+        SAXSMainWindow,
+        "_recent_projects_settings",
+        lambda self: settings_store,
+    )
+
+    def _capture_existing_directory(*args, **kwargs):
+        captured["start_dir"] = args[2]
+        return ""
+
+    monkeypatch.setattr(
+        "saxshell.saxs.ui.main_window.QFileDialog.getExistingDirectory",
+        _capture_existing_directory,
+    )
+
+    window = SAXSMainWindow()
+    window.project_setup_tab.open_project_dir_edit.clear()
+
+    window.open_project_from_dialog()
+
+    assert captured["start_dir"] == str(project_dir.resolve().parent)
+
+
+def test_auto_snap_panes_setting_defaults_enabled_and_persists(
+    qapp,
+    monkeypatch,
+):
+    del qapp
+
+    class _FakeSettings:
+        def __init__(self, values: dict[str, object] | None = None):
+            self.values = {} if values is None else dict(values)
+
+        def value(self, key, default=None):
+            return self.values.get(key, default)
+
+        def setValue(self, key, value):
+            self.values[key] = value
+
+    settings_store = _FakeSettings()
+
+    monkeypatch.setattr(
+        SAXSMainWindow,
+        "_recent_projects_settings",
+        lambda self: settings_store,
+    )
+
+    first_window = SAXSMainWindow()
+
+    assert first_window.auto_snap_panes_action.isChecked()
+    assert first_window.project_setup_tab._auto_snap_filter.is_enabled()
+    assert first_window.prefit_tab._auto_snap_filter.is_enabled()
+    assert first_window.dream_tab._auto_snap_filter.is_enabled()
+
+    first_window.auto_snap_panes_action.trigger()
+
+    assert settings_store.values[AUTO_SNAP_PANES_KEY] is False
+    assert not first_window.auto_snap_panes_action.isChecked()
+    assert not first_window.project_setup_tab._auto_snap_filter.is_enabled()
+    assert not first_window.prefit_tab._auto_snap_filter.is_enabled()
+    assert not first_window.dream_tab._auto_snap_filter.is_enabled()
+
+    second_window = SAXSMainWindow()
+
+    assert not second_window.auto_snap_panes_action.isChecked()
+    assert not second_window.project_setup_tab._auto_snap_filter.is_enabled()
+    assert not second_window.prefit_tab._auto_snap_filter.is_enabled()
+    assert not second_window.dream_tab._auto_snap_filter.is_enabled()
+
+    first_window.close()
+    second_window.close()
+
+
 def test_open_project_reports_loader_progress_and_output(qapp, tmp_path):
     del qapp
     project_dir, _paths = _build_minimal_saxs_project(tmp_path)
@@ -11645,7 +12543,7 @@ def test_build_components_in_contrast_mode_launches_scaffold_instead_of_builder_
     monkeypatch.setattr(
         window,
         "_open_contrast_mode_tool",
-        lambda: launched.append("contrast"),
+        lambda **kwargs: launched.append(kwargs),
     )
 
     window.project_setup_tab.set_component_build_mode(
@@ -11655,7 +12553,7 @@ def test_build_components_in_contrast_mode_launches_scaffold_instead_of_builder_
 
     saved_settings = SAXSProjectManager().load_project(project_dir)
     assert not start_calls
-    assert launched == ["contrast"]
+    assert launched == [{"preview_mode": False}]
     assert saved_settings.component_build_mode == COMPONENT_BUILD_MODE_CONTRAST
     assert window.current_settings is not None
     assert (
@@ -11663,7 +12561,71 @@ def test_build_components_in_contrast_mode_launches_scaffold_instead_of_builder_
         == COMPONENT_BUILD_MODE_CONTRAST
     )
     assert (
-        "Contrast Mode" in window.project_setup_tab.summary_box.toPlainText()
+        "Contrast (Debye)"
+        in window.project_setup_tab.summary_box.toPlainText()
+    )
+    window.close()
+
+
+def test_build_components_in_born_approximation_launches_electron_density_workflow(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    del qapp
+    project_dir, _paths = _build_minimal_saxs_project(tmp_path)
+    window = SAXSMainWindow(initial_project_dir=project_dir)
+    launched: list[dict[str, object]] = []
+    start_calls: list[str] = []
+    clusters_dir = tmp_path / "clusters"
+    (clusters_dir / "PbI2").mkdir(parents=True)
+    (clusters_dir / "PbI2" / "frame_0001.xyz").write_text(
+        "\n".join(
+            [
+                "3",
+                "frame_0001",
+                "Pb 0.0 0.0 0.0",
+                "I 2.8 0.0 0.0",
+                "I 0.0 2.8 0.0",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    window.project_setup_tab.clusters_dir_edit.setText(
+        str(clusters_dir.resolve())
+    )
+    window.project_setup_tab.set_component_build_mode(
+        COMPONENT_BUILD_MODE_BORN_APPROXIMATION
+    )
+    monkeypatch.setattr(
+        window,
+        "_confirm_default_q_range_for_component_build",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        window,
+        "_start_project_task",
+        lambda task_name, *args, **kwargs: start_calls.append(task_name),
+    )
+    monkeypatch.setattr(
+        window,
+        "_open_electron_density_mapping_tool",
+        lambda **kwargs: launched.append(kwargs),
+    )
+
+    window.build_project_components()
+
+    assert not start_calls
+    assert launched == [{"preview_mode": False}]
+    assert window.current_settings is not None
+    assert (
+        window.current_settings.component_build_mode
+        == COMPONENT_BUILD_MODE_BORN_APPROXIMATION
+    )
+    assert (
+        "Born Approximation (Average)"
+        in window.project_setup_tab.summary_box.toPlainText()
     )
     window.close()
 
@@ -11712,10 +12674,10 @@ def test_saved_distributions_can_coexist_and_load_by_component_build_mode(
         records[contrast_artifacts.distribution_id].component_build_mode
         == COMPONENT_BUILD_MODE_CONTRAST
     )
-    assert "Build: No Contrast Mode" in (
+    assert "Build: No Contrast (Debye)" in (
         records[no_contrast_artifacts.distribution_id].label
     )
-    assert "Build: Contrast Mode" in (
+    assert "Build: Contrast (Debye)" in (
         records[contrast_artifacts.distribution_id].label
     )
     assert (
@@ -12862,11 +13824,48 @@ def test_predicted_structure_mode_status_guides_user_when_bundle_is_missing(
     window = SAXSMainWindow(initial_project_dir=project_dir)
 
     assert window.project_setup_tab.use_predicted_structure_weights()
+    assert (
+        window.project_setup_tab.use_predicted_structure_weights_checkbox.isEnabled()
+    )
+    assert "#6b7280" in (
+        window.project_setup_tab.predicted_structure_ready_indicator.styleSheet()
+    )
     assert "Predicted Structures mode is on" in (
         window.project_setup_tab.predicted_structure_status_label.text()
     )
-    assert "Open Tools > Open Cluster Dynamics ML" in (
+    assert "Open Cluster Dynamics (ML)" in (
         window.project_setup_tab.predicted_structure_status_label.text()
+    )
+    window.close()
+
+
+def test_predicted_structure_toggle_stays_disabled_until_predictions_exist(
+    qapp,
+    tmp_path,
+):
+    del qapp
+    project_dir, paths = _build_minimal_saxs_project(tmp_path)
+    window = SAXSMainWindow(initial_project_dir=project_dir)
+
+    assert not window.project_setup_tab.use_predicted_structure_weights()
+    assert (
+        not window.project_setup_tab.use_predicted_structure_weights_checkbox.isEnabled()
+    )
+    assert "#6b7280" in (
+        window.project_setup_tab.predicted_structure_ready_indicator.styleSheet()
+    )
+
+    _write_predicted_structure_artifacts(paths)
+    window._refresh_predicted_structure_status()
+
+    assert (
+        window.project_setup_tab.use_predicted_structure_weights_checkbox.isEnabled()
+    )
+    assert "#16a34a" in (
+        window.project_setup_tab.predicted_structure_ready_indicator.styleSheet()
+    )
+    assert "1 predicted structure is available" in (
+        window.project_setup_tab.predicted_structure_ready_indicator.toolTip()
     )
     window.close()
 

--- a/tests/test_structure_viewer.py
+++ b/tests/test_structure_viewer.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import QApplication
+
+from saxshell.saxs.structure_viewer.ui.main_window import (
+    StructureViewerMainWindow,
+)
+
+
+@pytest.fixture(scope="module")
+def qapp():
+    os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+    app = QApplication.instance()
+    if app is None:
+        app = QApplication([])
+    yield app
+
+
+def _write_xyz(path: Path, lines: list[str]) -> Path:
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return path
+
+
+def test_structure_viewer_loads_single_structure(qapp, tmp_path):
+    del qapp
+    structure_path = _write_xyz(
+        tmp_path / "methane.xyz",
+        [
+            "5",
+            "methane",
+            "C 0.0 0.0 0.0",
+            "H 0.8 0.8 0.8",
+            "H -0.8 -0.8 0.8",
+            "H -0.8 0.8 -0.8",
+            "H 0.8 -0.8 -0.8",
+        ],
+    )
+
+    window = StructureViewerMainWindow(initial_input_path=structure_path)
+
+    assert window.input_mode_value.text() == "Single structure file"
+    assert window.reference_file_value.text() == str(structure_path.resolve())
+    assert "5 atoms" in window.structure_summary_value.text()
+    assert "Previewing methane" in window.viewer_status_label.text()
+    assert window.structure_viewer.current_structure is not None
+    assert (
+        window.structure_viewer.current_structure.file_path
+        == structure_path.resolve()
+    )
+    assert window.structure_viewer.current_mesh_geometry is not None
+    assert "shells=" in window.active_mesh_value.text()
+    window.close()
+
+
+def test_structure_viewer_center_updates_preserve_viewer_display(
+    qapp,
+    tmp_path,
+    monkeypatch,
+):
+    del qapp
+    structure_path = _write_xyz(
+        tmp_path / "snap_preserve.xyz",
+        [
+            "4",
+            "snap preserve",
+            "C 0.0 0.0 0.0",
+            "H 1.1 0.2 0.0",
+            "H -0.2 0.9 0.3",
+            "O 2.3 0.0 0.0",
+        ],
+    )
+    window = StructureViewerMainWindow(initial_input_path=structure_path)
+    viewer = window.structure_viewer
+
+    viewer.atom_contrast_spin.lineEdit().setText("30")
+    viewer.mesh_contrast_spin.lineEdit().setText("45")
+    viewer.mesh_linewidth_spin.lineEdit().setText("2.70")
+    viewer.atom_contrast_spin.interpretText()
+    viewer.mesh_contrast_spin.interpretText()
+    viewer.mesh_linewidth_spin.interpretText()
+    viewer.point_atoms_checkbox.setChecked(True)
+
+    monkeypatch.setattr(
+        "saxshell.saxs.structure_viewer.ui.widget.QColorDialog.getColor",
+        lambda *args, **kwargs: QColor("#ff6600"),
+    )
+    viewer.mesh_color_button.click()
+
+    viewer._view_radius = 7.5
+    viewer._view_center = np.asarray([0.2, -0.4, 0.6], dtype=float)
+    viewer._scene_rotation = np.asarray(
+        [
+            [0.0, -1.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+        dtype=float,
+    )
+    previous_centered = np.asarray(
+        viewer.current_structure.centered_coordinates,
+        dtype=float,
+    ).copy()
+
+    window.snap_center_button.click()
+
+    assert viewer._atom_contrast == pytest.approx(0.30)
+    assert viewer._mesh_contrast == pytest.approx(0.45)
+    assert viewer._mesh_linewidth == pytest.approx(2.7)
+    assert viewer._mesh_color == "#ff6600"
+    assert viewer._atom_render_mode == "points"
+    assert viewer._view_radius == pytest.approx(7.5)
+    assert np.allclose(viewer._view_center, [0.2, -0.4, 0.6])
+    assert np.allclose(
+        viewer._scene_rotation,
+        [
+            [0.0, -1.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ],
+    )
+    assert viewer.current_structure.center_mode == "nearest_atom"
+    assert not np.allclose(
+        viewer.current_structure.centered_coordinates,
+        previous_centered,
+    )
+    overlay_texts = [
+        text
+        for text in viewer._axis.texts
+        if getattr(text, "get_gid", lambda: None)() == "active-visual-settings"
+    ]
+    assert len(overlay_texts) == 1
+    overlay_text = overlay_texts[0].get_text()
+    assert f"ZOOM {viewer._current_zoom_percentage():05.1f}%" in overlay_text
+    assert "ATOM 030.0%" in overlay_text
+    assert "MESH 045.0%" in overlay_text
+    assert "LINE 2.70px" in overlay_text
+    assert "#FF6600" in overlay_text
+    window.close()
+
+
+def test_structure_viewer_mesh_notice_tracks_pending_fields(qapp, tmp_path):
+    del qapp
+    structure_path = _write_xyz(
+        tmp_path / "mesh_update.xyz",
+        [
+            "3",
+            "mesh update",
+            "O -1.16 0.0 0.0",
+            "C 0.0 0.0 0.0",
+            "O 1.16 0.0 0.0",
+        ],
+    )
+    window = StructureViewerMainWindow(initial_input_path=structure_path)
+
+    window.rstep_spin.setValue(0.2)
+
+    assert "differ from the rendered mesh" in window.pending_mesh_value.text()
+
+    window.update_mesh_button.click()
+
+    assert window.structure_viewer.current_mesh_geometry is not None
+    assert (
+        window.structure_viewer.current_mesh_geometry.settings.rstep
+        == pytest.approx(0.2)
+    )
+    assert "match the rendered mesh" in window.pending_mesh_value.text()
+    assert "rstep=0.200 A" in window.active_mesh_value.text()
+    window.close()


### PR DESCRIPTION
## Summary

- Add a project-aware Debye-Waller analysis workspace with save/reload support and dedicated regression coverage.
- Add a standalone Structure Viewer workflow and wire the visualization/X-ray helper tooling into the SAXS UI.
- Expand electron-density mapping with contiguous-frame handling, pinned geometric tracking, Born Approximation output support, and the related UI wiring.
- Refresh the getting-started and user-guide docs for the new workflows.

## Validation

- `pre-commit` hooks passed across all five local commits.
- Started targeted pytest coverage for:
  - `tests/test_debye_waller_analysis.py`
  - `tests/test_structure_viewer.py`
  - `tests/test_electron_density_mapping.py`
  - `tests/test_saxs_ui.py`
- The broader pytest sweep was still running when this PR text was drafted, so update this section with the final result if you wait for that run to finish before posting.

## Issue Tracking

Resolves #52, #58, #59, #60, #61, #62.
Resolves #70, #71, #76, #77, #78, #80.
Resolves #84.
Follow-up before merge: open new issue number for the remaining validation work and residual visualizer layout/base-cutoff cleanup, and reference #84 in that new issue.
Partially addresses #88; the base of the visualizer can still be cut off in some layouts.
Resolves #90.
Resolves #91; the center element list is now displayed in the dropdown within the mesh settings table.
Resolves #92, #93, #97, #100, #101.
