### PR TITLE
Avoid launch failure from FullRMC constraint import

### DIFF
--- a/src/saxshell/fullrmc/__init__.py
+++ b/src/saxshell/fullrmc/__init__.py
@@ -2,14 +2,6 @@
 
 from typing import TYPE_CHECKING
 
-from .constraint_generation import (
-    ConstraintGenerationEntry,
-    ConstraintGenerationMetadata,
-    ConstraintGenerationSettings,
-    build_constraint_generation,
-    load_constraint_generation_metadata,
-    save_constraint_generation_metadata,
-)
 from .packmol_docker import (
     DEFAULT_PACKMOL_CONTAINER_ROOT,
     PackmolDockerClient,
@@ -112,6 +104,14 @@ from .solvent_shell_builder import (
 )
 
 if TYPE_CHECKING:
+    from .constraint_generation import (
+        ConstraintGenerationEntry,
+        ConstraintGenerationMetadata,
+        ConstraintGenerationSettings,
+        build_constraint_generation,
+        load_constraint_generation_metadata,
+        save_constraint_generation_metadata,
+    )
     from .ui.main_window import RMCSetupMainWindow, launch_rmcsetup_ui
     from .ui.representative_preview_window import RepresentativePreviewWindow
     from .ui.solvent_shell_builder_window import (
@@ -215,6 +215,36 @@ __all__ = [
 
 
 def __getattr__(name: str):
+    if name in {
+        "ConstraintGenerationEntry",
+        "ConstraintGenerationMetadata",
+        "ConstraintGenerationSettings",
+        "build_constraint_generation",
+        "load_constraint_generation_metadata",
+        "save_constraint_generation_metadata",
+    }:
+        from .constraint_generation import (
+            ConstraintGenerationEntry,
+            ConstraintGenerationMetadata,
+            ConstraintGenerationSettings,
+            build_constraint_generation,
+            load_constraint_generation_metadata,
+            save_constraint_generation_metadata,
+        )
+
+        exports = {
+            "ConstraintGenerationEntry": ConstraintGenerationEntry,
+            "ConstraintGenerationMetadata": ConstraintGenerationMetadata,
+            "ConstraintGenerationSettings": ConstraintGenerationSettings,
+            "build_constraint_generation": build_constraint_generation,
+            "load_constraint_generation_metadata": (
+                load_constraint_generation_metadata
+            ),
+            "save_constraint_generation_metadata": (
+                save_constraint_generation_metadata
+            ),
+        }
+        return exports[name]
     if name in {"RMCSetupMainWindow", "launch_rmcsetup_ui"}:
         from .ui.main_window import RMCSetupMainWindow, launch_rmcsetup_ui
 

--- a/src/saxshell/fullrmc/constraint_generation.py
+++ b/src/saxshell/fullrmc/constraint_generation.py
@@ -6,7 +6,14 @@ from dataclasses import asdict, dataclass
 from datetime import datetime
 from pathlib import Path
 
-from saxshell.fullrmc._deprecated.constraintpdb import ConstraintPDB
+try:
+    from saxshell.fullrmc._deprecated.constraintpdb import ConstraintPDB
+except ModuleNotFoundError as exc:
+    ConstraintPDB = None  # type: ignore[assignment]
+    _CONSTRAINTPDB_IMPORT_ERROR = exc
+else:
+    _CONSTRAINTPDB_IMPORT_ERROR = None
+
 from saxshell.fullrmc.packmol_setup import PackmolSetupMetadata
 
 if False:  # pragma: no cover
@@ -169,6 +176,15 @@ def build_constraint_generation(
     merged_bond_lengths: dict[str, list[list[object]]] = {}
     merged_bond_angles: dict[str, list[list[object]]] = {}
     entries: list[ConstraintGenerationEntry] = []
+
+    if ConstraintPDB is None:
+        raise RuntimeError(
+            "Constraint generation requires ConstraintPDB, but "
+            "saxshell.fullrmc._deprecated.constraintpdb could not be "
+            "imported. Restore the missing module or update "
+            "constraint_generation.py to use the current ConstraintPDB "
+            "implementation."
+        ) from _CONSTRAINTPDB_IMPORT_ERROR
 
     for setup_entry in active_setup.entries:
         pdb_path = Path(setup_entry.packmol_pdb).expanduser().resolve()


### PR DESCRIPTION
A set of imports was moved do a different location. This was necessary for the software to launch on my machine. 